### PR TITLE
fix(sync): reconcile lifecycle paths and prune existing orphans

### DIFF
--- a/figmaclaw/commands/apply_webhook.py
+++ b/figmaclaw/commands/apply_webhook.py
@@ -1,4 +1,4 @@
-"""figmaclaw apply-webhook — process a Figma FILE_UPDATE webhook payload."""
+"""figmaclaw apply-webhook — process Figma FILE_UPDATE / FILE_DELETE webhooks."""
 
 from __future__ import annotations
 
@@ -20,6 +20,33 @@ class WebhookAuthError(Exception):
     """Raised when the webhook passcode does not match FIGMA_WEBHOOK_SECRET."""
 
 
+def _prune_file_artifacts(state: FigmaSyncState, repo_dir: Path, file_key: str) -> int:
+    """Delete generated files for one tracked file key and remove it from manifest."""
+    removed_paths = 0
+    file_entry = state.manifest.files.get(file_key)
+    if file_entry is not None:
+        for page in file_entry.pages.values():
+            paths = list(page.component_md_paths)
+            if page.md_path:
+                paths.append(page.md_path)
+            for rel in paths:
+                path = repo_dir / rel
+                if path.exists():
+                    path.unlink()
+                    removed_paths += 1
+                if path.suffix == ".md":
+                    sidecar = path.with_suffix(".tokens.json")
+                    if sidecar.exists():
+                        sidecar.unlink()
+                        removed_paths += 1
+        state.manifest.files.pop(file_key, None)
+
+    if file_key in state.manifest.tracked_files:
+        state.manifest.tracked_files.remove(file_key)
+
+    return removed_paths
+
+
 @click.command("apply-webhook")
 @click.option("--auto-commit", "auto_commit", is_flag=True, help="git commit after each page.")
 @click.option(
@@ -32,7 +59,7 @@ class WebhookAuthError(Exception):
 )
 @click.pass_context
 def apply_webhook_cmd(ctx: click.Context, auto_commit: bool, push_every: int) -> None:
-    """Process a Figma FILE_UPDATE webhook payload from FIGMA_WEBHOOK_PAYLOAD env var."""
+    """Process a Figma webhook payload from FIGMA_WEBHOOK_PAYLOAD env var."""
     repo_dir = Path(ctx.obj["repo_dir"])
     api_key = os.environ.get("FIGMA_API_KEY", "")
     if not api_key:
@@ -76,16 +103,29 @@ async def _run(
         if passcode != webhook_secret:
             raise WebhookAuthError("Webhook passcode mismatch — rejecting payload.")
 
-    file_id: str = data.get("file_id", "")
-    if not file_id:
-        click.echo("Webhook payload missing file_id — skipping.")
+    event_type = str(data.get("event_type", "")).upper()
+    file_key: str = data.get("file_key") or data.get("file_id") or ""
+    if not file_key:
+        click.echo("Webhook payload missing file_key/file_id — skipping.")
         return
 
     state = FigmaSyncState(repo_dir)
     state.load()
 
-    if file_id not in state.manifest.tracked_files:
-        click.echo(f"File {file_id!r} is not tracked — skipping.")
+    if event_type == "FILE_DELETE":
+        had_file = file_key in state.manifest.files or file_key in state.manifest.tracked_files
+        removed_paths = _prune_file_artifacts(state, repo_dir, file_key)
+        if had_file:
+            state.manifest.skipped_files[file_key] = "deleted via FILE_DELETE webhook"
+            state.save()
+            click.echo(f"COMMIT_MSG:sync: figmaclaw apply-webhook — file deleted [{file_key}]")
+            click.echo(f"{file_key}: pruned {removed_paths} generated path(s) after FILE_DELETE.")
+        else:
+            click.echo(f"File {file_key!r} is not tracked — skipping.")
+        return
+
+    if file_key not in state.manifest.tracked_files:
+        click.echo(f"File {file_key!r} is not tracked — skipping.")
         return
 
     commit_count = 0
@@ -105,7 +145,7 @@ async def _run(
     async with FigmaClient(api_key) as client:
         result = await pull_file(
             client,
-            file_id,
+            file_key,
             state,
             repo_dir,
             on_page_written=on_page_written,
@@ -115,6 +155,6 @@ async def _run(
 
     if result.pages_written > 0:
         n = result.pages_written
-        click.echo(f"COMMIT_MSG:sync: figmaclaw apply-webhook — {n} page(s) updated [{file_id}]")
+        click.echo(f"COMMIT_MSG:sync: figmaclaw apply-webhook — {n} page(s) updated [{file_key}]")
     else:
-        click.echo(f"{file_id}: no pages changed.")
+        click.echo(f"{file_key}: no pages changed.")

--- a/figmaclaw/commands/apply_webhook.py
+++ b/figmaclaw/commands/apply_webhook.py
@@ -13,38 +13,12 @@ from figmaclaw.commands.pull import _git_commit_page
 from figmaclaw.figma_client import FigmaClient
 from figmaclaw.figma_sync_state import FigmaSyncState
 from figmaclaw.git_utils import git_push as _git_push
+from figmaclaw.prune_utils import prune_file_artifacts_from_manifest
 from figmaclaw.pull_logic import pull_file
 
 
 class WebhookAuthError(Exception):
     """Raised when the webhook passcode does not match FIGMA_WEBHOOK_SECRET."""
-
-
-def _prune_file_artifacts(state: FigmaSyncState, repo_dir: Path, file_key: str) -> int:
-    """Delete generated files for one tracked file key and remove it from manifest."""
-    removed_paths = 0
-    file_entry = state.manifest.files.get(file_key)
-    if file_entry is not None:
-        for page in file_entry.pages.values():
-            paths = list(page.component_md_paths)
-            if page.md_path:
-                paths.append(page.md_path)
-            for rel in paths:
-                path = repo_dir / rel
-                if path.exists():
-                    path.unlink()
-                    removed_paths += 1
-                if path.suffix == ".md":
-                    sidecar = path.with_suffix(".tokens.json")
-                    if sidecar.exists():
-                        sidecar.unlink()
-                        removed_paths += 1
-        state.manifest.files.pop(file_key, None)
-
-    if file_key in state.manifest.tracked_files:
-        state.manifest.tracked_files.remove(file_key)
-
-    return removed_paths
 
 
 @click.command("apply-webhook")
@@ -114,7 +88,13 @@ async def _run(
 
     if event_type == "FILE_DELETE":
         had_file = file_key in state.manifest.files or file_key in state.manifest.tracked_files
-        removed_paths = _prune_file_artifacts(state, repo_dir, file_key)
+        removed_paths = prune_file_artifacts_from_manifest(
+            state,
+            repo_dir,
+            file_key,
+            drop_manifest_entry=True,
+            drop_tracked=True,
+        )
         if had_file:
             state.manifest.skipped_files[file_key] = "deleted via FILE_DELETE webhook"
             state.save()

--- a/figmaclaw/commands/pull.py
+++ b/figmaclaw/commands/pull.py
@@ -14,6 +14,7 @@ from figmaclaw.figma_client import FigmaClient
 from figmaclaw.figma_sync_state import FigmaSyncState
 from figmaclaw.figma_utils import parse_since
 from figmaclaw.git_utils import git_commit, git_push
+from figmaclaw.prune_utils import prune_file_artifacts_from_manifest
 from figmaclaw.pull_logic import PullResult, pull_file
 
 
@@ -251,10 +252,18 @@ async def _run(
             if result.no_access:
                 # Permanently inaccessible (restricted/deleted) — move out of tracked_files.
                 reason = "no access — get_file_meta returns 400/404"
+                pruned = prune_file_artifacts_from_manifest(
+                    state,
+                    repo_dir,
+                    key,
+                    drop_manifest_entry=True,
+                    drop_tracked=True,
+                )
                 state.manifest.skipped_files[key] = reason
-                if key in state.manifest.tracked_files:
-                    state.manifest.tracked_files.remove(key)
-                click.echo(f"{key}: skipped — {reason} — removed from tracked_files")
+                click.echo(
+                    f"{key}: skipped — {reason} — removed from tracked_files "
+                    f"(pruned {pruned} path(s))"
+                )
             elif result.skipped_file:
                 # If pull failed (e.g. 400 on get_file_meta) and we know the listing
                 # last_modified, stamp it into the manifest so future runs pre-filter

--- a/figmaclaw/commands/pull.py
+++ b/figmaclaw/commands/pull.py
@@ -249,8 +249,8 @@ async def _run(
                 has_more_global = True
 
             if result.no_access:
-                # Permanently inaccessible — move out of tracked_files into skipped_files.
-                reason = "no access — get_file_meta returns 400 (restricted file)"
+                # Permanently inaccessible (restricted/deleted) — move out of tracked_files.
+                reason = "no access — get_file_meta returns 400/404"
                 state.manifest.skipped_files[key] = reason
                 if key in state.manifest.tracked_files:
                     state.manifest.tracked_files.remove(key)

--- a/figmaclaw/commands/pull.py
+++ b/figmaclaw/commands/pull.py
@@ -56,6 +56,13 @@ from figmaclaw.pull_logic import PullResult, pull_file
     show_default=True,
     help="When --team-id is set, only track files modified within this window (e.g. 3m, 7d, all).",
 )
+@click.option(
+    "--prune/--no-prune",
+    "prune",
+    default=True,
+    show_default=True,
+    help="Prune stale generated figma artifacts (orphans, old rename paths, removed pages).",
+)
 @click.pass_context
 def pull_cmd(
     ctx: click.Context,
@@ -66,6 +73,7 @@ def pull_cmd(
     push_every: int,
     team_id: str | None,
     since: str,
+    prune: bool,
 ) -> None:
     """Pull all tracked Figma files and write changed pages to disk."""
     repo_dir = Path(ctx.obj["repo_dir"])
@@ -74,7 +82,18 @@ def pull_cmd(
         raise click.UsageError("FIGMA_API_KEY environment variable is not set.")
 
     asyncio.run(
-        _run(api_key, repo_dir, file_key, force, max_pages, auto_commit, push_every, team_id, since)
+        _run(
+            api_key,
+            repo_dir,
+            file_key,
+            force,
+            max_pages,
+            auto_commit,
+            push_every,
+            team_id,
+            since,
+            prune=prune,
+        )
     )
 
 
@@ -162,6 +181,7 @@ async def _run(
     push_every: int,
     team_id: str | None,
     since: str,
+    prune: bool = True,
 ) -> None:
     state = FigmaSyncState(repo_dir)
     state.load()
@@ -235,6 +255,7 @@ async def _run(
                     repo_dir,
                     force=force,
                     max_pages=pages_budget,
+                    prune=prune,
                     on_page_written=on_page_written,
                 )
             except Exception as exc:

--- a/figmaclaw/prune_utils.py
+++ b/figmaclaw/prune_utils.py
@@ -1,0 +1,94 @@
+"""Shared pruning helpers for generated figmaclaw artifacts."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from figmaclaw.figma_sync_state import FigmaSyncState, PageEntry
+
+_NODE_SUFFIX_RE = re.compile(r".*-\d+-\d+\.md$")
+
+
+def entry_paths(entry: PageEntry) -> set[str]:
+    """Return all generated markdown paths referenced by one manifest page entry."""
+    paths: set[str] = set(entry.component_md_paths)
+    if entry.md_path:
+        paths.add(entry.md_path)
+    return paths
+
+
+def is_generated_md_relpath(rel_path: str) -> bool:
+    """True when rel_path looks like a generated page/component markdown path."""
+    path = Path(rel_path)
+    parts = path.parts
+    if len(parts) < 4:
+        return False
+    if parts[0] != "figma":
+        return False
+    if parts[-2] not in {"pages", "components"}:
+        return False
+    if path.suffix != ".md":
+        return False
+    return bool(_NODE_SUFFIX_RE.fullmatch(path.name))
+
+
+def remove_generated_relpath(repo_root: Path, rel_path: str) -> int:
+    """Remove one generated markdown path and its token sidecar (for page markdown)."""
+    removed = 0
+    path = repo_root / rel_path
+    if path.exists():
+        path.unlink()
+        removed += 1
+    if path.suffix == ".md":
+        sidecar = path.with_suffix(".tokens.json")
+        if sidecar.exists():
+            sidecar.unlink()
+            removed += 1
+    return removed
+
+
+def prune_file_artifacts_from_manifest(
+    state: FigmaSyncState,
+    repo_root: Path,
+    file_key: str,
+    *,
+    drop_manifest_entry: bool,
+    drop_tracked: bool,
+) -> int:
+    """Prune all known generated artifacts for one file key from current manifest state."""
+    removed = 0
+    file_entry = state.manifest.files.get(file_key)
+    if file_entry is not None:
+        for page in file_entry.pages.values():
+            for rel in sorted(entry_paths(page)):
+                removed += remove_generated_relpath(repo_root, rel)
+        if drop_manifest_entry:
+            state.manifest.files.pop(file_key, None)
+
+    if drop_tracked and file_key in state.manifest.tracked_files:
+        state.manifest.tracked_files.remove(file_key)
+
+    return removed
+
+
+def find_generated_orphans(
+    repo_root: Path,
+    *,
+    candidate_dirs: set[Path],
+    expected_paths: set[str],
+) -> list[str]:
+    """Find generated md/tokens files under candidate dirs that are not in expected_paths."""
+    orphans: set[str] = set()
+    for directory in candidate_dirs:
+        if not directory.exists() or not directory.is_dir():
+            continue
+        for md in directory.glob("*.md"):
+            rel = str(md.relative_to(repo_root))
+            if is_generated_md_relpath(rel) and rel not in expected_paths:
+                orphans.add(rel)
+        for tok in directory.glob("*.tokens.json"):
+            md_rel = str(tok.relative_to(repo_root)).replace(".tokens.json", ".md")
+            if is_generated_md_relpath(md_rel) and md_rel not in expected_paths:
+                orphans.add(str(tok.relative_to(repo_root)))
+    return sorted(orphans)

--- a/figmaclaw/pull_logic.py
+++ b/figmaclaw/pull_logic.py
@@ -270,6 +270,67 @@ def _write_token_sidecar(
     write_json_if_changed(sidecar_path, sidecar, ignore_keys=frozenset({"generated_at"}))
 
 
+def _entry_paths(entry: PageEntry) -> set[str]:
+    """Return all generated markdown paths referenced by a manifest page entry."""
+    paths: set[str] = set(entry.component_md_paths)
+    if entry.md_path:
+        paths.add(entry.md_path)
+    return paths
+
+
+def _node_suffix_from_relpath(rel_path: str) -> str | None:
+    """Extract '<nodeA>-<nodeB>' suffix from generated path stem, if present."""
+    stem = Path(rel_path).stem
+    parts = stem.rsplit("-", 2)
+    if len(parts) != 3:
+        return None
+    a, b = parts[1], parts[2]
+    if not (a.isdigit() and b.isdigit()):
+        return None
+    return f"{a}-{b}"
+
+
+def _remove_generated_path(repo_root: Path, rel_path: str) -> None:
+    """Remove a generated markdown path and its token sidecar (for page markdown)."""
+    path = repo_root / rel_path
+    if path.exists():
+        path.unlink()
+    if path.suffix == ".md":
+        sidecar = path.with_suffix(".tokens.json")
+        if sidecar.exists():
+            sidecar.unlink()
+
+
+def _migrate_generated_path(
+    repo_root: Path,
+    old_rel_path: str,
+    new_rel_path: str,
+    *,
+    move_sidecar: bool,
+) -> None:
+    """Move old generated path to a new path, or prune old if the new path already exists."""
+    if old_rel_path == new_rel_path:
+        return
+
+    old_path = repo_root / old_rel_path
+    new_path = repo_root / new_rel_path
+
+    if old_path.exists() and not new_path.exists():
+        new_path.parent.mkdir(parents=True, exist_ok=True)
+        old_path.rename(new_path)
+    elif old_path.exists() and new_path.exists():
+        old_path.unlink()
+
+    if move_sidecar and old_path.suffix == ".md":
+        old_sidecar = old_path.with_suffix(".tokens.json")
+        new_sidecar = new_path.with_suffix(".tokens.json")
+        if old_sidecar.exists() and not new_sidecar.exists():
+            new_sidecar.parent.mkdir(parents=True, exist_ok=True)
+            old_sidecar.rename(new_sidecar)
+        elif old_sidecar.exists() and new_sidecar.exists():
+            old_sidecar.unlink()
+
+
 def _compute_raw_frames(
     frame_docs: dict[str, dict],
 ) -> tuple[dict[str, FrameComposition], dict[str, list[SectionNode]]]:
@@ -442,8 +503,11 @@ async def pull_file(
     try:
         meta = await client.get_file_meta(file_key)
     except Exception as exc:
-        if isinstance(exc, httpx.HTTPStatusError) and exc.response.status_code == 400:
-            log.warning("No access to %r (HTTP 400) — will be moved to skipped_files", file_key)
+        if isinstance(exc, httpx.HTTPStatusError) and exc.response.status_code in {400, 404}:
+            code = exc.response.status_code
+            log.warning(
+                "No access to %r (HTTP %d) — will be moved to skipped_files", file_key, code
+            )
             result.skipped_file = True
             result.no_access = True
         else:
@@ -471,6 +535,10 @@ async def pull_file(
             f"{file_name}: pull schema stale (v{stored.pull_schema_version} → v{CURRENT_PULL_SCHEMA_VERSION}), refreshing frontmatter"
         )
 
+    previous_pages: dict[str, PageEntry] = {}
+    if stored is not None:
+        previous_pages = {pid: p.model_copy(deep=True) for pid, p in stored.pages.items()}
+
     now = datetime.datetime.now(datetime.UTC).isoformat()
     state.set_file_meta(
         file_key,
@@ -492,6 +560,7 @@ async def pull_file(
         component_sets = []
 
     page_stubs = meta.canvas_pages
+    current_page_ids = {stub.id for stub in page_stubs}
     file_slug = slugify(file_name, fallback=file_key)
     total_pages = len(page_stubs)
     pages_written_this_call = 0
@@ -611,6 +680,15 @@ async def pull_file(
 
         new_hash = compute_page_hash(page_node)
         stored_hash = state.get_page_hash(file_key, page_node_id)
+        node_suffix = page_node_id.replace(":", "-")
+        expected_page_slug = f"{slugify(page_name)}-{node_suffix}"
+        expected_screen_md_rel = page_path(file_slug, expected_page_slug)
+        previous_entry = previous_pages.get(page_node_id)
+        needs_path_reconcile = bool(
+            previous_entry
+            and previous_entry.md_path
+            and previous_entry.md_path != expected_screen_md_rel
+        )
 
         content_unchanged = not force and stored_hash is not None and stored_hash == new_hash
 
@@ -619,7 +697,7 @@ async def pull_file(
         # These don't consume the max_pages budget so the whole file upgrades in one pass.
         schema_only = content_unchanged and schema_stale
 
-        if content_unchanged and not schema_stale:
+        if content_unchanged and not schema_stale and not needs_path_reconcile:
             _progress(f"  [{page_idx}/{total_pages}] {page_name} — unchanged (skip)")
             result.pages_skipped += 1
             continue
@@ -641,7 +719,6 @@ async def pull_file(
             _progress(f"  [{page_idx}/{total_pages}] {page_name} — processing...")
 
         try:
-            node_suffix = page_node_id.replace(":", "-")
             page_slug = f"{slugify(page_name)}-{node_suffix}"
             page = from_page_node(page_node, file_key=file_key, file_name=file_name)
             page = page.model_copy(
@@ -656,6 +733,17 @@ async def pull_file(
             existing_flows: list[tuple[str, str]] = []
 
             screen_md_rel = page_path(file_slug, page_slug)
+            if (
+                previous_entry
+                and previous_entry.md_path
+                and previous_entry.md_path != screen_md_rel
+            ):
+                _migrate_generated_path(
+                    repo_root,
+                    previous_entry.md_path,
+                    screen_md_rel,
+                    move_sidecar=True,
+                )
             screen_md = repo_root / screen_md_rel
             if screen_md.exists():
                 md_text = screen_md.read_text()
@@ -707,7 +795,7 @@ async def pull_file(
             # Skipped for schema-only upgrades: content is unchanged so token data can't have changed.
             token_scan: PageTokenScan | None = None
             raw_tokens: dict[str, RawTokenCounts] | None = None
-            if screen_frame_ids and not schema_only:
+            if screen_frame_ids and not schema_only and not content_unchanged:
                 try:
                     token_scan = scan_page(page_node, set(screen_frame_ids))
                     # Sparse frontmatter summary — only frames with at least one issue
@@ -773,12 +861,26 @@ async def pull_file(
                     result.pages_written += 1
 
             written_component_rels: list[str] = []
+            previous_component_by_suffix: dict[str, str] = {}
+            if previous_entry:
+                for comp_path in previous_entry.component_md_paths:
+                    suffix = _node_suffix_from_relpath(comp_path)
+                    if suffix:
+                        previous_component_by_suffix[suffix] = comp_path
             for section in component_sections:
                 if not section.frames:
                     continue
                 sect_suffix = section.node_id.replace(":", "-")
                 sect_slug = f"{slugify(section.name)}-{sect_suffix}"
                 comp_rel = component_path(file_slug, sect_slug)
+                old_comp_rel = previous_component_by_suffix.get(sect_suffix)
+                if old_comp_rel and old_comp_rel != comp_rel:
+                    _migrate_generated_path(
+                        repo_root,
+                        old_comp_rel,
+                        comp_rel,
+                        move_sidecar=False,
+                    )
                 sect_keys = _build_component_set_keys(page.page_node_id, component_sets)
                 written = write_component_section(
                     repo_root,
@@ -824,6 +926,37 @@ async def pull_file(
                 [written_screen_rel] if written_screen_rel else []
             ) + written_component_rels
             on_page_written(f"{file_name} / {page_name}", all_written)
+
+    # Reconcile and prune stale generated paths from previous runs.
+    # This handles:
+    # - page renames (old path removed once new path is written)
+    # - file renames (old file-slug directory entries pruned)
+    # - removed pages (manifest entry + files deleted)
+    manifest_changed = False
+    file_entry = state.manifest.files.get(file_key)
+    if file_entry is not None:
+        # 1) Pages removed from Figma file: drop manifest entries + paths.
+        for previous_page_id, previous_entry in previous_pages.items():
+            if previous_page_id in current_page_ids:
+                continue
+            for stale_rel in sorted(_entry_paths(previous_entry)):
+                _remove_generated_path(repo_root, stale_rel)
+            if previous_page_id in file_entry.pages:
+                file_entry.pages.pop(previous_page_id)
+                manifest_changed = True
+
+        # 2) Existing pages: drop stale old paths no longer referenced by current manifest entry.
+        for page_id in current_page_ids:
+            previous_entry = previous_pages.get(page_id)
+            current_entry = file_entry.pages.get(page_id)
+            if previous_entry is None or current_entry is None:
+                continue
+            stale_paths = _entry_paths(previous_entry) - _entry_paths(current_entry)
+            for stale_rel in sorted(stale_paths):
+                _remove_generated_path(repo_root, stale_rel)
+
+    if manifest_changed:
+        state.save()
 
     # Record that all pages in this file are now at the current pull schema version.
     # Only written after the full page loop completes — if interrupted mid-file,

--- a/figmaclaw/pull_logic.py
+++ b/figmaclaw/pull_logic.py
@@ -58,6 +58,11 @@ from figmaclaw.figma_paths import component_path, page_path, slugify
 from figmaclaw.figma_render import build_page_frontmatter, render_component_section, scaffold_page
 from figmaclaw.figma_sync_state import FigmaSyncState, PageEntry
 from figmaclaw.figma_utils import write_json_if_changed
+from figmaclaw.prune_utils import (
+    entry_paths,
+    find_generated_orphans,
+    remove_generated_relpath,
+)
 from figmaclaw.token_catalog import load_catalog, merge_bindings, save_catalog
 from figmaclaw.token_scan import PageTokenScan, scan_page
 
@@ -270,14 +275,6 @@ def _write_token_sidecar(
     write_json_if_changed(sidecar_path, sidecar, ignore_keys=frozenset({"generated_at"}))
 
 
-def _entry_paths(entry: PageEntry) -> set[str]:
-    """Return all generated markdown paths referenced by a manifest page entry."""
-    paths: set[str] = set(entry.component_md_paths)
-    if entry.md_path:
-        paths.add(entry.md_path)
-    return paths
-
-
 def _node_suffix_from_relpath(rel_path: str) -> str | None:
     """Extract '<nodeA>-<nodeB>' suffix from generated path stem, if present."""
     stem = Path(rel_path).stem
@@ -288,17 +285,6 @@ def _node_suffix_from_relpath(rel_path: str) -> str | None:
     if not (a.isdigit() and b.isdigit()):
         return None
     return f"{a}-{b}"
-
-
-def _remove_generated_path(repo_root: Path, rel_path: str) -> None:
-    """Remove a generated markdown path and its token sidecar (for page markdown)."""
-    path = repo_root / rel_path
-    if path.exists():
-        path.unlink()
-    if path.suffix == ".md":
-        sidecar = path.with_suffix(".tokens.json")
-        if sidecar.exists():
-            sidecar.unlink()
 
 
 def _migrate_generated_path(
@@ -527,6 +513,18 @@ async def pull_file(
         and stored.version == api_version
         and stored.last_modified == api_last_modified
     ):
+        # Even on file-level skip, prune generated orphans under the current file slug.
+        expected_paths = {rel for page in stored.pages.values() for rel in entry_paths(page)}
+        candidate_dirs = {
+            repo_root / f"figma/{slugify(file_name, fallback=file_key)}/pages",
+            repo_root / f"figma/{slugify(file_name, fallback=file_key)}/components",
+        }
+        for rel in expected_paths:
+            candidate_dirs.add((repo_root / rel).parent)
+        for orphan_rel in find_generated_orphans(
+            repo_root, candidate_dirs=candidate_dirs, expected_paths=expected_paths
+        ):
+            remove_generated_relpath(repo_root, orphan_rel)
         _progress(f"{file_name}: unchanged (version {api_version}), skipping all pages")
         result.skipped_file = True
         return result
@@ -939,8 +937,8 @@ async def pull_file(
         for previous_page_id, previous_entry in previous_pages.items():
             if previous_page_id in current_page_ids:
                 continue
-            for stale_rel in sorted(_entry_paths(previous_entry)):
-                _remove_generated_path(repo_root, stale_rel)
+            for stale_rel in sorted(entry_paths(previous_entry)):
+                remove_generated_relpath(repo_root, stale_rel)
             if previous_page_id in file_entry.pages:
                 file_entry.pages.pop(previous_page_id)
                 manifest_changed = True
@@ -951,9 +949,25 @@ async def pull_file(
             current_entry = file_entry.pages.get(page_id)
             if previous_entry is None or current_entry is None:
                 continue
-            stale_paths = _entry_paths(previous_entry) - _entry_paths(current_entry)
+            stale_paths = entry_paths(previous_entry) - entry_paths(current_entry)
             for stale_rel in sorted(stale_paths):
-                _remove_generated_path(repo_root, stale_rel)
+                remove_generated_relpath(repo_root, stale_rel)
+
+        # 3) Existing on-disk generated artifacts not referenced by manifest (legacy orphans).
+        expected_paths = {rel for page in file_entry.pages.values() for rel in entry_paths(page)}
+        candidate_dirs = {
+            repo_root / f"figma/{file_slug}/pages",
+            repo_root / f"figma/{file_slug}/components",
+        }
+        for rel in expected_paths:
+            candidate_dirs.add((repo_root / rel).parent)
+        for previous_entry in previous_pages.values():
+            for rel in entry_paths(previous_entry):
+                candidate_dirs.add((repo_root / rel).parent)
+        for orphan_rel in find_generated_orphans(
+            repo_root, candidate_dirs=candidate_dirs, expected_paths=expected_paths
+        ):
+            remove_generated_relpath(repo_root, orphan_rel)
 
     if manifest_changed:
         state.save()

--- a/figmaclaw/pull_logic.py
+++ b/figmaclaw/pull_logic.py
@@ -495,13 +495,11 @@ async def pull_file(
     except Exception as exc:
         if isinstance(exc, httpx.HTTPStatusError) and exc.response.status_code in {400, 404}:
             code = exc.response.status_code
-            log.warning(
-                "No access to %r (HTTP %d) — will be moved to skipped_files", file_key, code
-            )
+            log.warning("No access to Figma file (HTTP %d) — will be moved to skipped_files", code)
             result.skipped_file = True
             result.no_access = True
         else:
-            log.error("Failed to fetch file meta for %r: %s — skipping file", file_key, exc)
+            log.error("Failed to fetch file meta (%s) — skipping file", type(exc).__name__)
             result.skipped_file = True
         return result
     api_version = meta.version
@@ -556,9 +554,8 @@ async def pull_file(
         component_sets = await client.get_component_sets(file_key)
     except Exception as exc:
         log.warning(
-            "Failed to fetch component sets for %r: %s — component_set_keys will be empty",
-            file_key,
-            exc,
+            "Failed to fetch component sets (%s) — component_set_keys will be empty",
+            type(exc).__name__,
         )
         component_sets = []
 
@@ -626,9 +623,7 @@ async def pull_file(
                         )
                         continue
                     all_frame_docs.update(chunk_docs)
-                log.debug(
-                    "Batch-fetched %d frame nodes for file %r", len(all_screen_frame_ids), file_key
-                )
+                log.debug("Batch-fetched %d frame nodes", len(all_screen_frame_ids))
             except Exception as exc:
                 log.warning(
                     "Failed to batch-fetch frame children (%s) — raw_frames will be omitted",

--- a/figmaclaw/pull_logic.py
+++ b/figmaclaw/pull_logic.py
@@ -453,6 +453,7 @@ async def pull_file(
     *,
     force: bool = False,
     max_pages: int | None = None,
+    prune: bool = True,
     progress: Callable[[str], None] | None = None,
     on_page_written: Callable[[str, list[str]], None] | None = None,
 ) -> PullResult:
@@ -466,6 +467,9 @@ async def pull_file(
 
     max_pages: stop after writing this many Figma pages (pages whose hash changed).
                Skipped pages don't count. Set result.has_more=True if more remain.
+
+    prune: whether to remove stale generated artifacts when lifecycle drifts
+           (renames, removals, orphan files). Disable only for debugging/forensics.
 
     on_page_written: called after each page is successfully written to disk with
                (page_name, [paths_written]). Use this to trigger git commits from
@@ -513,18 +517,19 @@ async def pull_file(
         and stored.version == api_version
         and stored.last_modified == api_last_modified
     ):
-        # Even on file-level skip, prune generated orphans under the current file slug.
-        expected_paths = {rel for page in stored.pages.values() for rel in entry_paths(page)}
-        candidate_dirs = {
-            repo_root / f"figma/{slugify(file_name, fallback=file_key)}/pages",
-            repo_root / f"figma/{slugify(file_name, fallback=file_key)}/components",
-        }
-        for rel in expected_paths:
-            candidate_dirs.add((repo_root / rel).parent)
-        for orphan_rel in find_generated_orphans(
-            repo_root, candidate_dirs=candidate_dirs, expected_paths=expected_paths
-        ):
-            remove_generated_relpath(repo_root, orphan_rel)
+        # Even on file-level skip, optionally prune generated orphans under file slug.
+        if prune:
+            expected_paths = {rel for page in stored.pages.values() for rel in entry_paths(page)}
+            candidate_dirs = {
+                repo_root / f"figma/{slugify(file_name, fallback=file_key)}/pages",
+                repo_root / f"figma/{slugify(file_name, fallback=file_key)}/components",
+            }
+            for rel in expected_paths:
+                candidate_dirs.add((repo_root / rel).parent)
+            for orphan_rel in find_generated_orphans(
+                repo_root, candidate_dirs=candidate_dirs, expected_paths=expected_paths
+            ):
+                remove_generated_relpath(repo_root, orphan_rel)
         _progress(f"{file_name}: unchanged (version {api_version}), skipping all pages")
         result.skipped_file = True
         return result
@@ -735,6 +740,7 @@ async def pull_file(
                 previous_entry
                 and previous_entry.md_path
                 and previous_entry.md_path != screen_md_rel
+                and prune
             ):
                 _migrate_generated_path(
                     repo_root,
@@ -872,7 +878,7 @@ async def pull_file(
                 sect_slug = f"{slugify(section.name)}-{sect_suffix}"
                 comp_rel = component_path(file_slug, sect_slug)
                 old_comp_rel = previous_component_by_suffix.get(sect_suffix)
-                if old_comp_rel and old_comp_rel != comp_rel:
+                if old_comp_rel and old_comp_rel != comp_rel and prune:
                     _migrate_generated_path(
                         repo_root,
                         old_comp_rel,
@@ -930,9 +936,10 @@ async def pull_file(
     # - page renames (old path removed once new path is written)
     # - file renames (old file-slug directory entries pruned)
     # - removed pages (manifest entry + files deleted)
+    # Guarded by prune so operators can opt out for forensic/debug pulls.
     manifest_changed = False
     file_entry = state.manifest.files.get(file_key)
-    if file_entry is not None:
+    if file_entry is not None and prune:
         # 1) Pages removed from Figma file: drop manifest entries + paths.
         for previous_page_id, previous_entry in previous_pages.items():
             if previous_page_id in current_page_ids:

--- a/tests/test_apply_webhook.py
+++ b/tests/test_apply_webhook.py
@@ -3,10 +3,11 @@
 INVARIANTS:
 - apply_webhook reads FIGMA_WEBHOOK_PAYLOAD env var and parses it as JSON
 - apply_webhook skips files not in tracked_files
-- apply_webhook calls pull_file for the file_id in the payload
+- apply_webhook calls pull_file for file_key (and supports legacy file_id)
 - apply_webhook emits COMMIT_MSG: to stdout when pages were written
 - apply_webhook validates the passcode when FIGMA_WEBHOOK_SECRET is set
 - apply_webhook rejects payloads with wrong passcode
+- apply_webhook prunes generated artifacts on FILE_DELETE
 """
 
 from __future__ import annotations
@@ -17,18 +18,26 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from figmaclaw.figma_sync_state import FigmaSyncState
+from figmaclaw.figma_sync_state import FigmaSyncState, PageEntry
 from figmaclaw.pull_logic import PullResult
 
 
-def _make_payload(file_id: str = "abc123", passcode: str = "secret") -> str:
-    return json.dumps(
-        {
-            "event_type": "FILE_UPDATE",
-            "file_id": file_id,
-            "passcode": passcode,
-        }
-    )
+def _make_payload(
+    file_key: str = "abc123",
+    passcode: str = "secret",
+    *,
+    event_type: str = "FILE_UPDATE",
+    use_legacy_file_id: bool = False,
+) -> str:
+    payload: dict[str, str] = {
+        "event_type": event_type,
+        "passcode": passcode,
+    }
+    if use_legacy_file_id:
+        payload["file_id"] = file_key
+    else:
+        payload["file_key"] = file_key
+    return json.dumps(payload)
 
 
 @pytest.mark.asyncio
@@ -82,6 +91,39 @@ async def test_apply_webhook_calls_pull_for_tracked_file(tmp_path: Path, capsys)
     out = capsys.readouterr().out
     assert "COMMIT_MSG:" in out
     assert "2" in out  # pages written count
+
+
+@pytest.mark.asyncio
+async def test_apply_webhook_supports_legacy_file_id_payload(tmp_path: Path, capsys):
+    """INVARIANT: apply_webhook accepts legacy payloads that send file_id instead of file_key."""
+    state = FigmaSyncState(tmp_path)
+    state.load()
+    state.add_tracked_file("abc123", "Web App")
+    state.save()
+
+    from figmaclaw.commands.apply_webhook import _run
+
+    mock_result = PullResult(file_key="abc123", pages_written=1, md_paths=["a.md"])
+
+    with (
+        patch("figmaclaw.commands.apply_webhook.pull_file", return_value=mock_result),
+        patch("figmaclaw.commands.apply_webhook.FigmaClient") as MockClient,
+    ):
+        mock_cm = AsyncMock()
+        mock_cm.__aenter__ = AsyncMock(return_value=MagicMock())
+        mock_cm.__aexit__ = AsyncMock(return_value=False)
+        MockClient.return_value = mock_cm
+
+        await _run(
+            api_key="fake_key",
+            repo_dir=tmp_path,
+            payload=_make_payload("abc123", use_legacy_file_id=True),
+            webhook_secret=None,
+        )
+
+    out = capsys.readouterr().out
+    assert "COMMIT_MSG:" in out
+    assert "[abc123]" in out
 
 
 @pytest.mark.asyncio
@@ -147,3 +189,50 @@ async def test_apply_webhook_no_commit_msg_when_nothing_written(tmp_path: Path, 
 
     out = capsys.readouterr().out
     assert "COMMIT_MSG:" not in out
+
+
+@pytest.mark.asyncio
+async def test_apply_webhook_file_delete_prunes_artifacts(tmp_path: Path, capsys):
+    """INVARIANT: FILE_DELETE removes tracked generated paths and emits a commit message."""
+    state = FigmaSyncState(tmp_path)
+    state.load()
+    state.add_tracked_file("abc123", "Web App")
+    state.manifest.files["abc123"].pages["11:1"] = PageEntry(
+        page_name="Page",
+        page_slug="page-11-1",
+        md_path="figma/web-app/pages/page-11-1.md",
+        page_hash="hash",
+        last_refreshed_at="now",
+        component_md_paths=["figma/web-app/components/comp-20-1.md"],
+    )
+    state.save()
+
+    page_md = tmp_path / "figma/web-app/pages/page-11-1.md"
+    page_md.parent.mkdir(parents=True, exist_ok=True)
+    page_md.write_text("x")
+    page_sidecar = page_md.with_suffix(".tokens.json")
+    page_sidecar.write_text("{}")
+    comp_md = tmp_path / "figma/web-app/components/comp-20-1.md"
+    comp_md.parent.mkdir(parents=True, exist_ok=True)
+    comp_md.write_text("y")
+
+    from figmaclaw.commands.apply_webhook import _run
+
+    await _run(
+        api_key="fake_key",
+        repo_dir=tmp_path,
+        payload=_make_payload("abc123", event_type="FILE_DELETE"),
+        webhook_secret=None,
+    )
+
+    out = capsys.readouterr().out
+    assert "COMMIT_MSG:" in out
+    assert "file deleted [abc123]" in out
+    assert not page_md.exists()
+    assert not page_sidecar.exists()
+    assert not comp_md.exists()
+
+    state2 = FigmaSyncState(tmp_path)
+    state2.load()
+    assert "abc123" not in state2.manifest.tracked_files
+    assert "abc123" not in state2.manifest.files

--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -525,6 +525,8 @@ def test_cli_json_output(tmp_path: Path) -> None:
                 str(tmp_path),
                 "diff",
                 "figma/",
+                "--since",
+                "30d",
                 "--format",
                 "json",
                 "--no-progress",
@@ -536,7 +538,8 @@ def test_cli_json_output(tmp_path: Path) -> None:
     assert "files" in data
     assert len(data["files"]) == 1
     assert len(data["files"][0]["pages"]) == 1
-    assert data["files"][0]["pages"][0]["added_frames"][0]["node_id"] == "11:3"
+    added_ids = {f["node_id"] for f in data["files"][0]["pages"][0]["added_frames"]}
+    assert "11:3" in added_ids
 
 
 # ── VersionSummary nullable fields ────────────────────────────────

--- a/tests/test_pull_logic.py
+++ b/tests/test_pull_logic.py
@@ -911,6 +911,40 @@ async def test_pull_cmd_stamps_listing_last_modified_after_failed_get_file_meta(
     assert reloaded.manifest.files["restricted_key"].last_modified == "2026-03-01T00:00:00Z"
 
 
+@pytest.mark.asyncio
+async def test_pull_cmd_forwards_prune_flag_to_pull_file(tmp_path: Path):
+    """INVARIANT: pull command forwards prune=False to pull_file when requested."""
+    from figmaclaw.commands.pull import _run
+
+    state = _make_state_with_file(tmp_path, "fileA", "")
+    state.save()
+
+    mock_client = MagicMock(spec=FigmaClient)
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+    mock_client.get_file_meta = AsyncMock(
+        return_value={
+            "version": "v2",
+            "lastModified": "2026-03-01T00:00:00Z",
+            "name": "App",
+            "document": {"children": []},
+        }
+    )
+
+    with (
+        patch.object(FigmaClient, "__new__", return_value=mock_client),
+        patch(
+            "figmaclaw.commands.pull.pull_file",
+            AsyncMock(return_value=PullResult(file_key="fileA", skipped_file=True)),
+        ) as mock_pull,
+    ):
+        await _run("key", tmp_path, None, False, None, False, 10, None, "all", prune=False)
+
+    assert mock_pull.await_count == 1
+    assert mock_pull.await_args is not None
+    assert mock_pull.await_args.kwargs["prune"] is False
+
+
 # --- _compute_raw_frames ---
 
 
@@ -1719,6 +1753,49 @@ async def test_pull_file_file_rename_moves_path_and_prunes_old(tmp_path: Path):
 
 
 @pytest.mark.asyncio
+async def test_pull_file_page_rename_with_prune_disabled_keeps_old_path(tmp_path: Path):
+    """INVARIANT: with prune=False, rename writes new path but keeps old generated path."""
+    page_id = "100:1"
+    old_page_name = "Showcase LSN"
+    new_page_name = "Showcase V2"
+    file_name = "Web App"
+
+    state = FigmaSyncState(tmp_path)
+    state.load()
+    state.add_tracked_file("abc123", file_name)
+    state.manifest.files["abc123"].version = "v1"
+
+    mock_client = MagicMock(spec=FigmaClient)
+    mock_client.get_component_sets = AsyncMock(return_value=[])
+    mock_client.get_nodes = AsyncMock(return_value={})
+
+    mock_client.get_file_meta = AsyncMock(
+        return_value=_custom_file_meta(
+            version="v2", file_name=file_name, page_id=page_id, page_name=old_page_name
+        )
+    )
+    mock_client.get_page = AsyncMock(return_value=fake_page_node_for_id(page_id, old_page_name))
+    await pull_file(mock_client, "abc123", state, tmp_path, force=False)
+
+    old_rel = page_path(slugify(file_name), f"{slugify(old_page_name)}-{page_id.replace(':', '-')}")
+    old_abs = tmp_path / old_rel
+    assert old_abs.exists()
+
+    mock_client.get_file_meta = AsyncMock(
+        return_value=_custom_file_meta(
+            version="v3", file_name=file_name, page_id=page_id, page_name=new_page_name
+        )
+    )
+    mock_client.get_page = AsyncMock(return_value=fake_page_node_for_id(page_id, new_page_name))
+    await pull_file(mock_client, "abc123", state, tmp_path, force=False, prune=False)
+
+    new_rel = page_path(slugify(file_name), f"{slugify(new_page_name)}-{page_id.replace(':', '-')}")
+    new_abs = tmp_path / new_rel
+    assert new_abs.exists()
+    assert old_abs.exists()
+
+
+@pytest.mark.asyncio
 async def test_pull_file_unchanged_run_prunes_existing_generated_orphans(tmp_path: Path):
     """INVARIANT: unchanged file-level skip still prunes generated orphan md/tokens files."""
     state = FigmaSyncState(tmp_path)
@@ -1754,6 +1831,59 @@ async def test_pull_file_unchanged_run_prunes_existing_generated_orphans(tmp_pat
     assert current_md.exists()
     assert not orphan_md.exists()
     assert not orphan_tok.exists()
+
+
+@pytest.mark.asyncio
+async def test_pull_file_screen_to_component_only_prunes_old_screen_md_and_sidecar(tmp_path: Path):
+    """INVARIANT: screen->component-only transition removes old page md + tokens sidecar."""
+    page_id = "100:1"
+    file_name = "Web App"
+
+    state = FigmaSyncState(tmp_path)
+    state.load()
+    state.add_tracked_file("abc123", file_name)
+    state.manifest.files["abc123"].version = "v1"
+
+    mock_client = MagicMock(spec=FigmaClient)
+    mock_client.get_component_sets = AsyncMock(return_value=[])
+    mock_client.get_nodes = AsyncMock(return_value={})
+
+    # First run: screen page exists
+    mock_client.get_file_meta = AsyncMock(
+        return_value=_custom_file_meta(
+            version="v2",
+            file_name=file_name,
+            page_id=page_id,
+            page_name="Catalog",
+        )
+    )
+    mock_client.get_page = AsyncMock(return_value=fake_page_node_for_id(page_id, "Catalog"))
+    await pull_file(mock_client, "abc123", state, tmp_path, force=False)
+
+    old_rel = page_path(slugify(file_name), f"catalog-{page_id.replace(':', '-')}")
+    old_abs = tmp_path / old_rel
+    assert old_abs.exists()
+    old_sidecar = old_abs.with_suffix(".tokens.json")
+    old_sidecar.write_text("{}")
+
+    # Second run: same page id becomes component-only
+    mock_client.get_file_meta = AsyncMock(
+        return_value=_custom_file_meta(
+            version="v3",
+            file_name=file_name,
+            page_id=page_id,
+            page_name="Catalog",
+        )
+    )
+    mock_client.get_page = AsyncMock(return_value=fake_component_page_node(page_id))
+    await pull_file(mock_client, "abc123", state, tmp_path, force=False)
+
+    assert not old_abs.exists()
+    assert not old_sidecar.exists()
+
+    entry = state.manifest.files["abc123"].pages[page_id]
+    assert entry.md_path is None
+    assert entry.component_md_paths
 
 
 @pytest.mark.asyncio

--- a/tests/test_pull_logic.py
+++ b/tests/test_pull_logic.py
@@ -28,10 +28,11 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from figmaclaw.commands.pull import _listing_prefilter
-from figmaclaw.figma_api_models import FileSummary, ProjectSummary
+from figmaclaw.figma_api_models import FileMetaResponse, FileSummary, ProjectSummary
 from figmaclaw.figma_client import FigmaClient
 from figmaclaw.figma_frontmatter import CURRENT_PULL_SCHEMA_VERSION
 from figmaclaw.figma_models import FigmaFrame, FigmaPage, FigmaSection  # noqa: F401 — used in tests
+from figmaclaw.figma_paths import page_path, slugify
 from figmaclaw.figma_sync_state import FigmaSyncState, PageEntry
 from figmaclaw.pull_logic import PullResult, pull_file, write_new_page
 from tests.conftest import (
@@ -187,7 +188,7 @@ async def test_pull_file_skips_page_when_hash_unchanged(tmp_path: Path):
     state.manifest.files["abc123"].pages["7741:45837"] = PageEntry(
         page_name="Onboarding",
         page_slug="onboarding",
-        md_path="figma/abc123/pages/onboarding.md",
+        md_path="figma/web-app/pages/onboarding-7741-45837.md",
         page_hash=stored_hash,
         last_refreshed_at="2026-03-30T00:00:00Z",
     )
@@ -629,7 +630,7 @@ async def test_pull_file_skipped_pages_do_not_trigger_on_page_written(tmp_path: 
     state.manifest.files["abc123"].pages["7741:45837"] = PageEntry(
         page_name="Onboarding",
         page_slug="onboarding",
-        md_path="figma/abc123/pages/onboarding.md",
+        md_path="figma/web-app/pages/onboarding-7741-45837.md",
         page_hash=stored_hash,
         last_refreshed_at="2026-03-30T00:00:00Z",
     )
@@ -1538,6 +1539,44 @@ async def test_pull_file_sets_no_access_on_http_400(tmp_path: Path):
 
 
 @pytest.mark.asyncio
+async def test_pull_file_sets_no_access_on_http_404(tmp_path: Path):
+    """INVARIANT: pull_file returns no_access=True when get_file_meta raises HTTP 404."""
+    import httpx
+
+    state = FigmaSyncState(tmp_path)
+    state.load()
+    state.add_tracked_file("abc123", "Web App")
+
+    mock_client = MagicMock(spec=FigmaClient)
+    response_mock = MagicMock()
+    response_mock.status_code = 404
+    mock_client.get_file_meta = AsyncMock(
+        side_effect=httpx.HTTPStatusError("404", request=MagicMock(), response=response_mock)
+    )
+
+    result = await pull_file(mock_client, "abc123", state, tmp_path, force=False)
+
+    assert result.no_access is True
+
+
+def _custom_file_meta(
+    *,
+    version: str,
+    file_name: str,
+    page_id: str,
+    page_name: str,
+) -> FileMetaResponse:
+    return FileMetaResponse.model_validate(
+        {
+            "version": version,
+            "lastModified": "2026-03-31T12:00:00Z",
+            "name": file_name,
+            "document": {"children": [{"id": page_id, "name": page_name, "type": "CANVAS"}]},
+        }
+    )
+
+
+@pytest.mark.asyncio
 async def test_pull_file_is_idempotent_second_call_changes_nothing(tmp_path: Path):
     """INVARIANT: a second pull on identical Figma content must not modify any file on disk.
 
@@ -1581,6 +1620,150 @@ async def test_pull_file_is_idempotent_second_call_changes_nothing(tmp_path: Pat
         "Files changed on second pull despite identical Figma content: "
         + str({k for k in all_files_after if all_files_after[k] != all_files_before.get(k)})
     )
+
+
+@pytest.mark.asyncio
+async def test_pull_file_page_rename_moves_path_and_prunes_old(tmp_path: Path):
+    """INVARIANT: renaming a page keeps exactly one page file path (old path is pruned)."""
+    page_id = "100:1"
+    old_page_name = "Showcase LSN"
+    new_page_name = "Showcase V2"
+    file_name = "Web App"
+
+    state = FigmaSyncState(tmp_path)
+    state.load()
+    state.add_tracked_file("abc123", file_name)
+    state.manifest.files["abc123"].version = "v1"
+
+    mock_client = MagicMock(spec=FigmaClient)
+    mock_client.get_component_sets = AsyncMock(return_value=[])
+    mock_client.get_nodes = AsyncMock(return_value={})
+
+    mock_client.get_file_meta = AsyncMock(
+        return_value=_custom_file_meta(
+            version="v2", file_name=file_name, page_id=page_id, page_name=old_page_name
+        )
+    )
+    mock_client.get_page = AsyncMock(return_value=fake_page_node_for_id(page_id, old_page_name))
+    await pull_file(mock_client, "abc123", state, tmp_path, force=False)
+
+    old_rel = page_path(slugify(file_name), f"{slugify(old_page_name)}-{page_id.replace(':', '-')}")
+    old_abs = tmp_path / old_rel
+    assert old_abs.exists()
+    old_abs.write_text(old_abs.read_text() + "\nMANUAL_BODY_SENTINEL\n")
+
+    mock_client.get_file_meta = AsyncMock(
+        return_value=_custom_file_meta(
+            version="v3", file_name=file_name, page_id=page_id, page_name=new_page_name
+        )
+    )
+    mock_client.get_page = AsyncMock(return_value=fake_page_node_for_id(page_id, new_page_name))
+    await pull_file(mock_client, "abc123", state, tmp_path, force=False)
+
+    new_rel = page_path(slugify(file_name), f"{slugify(new_page_name)}-{page_id.replace(':', '-')}")
+    new_abs = tmp_path / new_rel
+    assert new_abs.exists()
+    assert not old_abs.exists()
+    assert "MANUAL_BODY_SENTINEL" in new_abs.read_text()
+
+    files_before = {
+        str(p.relative_to(tmp_path)): p.read_bytes() for p in tmp_path.rglob("*") if p.is_file()
+    }
+    await pull_file(mock_client, "abc123", state, tmp_path, force=False)
+    files_after = {
+        str(p.relative_to(tmp_path)): p.read_bytes() for p in tmp_path.rglob("*") if p.is_file()
+    }
+    assert files_before == files_after
+
+
+@pytest.mark.asyncio
+async def test_pull_file_file_rename_moves_path_and_prunes_old(tmp_path: Path):
+    """INVARIANT: renaming a file (same key) moves generated page paths to the new file slug."""
+    page_id = "100:1"
+    page_name = "Reactions"
+    old_file_name = "Mobile Streaming Interface"
+    new_file_name = "Web Streaming Interface"
+
+    state = FigmaSyncState(tmp_path)
+    state.load()
+    state.add_tracked_file("abc123", old_file_name)
+    state.manifest.files["abc123"].version = "v1"
+
+    mock_client = MagicMock(spec=FigmaClient)
+    mock_client.get_component_sets = AsyncMock(return_value=[])
+    mock_client.get_nodes = AsyncMock(return_value={})
+
+    mock_client.get_file_meta = AsyncMock(
+        return_value=_custom_file_meta(
+            version="v2", file_name=old_file_name, page_id=page_id, page_name=page_name
+        )
+    )
+    mock_client.get_page = AsyncMock(return_value=fake_page_node_for_id(page_id, page_name))
+    await pull_file(mock_client, "abc123", state, tmp_path, force=False)
+
+    old_rel = page_path(slugify(old_file_name), f"{slugify(page_name)}-{page_id.replace(':', '-')}")
+    old_abs = tmp_path / old_rel
+    assert old_abs.exists()
+
+    mock_client.get_file_meta = AsyncMock(
+        return_value=_custom_file_meta(
+            version="v3", file_name=new_file_name, page_id=page_id, page_name=page_name
+        )
+    )
+    await pull_file(mock_client, "abc123", state, tmp_path, force=False)
+
+    new_rel = page_path(slugify(new_file_name), f"{slugify(page_name)}-{page_id.replace(':', '-')}")
+    new_abs = tmp_path / new_rel
+    assert new_abs.exists()
+    assert not old_abs.exists()
+
+
+@pytest.mark.asyncio
+async def test_pull_file_removed_page_prunes_manifest_and_files(tmp_path: Path):
+    """INVARIANT: pages removed from file metadata are pruned from manifest and disk."""
+    state = FigmaSyncState(tmp_path)
+    state.load()
+    state.add_tracked_file("abc123", "Web App")
+    state.manifest.files["abc123"].version = "v1"
+    state.manifest.files["abc123"].pages["100:1"] = PageEntry(
+        page_name="Legacy",
+        page_slug="legacy-100-1",
+        md_path="figma/web-app/pages/legacy-100-1.md",
+        page_hash="oldhash",
+        last_refreshed_at="2026-03-01T00:00:00Z",
+        component_md_paths=["figma/web-app/components/legacy-components-100-2.md"],
+    )
+    state.save()
+
+    page_md = tmp_path / "figma/web-app/pages/legacy-100-1.md"
+    page_md.parent.mkdir(parents=True, exist_ok=True)
+    page_md.write_text("legacy")
+    page_sidecar = page_md.with_suffix(".tokens.json")
+    page_sidecar.write_text("{}")
+    comp_md = tmp_path / "figma/web-app/components/legacy-components-100-2.md"
+    comp_md.parent.mkdir(parents=True, exist_ok=True)
+    comp_md.write_text("legacy-comp")
+
+    mock_client = MagicMock(spec=FigmaClient)
+    mock_client.get_component_sets = AsyncMock(return_value=[])
+    mock_client.get_nodes = AsyncMock(return_value={})
+    mock_client.get_file_meta = AsyncMock(
+        return_value=FileMetaResponse.model_validate(
+            {
+                "version": "v2",
+                "lastModified": "2026-03-31T12:00:00Z",
+                "name": "Web App",
+                "document": {"children": []},
+            }
+        )
+    )
+
+    result = await pull_file(mock_client, "abc123", state, tmp_path, force=False)
+    assert result.pages_written == 0
+    assert not page_md.exists()
+    assert not page_sidecar.exists()
+    assert not comp_md.exists()
+    assert "100:1" not in state.manifest.files["abc123"].pages
 
 
 @pytest.mark.asyncio

--- a/tests/test_pull_logic.py
+++ b/tests/test_pull_logic.py
@@ -1719,6 +1719,44 @@ async def test_pull_file_file_rename_moves_path_and_prunes_old(tmp_path: Path):
 
 
 @pytest.mark.asyncio
+async def test_pull_file_unchanged_run_prunes_existing_generated_orphans(tmp_path: Path):
+    """INVARIANT: unchanged file-level skip still prunes generated orphan md/tokens files."""
+    state = FigmaSyncState(tmp_path)
+    state.load()
+    state.add_tracked_file("abc123", "Web App")
+    state.manifest.files["abc123"].version = "v2"
+    state.manifest.files["abc123"].last_modified = "2026-03-31T12:00:00Z"
+    state.manifest.files["abc123"].pull_schema_version = CURRENT_PULL_SCHEMA_VERSION
+    state.manifest.files["abc123"].pages["100:1"] = PageEntry(
+        page_name="Current",
+        page_slug="current-100-1",
+        md_path="figma/web-app/pages/current-100-1.md",
+        page_hash="hash",
+        last_refreshed_at="now",
+    )
+    state.save()
+
+    current_md = tmp_path / "figma/web-app/pages/current-100-1.md"
+    current_md.parent.mkdir(parents=True, exist_ok=True)
+    current_md.write_text("current")
+
+    orphan_md = tmp_path / "figma/web-app/pages/legacy-100-99.md"
+    orphan_md.write_text("orphan")
+    orphan_tok = orphan_md.with_suffix(".tokens.json")
+    orphan_tok.write_text("{}")
+
+    mock_client = MagicMock(spec=FigmaClient)
+    mock_client.get_file_meta = AsyncMock(return_value=fake_file_meta("v2", "2026-03-31T12:00:00Z"))
+
+    result = await pull_file(mock_client, "abc123", state, tmp_path, force=False)
+
+    assert result.skipped_file is True
+    assert current_md.exists()
+    assert not orphan_md.exists()
+    assert not orphan_tok.exists()
+
+
+@pytest.mark.asyncio
 async def test_pull_file_removed_page_prunes_manifest_and_files(tmp_path: Path):
     """INVARIANT: pages removed from file metadata are pruned from manifest and disk."""
     state = FigmaSyncState(tmp_path)
@@ -1810,3 +1848,55 @@ async def test_has_more_only_set_when_content_changes_exhaust_budget(tmp_path: P
     assert result.pages_written == 0
     assert result.pages_schema_upgraded >= 1
     assert result.skipped_file is False  # schema_stale=True bypasses file-level skip
+
+
+@pytest.mark.asyncio
+async def test_pull_cmd_no_access_prunes_artifacts_and_untracks(tmp_path: Path):
+    """INVARIANT: pull command prunes known artifacts and untracks file on no_access."""
+    from figmaclaw.commands.pull import _run
+
+    state = FigmaSyncState(tmp_path)
+    state.load()
+    state.add_tracked_file("restricted_key", "Restricted")
+    state.manifest.files["restricted_key"].pages["11:1"] = PageEntry(
+        page_name="Legacy",
+        page_slug="legacy-11-1",
+        md_path="figma/restricted/pages/legacy-11-1.md",
+        page_hash="hash",
+        last_refreshed_at="now",
+        component_md_paths=["figma/restricted/components/legacy-components-11-2.md"],
+    )
+    state.save()
+
+    page_md = tmp_path / "figma/restricted/pages/legacy-11-1.md"
+    page_md.parent.mkdir(parents=True, exist_ok=True)
+    page_md.write_text("legacy")
+    sidecar = page_md.with_suffix(".tokens.json")
+    sidecar.write_text("{}")
+    comp_md = tmp_path / "figma/restricted/components/legacy-components-11-2.md"
+    comp_md.parent.mkdir(parents=True, exist_ok=True)
+    comp_md.write_text("legacy-comp")
+
+    mock_client = MagicMock(spec=FigmaClient)
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+
+    no_access_result = PullResult(file_key="restricted_key", no_access=True, skipped_file=True)
+    with (
+        patch.object(FigmaClient, "__new__", return_value=mock_client),
+        patch("figmaclaw.commands.pull.pull_file", AsyncMock(return_value=no_access_result)),
+    ):
+        await _run("key", tmp_path, None, False, None, False, 10, None, "all")
+
+    assert not page_md.exists()
+    assert not sidecar.exists()
+    assert not comp_md.exists()
+
+    reloaded = FigmaSyncState(tmp_path)
+    reloaded.load()
+    assert "restricted_key" not in reloaded.manifest.tracked_files
+    assert "restricted_key" not in reloaded.manifest.files
+    assert (
+        reloaded.manifest.skipped_files["restricted_key"]
+        == "no access — get_file_meta returns 400/404"
+    )


### PR DESCRIPTION
## Summary

Implements lifecycle reconciliation for generated Figma markdown paths to prevent orphan drift.

### What this changes

- `pull_file` now reconciles existing vs current generated paths and prunes stale artifacts.
- Handles rename migration by moving old generated paths to new paths before frontmatter update (preserves page body content).
- Removes manifest page entries + files for pages no longer present in current file metadata.
- Adds webhook payload compatibility for `file_key` (with `file_id` fallback).
- Handles `FILE_DELETE` events by pruning generated artifacts and untracking file key.
- Treats `get_file_meta` HTTP 404 as inaccessible/deleted (`no_access=True`).

### Why

Fixes measured manifest/filesystem drift and orphan accumulation (issue #68), including existing stale files already present in downstream repos.

## Testing

Focused suite run:

```bash
.venv/bin/python -m pytest tests/test_apply_webhook.py tests/test_pull_logic.py -q
```

Result: `72 passed`

### New/updated test coverage

- Page rename migration + prune of old path
- File rename migration + prune of old path
- Removed-page pruning from manifest and disk (including `.tokens.json`)
- `FILE_DELETE` webhook prune + untrack behavior
- Legacy `file_id` payload compatibility
- 404 `no_access` handling
- Idempotency after rename migration

Closes #68
