### PR TITLE
Restore census + webhook enrich in managed figmaclaw templates

### DIFF
--- a/figmaclaw/workflows/figmaclaw-sync.yaml
+++ b/figmaclaw/workflows/figmaclaw-sync.yaml
@@ -38,6 +38,15 @@ jobs:
     secrets:
       FIGMA_API_KEY: ${{ secrets.FIGMA_API_KEY }}
 
+  # Census: snapshot published DS component sets to figma/**/_census.md.
+  # Hash-gated in the reusable workflow: no-op when registry is unchanged.
+  census:
+    needs: sync
+    if: success()
+    uses: aviadr1/figmaclaw/.github/workflows/census.yml@main
+    secrets:
+      FIGMA_API_KEY: ${{ secrets.FIGMA_API_KEY }}
+
   # Whole-page enrichment: small pages (≤80 frames), many per run
   # Sorted smallest-first for throughput. ~38 pages/hour observed.
   enrich:

--- a/figmaclaw/workflows/figmaclaw-webhook.yaml
+++ b/figmaclaw/workflows/figmaclaw-webhook.yaml
@@ -25,3 +25,17 @@ jobs:
     secrets:
       FIGMA_API_KEY: ${{ secrets.FIGMA_API_KEY }}
       FIGMA_WEBHOOK_SECRET: ${{ secrets.FIGMA_WEBHOOK_SECRET }}
+
+  # Changed-only enrichment after webhook apply.
+  enrich:
+    needs: apply-webhook
+    if: success()
+    uses: aviadr1/figmaclaw/.github/workflows/claude-run.yml@main
+    with:
+      target: figma/
+      model: claude-sonnet-4-6
+      max_turns: 80
+      changed_only: true
+    secrets:
+      CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+      FIGMA_API_KEY: ${{ secrets.FIGMA_API_KEY }}


### PR DESCRIPTION
Follow-up to #66.

Restores two caller-stub behaviors that were present in consumer repos and should remain part of managed templates:

- `figmaclaw-sync.yaml`: restore `census` job calling reusable `census.yml`
- `figmaclaw-webhook.yaml`: restore post-apply `enrich` job with `changed_only: true`

This keeps `workflows upgrade` from removing these jobs in consumers like `linear-git`.
