### PR TITLE
fix: screen flows from design inspection, not frame name inference

### DIFF
--- a/figmaclaw/skills/figma-enrich-page.md
+++ b/figmaclaw/skills/figma-enrich-page.md
@@ -1,5 +1,5 @@
 ---
-description: Enrich a figmaclaw Figma page .md file with frame descriptions, page summary, and inferred screen flows.
+description: Enrich a figmaclaw Figma page .md file with frame descriptions, page summary, and screen flows from design inspection.
 ---
 
 # figma-enrich-page
@@ -8,7 +8,7 @@ Enrich a figmaclaw `.md` file with:
 - **Frame descriptions** — 1–3 sentence description for every frame
 - **Page summary** — 2–3 sentence prose overview of the whole page
 - **Section intros** — one sentence per section describing what that group shows
-- **Mermaid flowchart** — screen-flow diagram showing how screens connect (always present)
+- **Mermaid flowchart** — always present; built from `flows:` frontmatter (authoritative Figma reactions) and design inspection via screenshots
 
 **Format spec:** [`docs/figmaclaw-md-format.md`](https://github.com/aviadr1/figmaclaw/blob/main/docs/figmaclaw-md-format.md) — authoritative reference for frontmatter schema, body structure, and known limitations.
 

--- a/skills/figma-enrich-page/SKILL.md
+++ b/skills/figma-enrich-page/SKILL.md
@@ -1,5 +1,5 @@
 ---
-description: Enrich a figmaclaw Figma page .md file with frame descriptions, page summary, and inferred screen flows.
+description: Enrich a figmaclaw Figma page .md file with frame descriptions, page summary, and screen flows from design inspection.
 ---
 
 # figma-enrich-page
@@ -8,7 +8,7 @@ Enrich a figmaclaw `.md` file with:
 - **Frame descriptions** — 1–3 sentence description for every frame
 - **Page summary** — 2–3 sentence prose overview of the whole page
 - **Section intros** — one sentence per section describing what that group shows
-- **Mermaid flowchart** — screen-flow diagram derived from prototype reactions (only if flows exist)
+- **Mermaid flowchart** — always present; built from `flows:` frontmatter (authoritative Figma reactions) and design inspection via screenshots
 
 **Full workflow:** see `figmaclaw/skills/figma-enrich-page.md` (the authoritative skill file).
 Run `figmaclaw self skill enrich-page` to print it at runtime.
@@ -69,4 +69,4 @@ figmaclaw self skill enrich-page
 - **Never parse body prose** for node IDs, descriptions, or flows — always read frontmatter
 - The `reserach` section typo in some Figma files is real — preserve it as-is
 - Small frames (≤200px) are usually component details — describe them, note they are components
-- If `flows:` is absent or empty → omit `## Screen flows` entirely (correct behavior, not a gap)
+- Always include `## Screen flows` — look at screenshots to find transitions visible in the design (buttons, CTAs, step indicators, modals). Use `flows:` frontmatter as authoritative edges but don't rely on it alone. Never guess from frame names.


### PR DESCRIPTION
## Summary

- Both skill files were telling the LLM to infer screen flows from frame names when `flows:` frontmatter is empty — this produces hallucinated diagrams with no connection to the actual UI
- Corrected both files to say: always include `## Screen flows`; determine transitions by **looking at screenshots** (buttons, CTAs, step indicators, modals show what connects to what); use `flows:` as authoritative Figma reactions but never guess from names alone

## Changes

- `skills/figma-enrich-page/SKILL.md` — description, bullet, and note updated
- `figmaclaw/skills/figma-enrich-page.md` — description and bullet updated (Step 4 and Notes already had the correct guidance from the 88d20d9 merge)

## Context

Found while auditing the plugin cache against figmaclaw-repo. The SKILL.md stub still had the old "only if flows exist" / "infer from frame names" wording that predates the 88d20d9 merge. The internal detailed skill was already correct on the step-by-step but the summary/description contradicted it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)