### PR TITLE
Fix pull lifecycle: collision-safe file slugs, cross-file prune safety, sidecar backfill

### DIFF
--- a/docs/figmaclaw-md-format.md
+++ b/docs/figmaclaw-md-format.md
@@ -266,4 +266,4 @@ figmaclaw mark-enriched <file>               # snapshot hashes
 | Manifest | `.figma-sync/manifest.json` |
 | Screenshot cache | `.figma-cache/screenshots/{file_key}/{node_id}.png` (gitignored) |
 
-The slug portion is `slugify(name)` (lowercase, hyphens). The suffix is the node ID with `:` replaced by `-`.
+The slug portion is `slugify(name)` (lowercase, hyphens). If multiple tracked files resolve to the same slug, figmaclaw appends `-{file_key[:8]}` to keep directories unique (for example `web-app-hov4qmbn`). The page/section suffix is the node ID with `:` replaced by `-`.

--- a/docs/figmaclaw-md-format.md
+++ b/docs/figmaclaw-md-format.md
@@ -266,4 +266,4 @@ figmaclaw mark-enriched <file>               # snapshot hashes
 | Manifest | `.figma-sync/manifest.json` |
 | Screenshot cache | `.figma-cache/screenshots/{file_key}/{node_id}.png` (gitignored) |
 
-The slug portion is `slugify(name)` (lowercase, hyphens). If multiple tracked files resolve to the same slug, figmaclaw appends `-{file_key[:8]}` to keep directories unique (for example `web-app-hov4qmbn`). The page/section suffix is the node ID with `:` replaced by `-`.
+The slug portion is always `slugify(name)-{file_key}` (full key included, for example `web-app-hOV4QMBnDIG5s5OYkSrX9E`). The page/section suffix is the node ID with `:` replaced by `-`.

--- a/figmaclaw/figma_paths.py
+++ b/figmaclaw/figma_paths.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import re
+from collections.abc import Mapping
 from pathlib import Path
 
 
@@ -25,6 +26,31 @@ def page_path(file_slug: str, page_slug: str) -> str:
     Example: figma/web-app/pages/onboarding-7741-45837.md
     """
     return f"figma/{file_slug}/pages/{page_slug}.md"
+
+
+def file_slug_for_key(
+    file_name: str,
+    file_key: str,
+    *,
+    tracked_file_names: Mapping[str, str] | None = None,
+) -> str:
+    """Return a collision-safe slug for one tracked file.
+
+    Base form is ``slugify(file_name)``. When more than one tracked file maps to
+    the same base slug, append a short key suffix so each file gets a unique
+    output directory (e.g. ``web-app-abc12345``).
+    """
+    base_slug = slugify(file_name, fallback=file_key)
+    if not tracked_file_names:
+        return base_slug
+
+    matching_keys = [
+        key for key, name in tracked_file_names.items() if slugify(name, fallback=key) == base_slug
+    ]
+    if len(matching_keys) <= 1:
+        return base_slug
+
+    return f"{base_slug}-{file_key[:8].lower()}"
 
 
 def screenshot_cache_path(repo_dir: str | Path, file_key: str, node_id: str) -> Path:

--- a/figmaclaw/figma_paths.py
+++ b/figmaclaw/figma_paths.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import re
-from collections.abc import Mapping
 from pathlib import Path
 
 
@@ -32,25 +31,16 @@ def file_slug_for_key(
     file_name: str,
     file_key: str,
     *,
-    tracked_file_names: Mapping[str, str] | None = None,
+    tracked_file_names: dict[str, str] | None = None,
 ) -> str:
-    """Return a collision-safe slug for one tracked file.
+    """Return a deterministic slug for one tracked file.
 
-    Base form is ``slugify(file_name)``. When more than one tracked file maps to
-    the same base slug, append a short key suffix so each file gets a unique
-    output directory (e.g. ``web-app-abc12345``).
+    The full file key is always included so paths are globally unique and never
+    depend on collision detection order (e.g. ``web-app-hOV4...``).
     """
+    _ = tracked_file_names  # backward-compatible signature; intentionally unused
     base_slug = slugify(file_name, fallback=file_key)
-    if not tracked_file_names:
-        return base_slug
-
-    matching_keys = [
-        key for key, name in tracked_file_names.items() if slugify(name, fallback=key) == base_slug
-    ]
-    if len(matching_keys) <= 1:
-        return base_slug
-
-    return f"{base_slug}-{file_key[:8].lower()}"
+    return f"{base_slug}-{file_key}"
 
 
 def screenshot_cache_path(repo_dir: str | Path, file_key: str, node_id: str) -> Path:

--- a/figmaclaw/pull_logic.py
+++ b/figmaclaw/pull_logic.py
@@ -69,6 +69,25 @@ from figmaclaw.token_scan import PageTokenScan, scan_page
 log = logging.getLogger(__name__)
 
 
+def _all_manifest_generated_paths(state: FigmaSyncState) -> set[str]:
+    """Return all generated paths currently referenced by the manifest."""
+    return {
+        rel
+        for file_entry in state.manifest.files.values()
+        for page_entry in file_entry.pages.values()
+        for rel in entry_paths(page_entry)
+    }
+
+
+def _file_slug_for_state(state: FigmaSyncState, file_key: str, file_name: str) -> str:
+    """Return a collision-safe file slug for the current manifest state."""
+    from figmaclaw.figma_paths import file_slug_for_key
+
+    tracked_names = {key: entry.file_name for key, entry in state.manifest.files.items()}
+    tracked_names[file_key] = file_name
+    return file_slug_for_key(file_name, file_key, tracked_file_names=tracked_names)
+
+
 class PullResult(BaseModel):
     """Summary of a pull_file run."""
 
@@ -508,21 +527,42 @@ async def pull_file(
 
     stored = state.manifest.files.get(file_key)
     schema_stale = (stored.pull_schema_version if stored else 0) < CURRENT_PULL_SCHEMA_VERSION
+    file_slug = _file_slug_for_state(state, file_key, file_name)
+
+    local_reconcile_needed = False
+    if stored is not None:
+        for page in stored.pages.values():
+            if page.md_path:
+                expected_md = page_path(file_slug, page.page_slug)
+                if page.md_path != expected_md:
+                    local_reconcile_needed = True
+                    break
+                md_abs = repo_root / page.md_path
+                if not md_abs.exists() or not md_abs.with_suffix(".tokens.json").exists():
+                    local_reconcile_needed = True
+                    break
+            for comp_rel in page.component_md_paths:
+                if not comp_rel.startswith(f"figma/{file_slug}/components/"):
+                    local_reconcile_needed = True
+                    break
+            if local_reconcile_needed:
+                break
     if (
         not force
         and not schema_stale
         and stored
         and stored.version == api_version
         and stored.last_modified == api_last_modified
+        and not local_reconcile_needed
     ):
         # Even on file-level skip, optionally prune generated orphans under file slug.
         if prune:
-            expected_paths = {rel for page in stored.pages.values() for rel in entry_paths(page)}
+            expected_paths = _all_manifest_generated_paths(state)
             candidate_dirs = {
-                repo_root / f"figma/{slugify(file_name, fallback=file_key)}/pages",
-                repo_root / f"figma/{slugify(file_name, fallback=file_key)}/components",
+                repo_root / f"figma/{file_slug}/pages",
+                repo_root / f"figma/{file_slug}/components",
             }
-            for rel in expected_paths:
+            for rel in {rel for page in stored.pages.values() for rel in entry_paths(page)}:
                 candidate_dirs.add((repo_root / rel).parent)
             for orphan_rel in find_generated_orphans(
                 repo_root, candidate_dirs=candidate_dirs, expected_paths=expected_paths
@@ -561,7 +601,6 @@ async def pull_file(
 
     page_stubs = meta.canvas_pages
     current_page_ids = {stub.id for stub in page_stubs}
-    file_slug = slugify(file_name, fallback=file_key)
     total_pages = len(page_stubs)
     pages_written_this_call = 0
 
@@ -695,7 +734,19 @@ async def pull_file(
         # These don't consume the max_pages budget so the whole file upgrades in one pass.
         schema_only = content_unchanged and schema_stale
 
-        if content_unchanged and not schema_stale and not needs_path_reconcile:
+        needs_sidecar_backfill = False
+        if content_unchanged and previous_entry and previous_entry.md_path:
+            md_abs = repo_root / previous_entry.md_path
+            needs_sidecar_backfill = (
+                md_abs.exists() and not md_abs.with_suffix(".tokens.json").exists()
+            )
+
+        if (
+            content_unchanged
+            and not schema_stale
+            and not needs_path_reconcile
+            and not needs_sidecar_backfill
+        ):
             _progress(f"  [{page_idx}/{total_pages}] {page_name} — unchanged (skip)")
             result.pages_skipped += 1
             continue
@@ -794,7 +845,12 @@ async def pull_file(
             # Skipped for schema-only upgrades: content is unchanged so token data can't have changed.
             token_scan: PageTokenScan | None = None
             raw_tokens: dict[str, RawTokenCounts] | None = None
-            if screen_frame_ids and not schema_only and not content_unchanged:
+            should_scan_tokens = (
+                screen_frame_ids
+                and not schema_only
+                and (not content_unchanged or needs_sidecar_backfill)
+            )
+            if should_scan_tokens:
                 try:
                     token_scan = scan_page(page_node, set(screen_frame_ids))
                     # Sparse frontmatter summary — only frames with at least one issue
@@ -956,7 +1012,7 @@ async def pull_file(
                 remove_generated_relpath(repo_root, stale_rel)
 
         # 3) Existing on-disk generated artifacts not referenced by manifest (legacy orphans).
-        expected_paths = {rel for page in file_entry.pages.values() for rel in entry_paths(page)}
+        expected_paths = _all_manifest_generated_paths(state)
         candidate_dirs = {
             repo_root / f"figma/{file_slug}/pages",
             repo_root / f"figma/{file_slug}/components",

--- a/tests/smoke/test_figma_api_smoke.py
+++ b/tests/smoke/test_figma_api_smoke.py
@@ -325,6 +325,69 @@ async def test_pull_backfills_missing_sidecar_on_unchanged_page_real_api(
 
 @pytest.mark.smoke
 @pytest.mark.asyncio
+async def test_pull_migrates_legacy_unkeyed_paths_to_full_key_slug_real_api(
+    tmp_path,
+    api_key: str,  # type: ignore[no-untyped-def]
+) -> None:
+    """Smoke: legacy unkeyed manifest paths are migrated to full-key slug paths."""
+    state = FigmaSyncState(tmp_path)
+    state.load()
+    state.add_tracked_file(TEST_FILE_KEY_LSN_BRANDING, "LSN Branding")
+    state.manifest.files[TEST_FILE_KEY_LSN_BRANDING].version = "v0"
+
+    async with FigmaClient(api_key=api_key) as client:
+        first = await pull_file(
+            client, TEST_FILE_KEY_LSN_BRANDING, state, tmp_path, force=False, max_pages=1
+        )
+        assert first.pages_written + first.pages_schema_upgraded > 0
+
+        pages = state.manifest.files[TEST_FILE_KEY_LSN_BRANDING].pages
+        assert pages
+        page_id = next(iter(pages.keys()))
+        entry = pages[page_id]
+        assert entry.md_path is not None
+
+        keyed_rel = entry.md_path
+        keyed_abs = tmp_path / keyed_rel
+        keyed_sidecar = keyed_abs.with_suffix(".tokens.json")
+        assert keyed_abs.exists()
+        had_sidecar = keyed_sidecar.exists()
+
+        keyed_dir = Path(keyed_rel).parts[1]
+        legacy_dir = keyed_dir.replace(f"-{TEST_FILE_KEY_LSN_BRANDING}", "")
+        legacy_rel = str(Path("figma") / legacy_dir / "pages" / Path(keyed_rel).name)
+        legacy_abs = tmp_path / legacy_rel
+        legacy_abs.parent.mkdir(parents=True, exist_ok=True)
+        keyed_abs.rename(legacy_abs)
+        if keyed_sidecar.exists():
+            keyed_sidecar.rename(legacy_abs.with_suffix(".tokens.json"))
+
+        state.manifest.files[TEST_FILE_KEY_LSN_BRANDING].pages[page_id] = PageEntry(
+            page_name=entry.page_name,
+            page_slug=entry.page_slug,
+            md_path=legacy_rel,
+            page_hash=entry.page_hash,
+            last_refreshed_at=entry.last_refreshed_at,
+            component_md_paths=entry.component_md_paths,
+            frame_hashes=entry.frame_hashes,
+        )
+        state.save()
+
+        migrated = await pull_file(client, TEST_FILE_KEY_LSN_BRANDING, state, tmp_path, force=False)
+
+    assert migrated.skipped_file is False
+    assert keyed_abs.exists()
+    assert not legacy_abs.exists()
+    # If a sidecar existed pre-migration, it must now live at keyed path.
+    legacy_sidecar = legacy_abs.with_suffix(".tokens.json")
+    if legacy_sidecar.exists():
+        raise AssertionError("legacy sidecar path was not pruned")
+    if had_sidecar:
+        assert keyed_sidecar.exists()
+
+
+@pytest.mark.smoke
+@pytest.mark.asyncio
 async def test_schema_upgrade_backfills_instance_component_ids_without_body_rewrite(
     tmp_path,
     api_key: str,  # type: ignore[no-untyped-def]

--- a/tests/smoke/test_figma_api_smoke.py
+++ b/tests/smoke/test_figma_api_smoke.py
@@ -275,10 +275,8 @@ async def test_pull_collision_safe_file_dirs_and_sidecar_backfill(
         assert entry_a.md_path is not None
         assert entry_b.md_path is not None
 
-        assert entry_a.md_path.startswith(f"figma/web-app-{TEST_FILE_KEY[:8].lower()}/pages/")
-        assert entry_b.md_path.startswith(
-            f"figma/web-app-{TEST_FILE_KEY_WEB_APP_DUP[:8].lower()}/pages/"
-        )
+        assert entry_a.md_path.startswith(f"figma/web-app-{TEST_FILE_KEY}/pages/")
+        assert entry_b.md_path.startswith(f"figma/web-app-{TEST_FILE_KEY_WEB_APP_DUP}/pages/")
         assert Path(entry_a.md_path).parts[1] != Path(entry_b.md_path).parts[1]
 
 

--- a/tests/smoke/test_figma_api_smoke.py
+++ b/tests/smoke/test_figma_api_smoke.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import os
 import re
+from pathlib import Path
 
 import httpx
 import pytest
@@ -25,6 +26,10 @@ from figmaclaw.pull_logic import pull_file
 
 # The Web App file used in linear-git
 TEST_FILE_KEY = "hOV4QMBnDIG5s5OYkSrX9E"
+# A second tracked file that also has the name "Web App" in linear-git manifest.
+TEST_FILE_KEY_WEB_APP_DUP = "jb1bZRQUUOQKEpb5p6vt5e"
+# Small file with known token sidecars (`cover-0-1`, `screens-1-3`) in linear-git.
+TEST_FILE_KEY_LSN_BRANDING = "IXVzan1Xz6J1rA1moyDsk5"
 # Reach - auto content sharing page
 TEST_PAGE_NODE_ID = "7741:45837"
 # Confirmed from live API: 8 SECTION children on this page
@@ -235,6 +240,89 @@ async def test_pull_is_idempotent_for_written_page_markdown(tmp_path, api_key: s
         md_after = page_md.read_text()
 
     assert md_before == md_after
+
+
+@pytest.mark.smoke
+@pytest.mark.asyncio
+async def test_pull_collision_safe_file_dirs_and_sidecar_backfill(
+    tmp_path,
+    api_key: str,  # type: ignore[no-untyped-def]
+) -> None:
+    """Smoke: same-name files get unique output directories (collision-safe slugs)."""
+    state = FigmaSyncState(tmp_path)
+    state.load()
+    # Intentionally track both as the same name to force slug collision handling.
+    state.add_tracked_file(TEST_FILE_KEY, "Web App")
+    state.add_tracked_file(TEST_FILE_KEY_WEB_APP_DUP, "Web App")
+    state.manifest.files[TEST_FILE_KEY].version = "v0"
+    state.manifest.files[TEST_FILE_KEY_WEB_APP_DUP].version = "v0"
+
+    async with FigmaClient(api_key=api_key) as client:
+        first = await pull_file(client, TEST_FILE_KEY, state, tmp_path, force=False, max_pages=1)
+        second = await pull_file(
+            client, TEST_FILE_KEY_WEB_APP_DUP, state, tmp_path, force=False, max_pages=1
+        )
+
+        assert first.pages_written + first.pages_schema_upgraded > 0
+        assert second.pages_written + second.pages_schema_upgraded > 0
+
+        pages_a = state.manifest.files[TEST_FILE_KEY].pages
+        pages_b = state.manifest.files[TEST_FILE_KEY_WEB_APP_DUP].pages
+        assert pages_a and pages_b
+
+        entry_a = next(iter(pages_a.values()))
+        entry_b = next(iter(pages_b.values()))
+        assert entry_a.md_path is not None
+        assert entry_b.md_path is not None
+
+        assert entry_a.md_path.startswith(f"figma/web-app-{TEST_FILE_KEY[:8].lower()}/pages/")
+        assert entry_b.md_path.startswith(
+            f"figma/web-app-{TEST_FILE_KEY_WEB_APP_DUP[:8].lower()}/pages/"
+        )
+        assert Path(entry_a.md_path).parts[1] != Path(entry_b.md_path).parts[1]
+
+
+@pytest.mark.smoke
+@pytest.mark.asyncio
+async def test_pull_backfills_missing_sidecar_on_unchanged_page_real_api(
+    tmp_path,
+    api_key: str,  # type: ignore[no-untyped-def]
+) -> None:
+    """Smoke: deleting a real sidecar is repaired by a subsequent unchanged pull."""
+    state = FigmaSyncState(tmp_path)
+    state.load()
+    state.add_tracked_file(TEST_FILE_KEY_LSN_BRANDING, "LSN Branding")
+    state.manifest.files[TEST_FILE_KEY_LSN_BRANDING].version = "v0"
+
+    async with FigmaClient(api_key=api_key) as client:
+        first = await pull_file(
+            client, TEST_FILE_KEY_LSN_BRANDING, state, tmp_path, force=False, max_pages=2
+        )
+        assert first.pages_written + first.pages_schema_upgraded > 0
+
+        pages = state.manifest.files[TEST_FILE_KEY_LSN_BRANDING].pages
+        assert pages
+        target_sidecar: Path | None = None
+        for entry in pages.values():
+            if not entry.md_path:
+                continue
+            sidecar = (tmp_path / entry.md_path).with_suffix(".tokens.json")
+            if "cover-0-1.tokens.json" in str(sidecar):
+                continue
+            if sidecar.exists():
+                target_sidecar = sidecar
+                break
+
+        assert target_sidecar is not None, (
+            "expected a non-cover sidecar to exist after initial pull"
+        )
+        target_sidecar.unlink()
+        assert not target_sidecar.exists()
+
+        backfill = await pull_file(client, TEST_FILE_KEY_LSN_BRANDING, state, tmp_path, force=False)
+
+    assert backfill.skipped_file is False
+    assert target_sidecar.exists()
 
 
 @pytest.mark.smoke

--- a/tests/test_body_preservation.py
+++ b/tests/test_body_preservation.py
@@ -212,8 +212,8 @@ async def test_bp1_sync_preserves_body_byte_for_byte(tmp_path: Path) -> None:
 @pytest.mark.asyncio
 async def test_bp2_pull_preserves_body_byte_for_byte(tmp_path: Path) -> None:
     """BP-2: pull_file on an existing file updates only frontmatter — body is byte-for-byte identical."""
-    # pull_file constructs: figma/web-app/pages/onboarding-7741-45837.md
-    pull_md_rel = "figma/web-app/pages/onboarding-7741-45837.md"
+    # pull_file constructs: figma/web-app-abc123/pages/onboarding-7741-45837.md
+    pull_md_rel = "figma/web-app-abc123/pages/onboarding-7741-45837.md"
     md_path, original_body = _write_enriched_md(tmp_path)
     # Also write at the pull-constructed path so pull_file finds it
     pull_md_path = tmp_path / pull_md_rel
@@ -310,9 +310,9 @@ async def test_bp5_sync_does_not_call_scaffold_on_existing_file(tmp_path: Path) 
 async def test_bp5_pull_does_not_call_scaffold_on_existing_file(tmp_path: Path) -> None:
     """BP-5: pull_file must never call write_new_page when the file already exists."""
     # pull_file builds its own path: figma/{file_slug}/pages/{page_slug}.md
-    # file_slug = slugify("Web App") = "web-app"
+    # file_slug = slugify("Web App") + "-abc123" = "web-app-abc123"
     # page_slug = slugify("Onboarding") + "-7741-45837" = "onboarding-7741-45837"
-    pull_md_rel = "figma/web-app/pages/onboarding-7741-45837.md"
+    pull_md_rel = "figma/web-app-abc123/pages/onboarding-7741-45837.md"
     page = _make_page(flows=[("11:1", "11:2")])
     entry = _make_entry(md_path=pull_md_rel)
     md = scaffold_page(page, entry)
@@ -391,7 +391,7 @@ async def test_sc2_pull_writes_scaffold_for_new_file(tmp_path: Path) -> None:
     mock_client = _mock_figma_client()
     await pull_file(mock_client, "abc123", state, tmp_path, force=False)
 
-    out = tmp_path / "figma" / "web-app" / "pages" / "onboarding-7741-45837.md"
+    out = tmp_path / "figma" / "web-app-abc123" / "pages" / "onboarding-7741-45837.md"
     assert out.exists()
     content = out.read_text()
     # Must contain LLM placeholders since this is a new file

--- a/tests/test_figma_paths_and_state.py
+++ b/tests/test_figma_paths_and_state.py
@@ -6,7 +6,7 @@ import json
 from pathlib import Path
 
 from figmaclaw.figma_hash import compute_page_hash
-from figmaclaw.figma_paths import page_path, slugify
+from figmaclaw.figma_paths import file_slug_for_key, page_path, slugify
 from figmaclaw.figma_sync_state import FigmaSyncState, Manifest
 
 # --- figma_paths ---
@@ -42,6 +42,25 @@ def test_slugify_handles_unicode():
     result = slugify("🎨 Designs")
     assert result  # non-empty
     assert "-" not in result[:1]  # no leading hyphen
+
+
+def test_file_slug_for_key_uses_plain_slug_when_unique():
+    tracked = {
+        "abc123": "Web App",
+        "def456": "Design System",
+    }
+    assert file_slug_for_key("Web App", "abc123", tracked_file_names=tracked) == "web-app"
+
+
+def test_file_slug_for_key_adds_key_suffix_when_slug_collides():
+    tracked = {
+        "hOV4QMBnDIG5s5OYkSrX9E": "Web App",
+        "jb1bZRQUUOQKEpb5p6vt5e": "Web App",
+    }
+    assert (
+        file_slug_for_key("Web App", "hOV4QMBnDIG5s5OYkSrX9E", tracked_file_names=tracked)
+        == "web-app-hov4qmbn"
+    )
 
 
 # --- figma_hash ---

--- a/tests/test_figma_paths_and_state.py
+++ b/tests/test_figma_paths_and_state.py
@@ -44,22 +44,22 @@ def test_slugify_handles_unicode():
     assert "-" not in result[:1]  # no leading hyphen
 
 
-def test_file_slug_for_key_uses_plain_slug_when_unique():
+def test_file_slug_for_key_always_appends_full_file_key_when_unique():
     tracked = {
         "abc123": "Web App",
         "def456": "Design System",
     }
-    assert file_slug_for_key("Web App", "abc123", tracked_file_names=tracked) == "web-app"
+    assert file_slug_for_key("Web App", "abc123", tracked_file_names=tracked) == "web-app-abc123"
 
 
-def test_file_slug_for_key_adds_key_suffix_when_slug_collides():
+def test_file_slug_for_key_uses_full_key_when_slug_collides():
     tracked = {
         "hOV4QMBnDIG5s5OYkSrX9E": "Web App",
         "jb1bZRQUUOQKEpb5p6vt5e": "Web App",
     }
     assert (
         file_slug_for_key("Web App", "hOV4QMBnDIG5s5OYkSrX9E", tracked_file_names=tracked)
-        == "web-app-hov4qmbn"
+        == "web-app-hOV4QMBnDIG5s5OYkSrX9E"
     )
 
 

--- a/tests/test_pull_logic.py
+++ b/tests/test_pull_logic.py
@@ -1657,6 +1657,51 @@ async def test_pull_file_is_idempotent_second_call_changes_nothing(tmp_path: Pat
 
 
 @pytest.mark.asyncio
+async def test_pull_file_backfills_missing_sidecar_on_unchanged_page(tmp_path: Path):
+    """INVARIANT: unchanged pages with missing sidecar are re-processed to recreate sidecar."""
+    from figmaclaw.figma_hash import compute_page_hash
+
+    page_id = "7741:45837"
+    file_key = "abc123"
+    page_node = fake_page_node_with_children()
+    page_hash = compute_page_hash(page_node)
+
+    state = FigmaSyncState(tmp_path)
+    state.load()
+    state.add_tracked_file(file_key, "Web App")
+    state.manifest.files[file_key].version = "v2"
+    state.manifest.files[file_key].last_modified = "2026-03-31T12:00:00Z"
+    state.manifest.files[file_key].pull_schema_version = CURRENT_PULL_SCHEMA_VERSION
+    md_rel = "figma/web-app/pages/onboarding-7741-45837.md"
+    state.manifest.files[file_key].pages[page_id] = PageEntry(
+        page_name="Onboarding",
+        page_slug="onboarding-7741-45837",
+        md_path=md_rel,
+        page_hash=page_hash,
+        last_refreshed_at="2026-03-31T12:00:00Z",
+    )
+    state.save()
+
+    md_abs = tmp_path / md_rel
+    md_abs.parent.mkdir(parents=True, exist_ok=True)
+    md_abs.write_text(
+        "---\nfile_key: abc123\npage_node_id: '7741:45837'\nframes: ['11:1']\n---\n\n# body\n"
+    )
+    assert not md_abs.with_suffix(".tokens.json").exists()
+
+    mock_client = MagicMock(spec=FigmaClient)
+    mock_client.get_file_meta = AsyncMock(return_value=fake_file_meta("v2", "2026-03-31T12:00:00Z"))
+    mock_client.get_page = AsyncMock(return_value=page_node)
+    mock_client.get_component_sets = AsyncMock(return_value=[])
+    mock_client.get_nodes = AsyncMock(return_value=fake_get_nodes_response())
+
+    result = await pull_file(mock_client, file_key, state, tmp_path, force=False)
+
+    assert result.skipped_file is False
+    assert md_abs.with_suffix(".tokens.json").exists()
+
+
+@pytest.mark.asyncio
 async def test_pull_file_page_rename_moves_path_and_prunes_old(tmp_path: Path):
     """INVARIANT: renaming a page keeps exactly one page file path (old path is pruned)."""
     page_id = "100:1"
@@ -1816,6 +1861,7 @@ async def test_pull_file_unchanged_run_prunes_existing_generated_orphans(tmp_pat
     current_md = tmp_path / "figma/web-app/pages/current-100-1.md"
     current_md.parent.mkdir(parents=True, exist_ok=True)
     current_md.write_text("current")
+    current_md.with_suffix(".tokens.json").write_text("{}")
 
     orphan_md = tmp_path / "figma/web-app/pages/legacy-100-99.md"
     orphan_md.write_text("orphan")
@@ -1831,6 +1877,57 @@ async def test_pull_file_unchanged_run_prunes_existing_generated_orphans(tmp_pat
     assert current_md.exists()
     assert not orphan_md.exists()
     assert not orphan_tok.exists()
+
+
+@pytest.mark.asyncio
+async def test_pull_file_unchanged_skip_does_not_prune_other_file_paths_in_candidate_dir(
+    tmp_path: Path,
+):
+    """INVARIANT: prune on one file never deletes files referenced by another tracked file."""
+    file_a = "fileA1111111111111111111111"
+    file_b = "fileB2222222222222222222222"
+
+    state = FigmaSyncState(tmp_path)
+    state.load()
+    state.add_tracked_file(file_a, "Web App")
+    state.add_tracked_file(file_b, "Design System")
+
+    for key in (file_a, file_b):
+        state.manifest.files[key].version = "v2"
+        state.manifest.files[key].last_modified = "2026-03-31T12:00:00Z"
+        state.manifest.files[key].pull_schema_version = CURRENT_PULL_SCHEMA_VERSION
+
+    state.manifest.files[file_a].pages["100:1"] = PageEntry(
+        page_name="Alpha",
+        page_slug="alpha-100-1",
+        md_path="figma/web-app/pages/alpha-100-1.md",
+        page_hash="hash-a",
+        last_refreshed_at="now",
+    )
+    state.manifest.files[file_b].pages["200:1"] = PageEntry(
+        page_name="Beta",
+        page_slug="beta-200-1",
+        md_path="figma/web-app/pages/beta-200-1.md",
+        page_hash="hash-b",
+        last_refreshed_at="now",
+    )
+    state.save()
+
+    alpha = tmp_path / "figma/web-app/pages/alpha-100-1.md"
+    beta = tmp_path / "figma/web-app/pages/beta-200-1.md"
+    alpha.parent.mkdir(parents=True, exist_ok=True)
+    alpha.write_text("alpha")
+    beta.write_text("beta")
+    alpha.with_suffix(".tokens.json").write_text("{}")
+    beta.with_suffix(".tokens.json").write_text("{}")
+
+    mock_client = MagicMock(spec=FigmaClient)
+    mock_client.get_file_meta = AsyncMock(return_value=fake_file_meta("v2", "2026-03-31T12:00:00Z"))
+
+    result = await pull_file(mock_client, file_a, state, tmp_path, force=False)
+    assert result.skipped_file is True
+    assert alpha.exists()
+    assert beta.exists()
 
 
 @pytest.mark.asyncio

--- a/tests/test_pull_logic.py
+++ b/tests/test_pull_logic.py
@@ -91,7 +91,7 @@ def _make_entry(page_hash: str = "aaaa1111bbbb2222") -> PageEntry:
     return PageEntry(
         page_name="Onboarding",
         page_slug="onboarding",
-        md_path="figma/abc123/pages/onboarding.md",
+        md_path="figma/web-app-abc123/pages/onboarding.md",
         page_hash=page_hash,
         last_refreshed_at="2026-03-31T00:00:00Z",
     )
@@ -105,7 +105,7 @@ def test_write_new_page_creates_file(tmp_path: Path):
     page = _make_page()
     entry = _make_entry()
     write_new_page(tmp_path, page, entry)
-    out = tmp_path / "figma" / "abc123" / "pages" / "onboarding.md"
+    out = tmp_path / "figma" / "web-app-abc123" / "pages" / "onboarding.md"
     assert out.exists()
     assert "# Web App / Onboarding" in out.read_text()
 
@@ -115,7 +115,7 @@ def test_write_new_page_creates_parent_dirs(tmp_path: Path):
     page = _make_page()
     entry = _make_entry()
     write_new_page(tmp_path, page, entry)
-    assert (tmp_path / "figma" / "abc123" / "pages").is_dir()
+    assert (tmp_path / "figma" / "web-app-abc123" / "pages").is_dir()
 
 
 def test_write_new_page_returns_path(tmp_path: Path):
@@ -123,7 +123,7 @@ def test_write_new_page_returns_path(tmp_path: Path):
     page = _make_page()
     entry = _make_entry()
     result = write_new_page(tmp_path, page, entry)
-    assert result == tmp_path / "figma" / "abc123" / "pages" / "onboarding.md"
+    assert result == tmp_path / "figma" / "web-app-abc123" / "pages" / "onboarding.md"
 
 
 # --- pull_file ---
@@ -188,10 +188,14 @@ async def test_pull_file_skips_page_when_hash_unchanged(tmp_path: Path):
     state.manifest.files["abc123"].pages["7741:45837"] = PageEntry(
         page_name="Onboarding",
         page_slug="onboarding",
-        md_path="figma/web-app/pages/onboarding-7741-45837.md",
+        md_path="figma/web-app-abc123/pages/onboarding-7741-45837.md",
         page_hash=stored_hash,
         last_refreshed_at="2026-03-30T00:00:00Z",
     )
+    existing_md = tmp_path / "figma/web-app-abc123/pages/onboarding-7741-45837.md"
+    existing_md.parent.mkdir(parents=True, exist_ok=True)
+    existing_md.write_text("---\n---\n")
+    existing_md.with_suffix(".tokens.json").write_text("{}")
 
     mock_client = MagicMock(spec=FigmaClient)
     mock_client.get_file_meta = AsyncMock(return_value=fake_file_meta("v2"))
@@ -215,7 +219,7 @@ async def test_pull_file_writes_page_when_hash_changed(tmp_path: Path):
     state.manifest.files["abc123"].pages["7741:45837"] = PageEntry(
         page_name="Onboarding",
         page_slug="onboarding",
-        md_path="figma/abc123/pages/onboarding.md",
+        md_path="figma/web-app-abc123/pages/onboarding.md",
         page_hash="0000000000000000",
         last_refreshed_at="2026-03-30T00:00:00Z",
     )
@@ -227,7 +231,7 @@ async def test_pull_file_writes_page_when_hash_changed(tmp_path: Path):
     result = await pull_file(mock_client, "abc123", state, tmp_path, force=False)
 
     assert result.pages_written == 1
-    out = tmp_path / "figma" / "web-app" / "pages" / "onboarding-7741-45837.md"
+    out = tmp_path / "figma" / "web-app-abc123" / "pages" / "onboarding-7741-45837.md"
     assert out.exists()
 
 
@@ -264,7 +268,7 @@ async def test_pull_file_writes_component_md_for_component_section(pull_env: Pul
 
     assert result.component_sections_written == 1
     assert result.pages_written == 0  # no screen sections
-    out = tmp_path / "figma" / "web-app" / "components" / "buttons-20-1.md"
+    out = tmp_path / "figma" / "web-app-abc123" / "components" / "buttons-20-1.md"
     assert out.exists()
     assert "## Variants" in out.read_text()
 
@@ -278,7 +282,7 @@ async def test_pull_file_skips_screen_md_when_all_sections_are_components(pull_e
     result = await pull_file(mock_client, "abc123", state, tmp_path, force=False)
 
     assert result.pages_written == 0
-    pages_dir = tmp_path / "figma" / "web-app" / "pages"
+    pages_dir = tmp_path / "figma" / "web-app-abc123" / "pages"
     assert not pages_dir.exists() or not any(pages_dir.iterdir())
 
 
@@ -292,7 +296,7 @@ async def test_pull_file_manifest_records_component_paths(pull_env: PullEnv):
 
     entry = state.manifest.files["abc123"].pages["7741:45837"]
     assert entry.md_path is None  # no screen sections
-    assert "figma/web-app/components/buttons-20-1.md" in entry.component_md_paths
+    assert "figma/web-app-abc123/components/buttons-20-1.md" in entry.component_md_paths
 
 
 @pytest.mark.asyncio
@@ -303,7 +307,7 @@ async def test_pull_file_writes_component_section_with_frame_ids(pull_env: PullE
 
     await pull_file(mock_client, "abc123", state, tmp_path, force=False)
 
-    comp_out = tmp_path / "figma" / "web-app" / "components" / "buttons-20-1.md"
+    comp_out = tmp_path / "figma" / "web-app-abc123" / "components" / "buttons-20-1.md"
     content = comp_out.read_text()
     from figmaclaw.figma_parse import parse_frontmatter
 
@@ -319,7 +323,7 @@ async def test_pull_file_preserves_existing_descriptions(tmp_path: Path):
     # Pre-write a .md with existing descriptions at the slug-based path
     existing_entry = _make_entry("0000000000000000")
     existing_entry = existing_entry.model_copy(
-        update={"md_path": "figma/web-app/pages/onboarding-7741-45837.md"}
+        update={"md_path": "figma/web-app-abc123/pages/onboarding-7741-45837.md"}
     )
     page_with_descs = _make_page()  # has descriptions
     write_new_page(tmp_path, page_with_descs, existing_entry)
@@ -331,7 +335,7 @@ async def test_pull_file_preserves_existing_descriptions(tmp_path: Path):
     state.manifest.files["abc123"].pages["7741:45837"] = PageEntry(
         page_name="Onboarding",
         page_slug="onboarding",
-        md_path="figma/abc123/pages/onboarding.md",
+        md_path="figma/web-app-abc123/pages/onboarding.md",
         page_hash="0000000000000000",
         last_refreshed_at="2026-03-30T00:00:00Z",
     )
@@ -344,7 +348,7 @@ async def test_pull_file_preserves_existing_descriptions(tmp_path: Path):
 
     await pull_file(mock_client, "abc123", state, tmp_path, force=False)
 
-    out = tmp_path / "figma" / "web-app" / "pages" / "onboarding-7741-45837.md"
+    out = tmp_path / "figma" / "web-app-abc123" / "pages" / "onboarding-7741-45837.md"
     content = out.read_text()
     # The existing descriptions should be preserved in the output
     assert "Welcome screen." in content
@@ -630,10 +634,14 @@ async def test_pull_file_skipped_pages_do_not_trigger_on_page_written(tmp_path: 
     state.manifest.files["abc123"].pages["7741:45837"] = PageEntry(
         page_name="Onboarding",
         page_slug="onboarding",
-        md_path="figma/web-app/pages/onboarding-7741-45837.md",
+        md_path="figma/web-app-abc123/pages/onboarding-7741-45837.md",
         page_hash=stored_hash,
         last_refreshed_at="2026-03-30T00:00:00Z",
     )
+    existing_md = tmp_path / "figma/web-app-abc123/pages/onboarding-7741-45837.md"
+    existing_md.parent.mkdir(parents=True, exist_ok=True)
+    existing_md.write_text("---\n---\n")
+    existing_md.with_suffix(".tokens.json").write_text("{}")
 
     mock_client = MagicMock(spec=FigmaClient)
     mock_client.get_file_meta = AsyncMock(return_value=fake_file_meta("v2"))
@@ -1248,7 +1256,7 @@ async def test_pull_file_writes_raw_frames_to_new_page_frontmatter(pull_env: Pul
 
     await pull_file(mock_client, "abc123", state, tmp_path, force=False)
 
-    out = tmp_path / "figma" / "web-app" / "pages" / "onboarding-7741-45837.md"
+    out = tmp_path / "figma" / "web-app-abc123" / "pages" / "onboarding-7741-45837.md"
     fm = parse_frontmatter(out.read_text())
     assert fm is not None
     assert "11:1" in fm.raw_frames
@@ -1272,7 +1280,7 @@ async def test_pull_file_is_idempotent_for_frame_sections_inventory(pull_env: Pu
     mock_client.get_nodes = AsyncMock(return_value=fake_get_nodes_response())
 
     await pull_file(mock_client, "abc123", state, tmp_path, force=False)
-    out = tmp_path / "figma" / "web-app" / "pages" / "onboarding-7741-45837.md"
+    out = tmp_path / "figma" / "web-app-abc123" / "pages" / "onboarding-7741-45837.md"
     first_text = out.read_text()
     fm1 = parse_frontmatter(first_text)
     assert fm1 is not None
@@ -1314,7 +1322,7 @@ async def test_pull_file_writes_component_set_keys_to_component_frontmatter(pull
 
     await pull_file(mock_client, "abc123", state, tmp_path, force=False)
 
-    comp_out = tmp_path / "figma" / "web-app" / "components" / "buttons-20-1.md"
+    comp_out = tmp_path / "figma" / "web-app-abc123" / "components" / "buttons-20-1.md"
     fm = parse_frontmatter(comp_out.read_text())
     assert fm is not None
     assert fm.component_set_keys == {
@@ -1337,7 +1345,7 @@ async def test_pull_file_handles_get_component_sets_failure_gracefully(pull_env:
     result = await pull_file(mock_client, "abc123", state, tmp_path, force=False)
 
     assert result.component_sections_written == 1  # still wrote the file
-    comp_out = tmp_path / "figma" / "web-app" / "components" / "buttons-20-1.md"
+    comp_out = tmp_path / "figma" / "web-app-abc123" / "components" / "buttons-20-1.md"
     fm = parse_frontmatter(comp_out.read_text())
     assert fm is not None
     assert fm.component_set_keys == {}  # empty — not an error
@@ -1355,7 +1363,7 @@ async def test_pull_file_handles_get_nodes_failure_gracefully(pull_env: PullEnv)
     result = await pull_file(mock_client, "abc123", state, tmp_path, force=False)
 
     assert result.pages_written == 1  # still wrote the page
-    out = tmp_path / "figma" / "web-app" / "pages" / "onboarding-7741-45837.md"
+    out = tmp_path / "figma" / "web-app-abc123" / "pages" / "onboarding-7741-45837.md"
     fm = parse_frontmatter(out.read_text())
     assert fm is not None
     assert fm.raw_frames == {}  # absent from frontmatter when fetch failed
@@ -1439,7 +1447,7 @@ async def test_pull_file_processes_schema_stale_pages_even_when_page_hash_unchan
     # First pull: write the page, bump version and schema version
     await pull_file(mock_client, "abc123", state, tmp_path, force=False)
 
-    out = tmp_path / "figma" / "web-app" / "pages" / "onboarding-7741-45837.md"
+    out = tmp_path / "figma" / "web-app-abc123" / "pages" / "onboarding-7741-45837.md"
     body_before = out.read_text().split("---\n", 2)[-1]  # capture body
     fm_before = parse_frontmatter(out.read_text())
     assert fm_before is not None
@@ -1672,7 +1680,7 @@ async def test_pull_file_backfills_missing_sidecar_on_unchanged_page(tmp_path: P
     state.manifest.files[file_key].version = "v2"
     state.manifest.files[file_key].last_modified = "2026-03-31T12:00:00Z"
     state.manifest.files[file_key].pull_schema_version = CURRENT_PULL_SCHEMA_VERSION
-    md_rel = "figma/web-app/pages/onboarding-7741-45837.md"
+    md_rel = "figma/web-app-abc123/pages/onboarding-7741-45837.md"
     state.manifest.files[file_key].pages[page_id] = PageEntry(
         page_name="Onboarding",
         page_slug="onboarding-7741-45837",
@@ -1726,7 +1734,9 @@ async def test_pull_file_page_rename_moves_path_and_prunes_old(tmp_path: Path):
     mock_client.get_page = AsyncMock(return_value=fake_page_node_for_id(page_id, old_page_name))
     await pull_file(mock_client, "abc123", state, tmp_path, force=False)
 
-    old_rel = page_path(slugify(file_name), f"{slugify(old_page_name)}-{page_id.replace(':', '-')}")
+    old_rel = page_path(
+        f"{slugify(file_name)}-abc123", f"{slugify(old_page_name)}-{page_id.replace(':', '-')}"
+    )
     old_abs = tmp_path / old_rel
     assert old_abs.exists()
     old_abs.write_text(old_abs.read_text() + "\nMANUAL_BODY_SENTINEL\n")
@@ -1739,7 +1749,9 @@ async def test_pull_file_page_rename_moves_path_and_prunes_old(tmp_path: Path):
     mock_client.get_page = AsyncMock(return_value=fake_page_node_for_id(page_id, new_page_name))
     await pull_file(mock_client, "abc123", state, tmp_path, force=False)
 
-    new_rel = page_path(slugify(file_name), f"{slugify(new_page_name)}-{page_id.replace(':', '-')}")
+    new_rel = page_path(
+        f"{slugify(file_name)}-abc123", f"{slugify(new_page_name)}-{page_id.replace(':', '-')}"
+    )
     new_abs = tmp_path / new_rel
     assert new_abs.exists()
     assert not old_abs.exists()
@@ -1780,7 +1792,9 @@ async def test_pull_file_file_rename_moves_path_and_prunes_old(tmp_path: Path):
     mock_client.get_page = AsyncMock(return_value=fake_page_node_for_id(page_id, page_name))
     await pull_file(mock_client, "abc123", state, tmp_path, force=False)
 
-    old_rel = page_path(slugify(old_file_name), f"{slugify(page_name)}-{page_id.replace(':', '-')}")
+    old_rel = page_path(
+        f"{slugify(old_file_name)}-abc123", f"{slugify(page_name)}-{page_id.replace(':', '-')}"
+    )
     old_abs = tmp_path / old_rel
     assert old_abs.exists()
 
@@ -1791,7 +1805,9 @@ async def test_pull_file_file_rename_moves_path_and_prunes_old(tmp_path: Path):
     )
     await pull_file(mock_client, "abc123", state, tmp_path, force=False)
 
-    new_rel = page_path(slugify(new_file_name), f"{slugify(page_name)}-{page_id.replace(':', '-')}")
+    new_rel = page_path(
+        f"{slugify(new_file_name)}-abc123", f"{slugify(page_name)}-{page_id.replace(':', '-')}"
+    )
     new_abs = tmp_path / new_rel
     assert new_abs.exists()
     assert not old_abs.exists()
@@ -1822,7 +1838,9 @@ async def test_pull_file_page_rename_with_prune_disabled_keeps_old_path(tmp_path
     mock_client.get_page = AsyncMock(return_value=fake_page_node_for_id(page_id, old_page_name))
     await pull_file(mock_client, "abc123", state, tmp_path, force=False)
 
-    old_rel = page_path(slugify(file_name), f"{slugify(old_page_name)}-{page_id.replace(':', '-')}")
+    old_rel = page_path(
+        f"{slugify(file_name)}-abc123", f"{slugify(old_page_name)}-{page_id.replace(':', '-')}"
+    )
     old_abs = tmp_path / old_rel
     assert old_abs.exists()
 
@@ -1834,7 +1852,9 @@ async def test_pull_file_page_rename_with_prune_disabled_keeps_old_path(tmp_path
     mock_client.get_page = AsyncMock(return_value=fake_page_node_for_id(page_id, new_page_name))
     await pull_file(mock_client, "abc123", state, tmp_path, force=False, prune=False)
 
-    new_rel = page_path(slugify(file_name), f"{slugify(new_page_name)}-{page_id.replace(':', '-')}")
+    new_rel = page_path(
+        f"{slugify(file_name)}-abc123", f"{slugify(new_page_name)}-{page_id.replace(':', '-')}"
+    )
     new_abs = tmp_path / new_rel
     assert new_abs.exists()
     assert old_abs.exists()
@@ -1852,18 +1872,18 @@ async def test_pull_file_unchanged_run_prunes_existing_generated_orphans(tmp_pat
     state.manifest.files["abc123"].pages["100:1"] = PageEntry(
         page_name="Current",
         page_slug="current-100-1",
-        md_path="figma/web-app/pages/current-100-1.md",
+        md_path="figma/web-app-abc123/pages/current-100-1.md",
         page_hash="hash",
         last_refreshed_at="now",
     )
     state.save()
 
-    current_md = tmp_path / "figma/web-app/pages/current-100-1.md"
+    current_md = tmp_path / "figma/web-app-abc123/pages/current-100-1.md"
     current_md.parent.mkdir(parents=True, exist_ok=True)
     current_md.write_text("current")
     current_md.with_suffix(".tokens.json").write_text("{}")
 
-    orphan_md = tmp_path / "figma/web-app/pages/legacy-100-99.md"
+    orphan_md = tmp_path / "figma/web-app-abc123/pages/legacy-100-99.md"
     orphan_md.write_text("orphan")
     orphan_tok = orphan_md.with_suffix(".tokens.json")
     orphan_tok.write_text("{}")
@@ -1900,22 +1920,23 @@ async def test_pull_file_unchanged_skip_does_not_prune_other_file_paths_in_candi
     state.manifest.files[file_a].pages["100:1"] = PageEntry(
         page_name="Alpha",
         page_slug="alpha-100-1",
-        md_path="figma/web-app/pages/alpha-100-1.md",
+        md_path="figma/web-app-fileA1111111111111111111111/pages/alpha-100-1.md",
         page_hash="hash-a",
         last_refreshed_at="now",
     )
     state.manifest.files[file_b].pages["200:1"] = PageEntry(
         page_name="Beta",
         page_slug="beta-200-1",
-        md_path="figma/web-app/pages/beta-200-1.md",
+        md_path="figma/design-system-fileB2222222222222222222222/pages/beta-200-1.md",
         page_hash="hash-b",
         last_refreshed_at="now",
     )
     state.save()
 
-    alpha = tmp_path / "figma/web-app/pages/alpha-100-1.md"
-    beta = tmp_path / "figma/web-app/pages/beta-200-1.md"
+    alpha = tmp_path / "figma/web-app-fileA1111111111111111111111/pages/alpha-100-1.md"
+    beta = tmp_path / "figma/design-system-fileB2222222222222222222222/pages/beta-200-1.md"
     alpha.parent.mkdir(parents=True, exist_ok=True)
+    beta.parent.mkdir(parents=True, exist_ok=True)
     alpha.write_text("alpha")
     beta.write_text("beta")
     alpha.with_suffix(".tokens.json").write_text("{}")
@@ -1957,7 +1978,7 @@ async def test_pull_file_screen_to_component_only_prunes_old_screen_md_and_sidec
     mock_client.get_page = AsyncMock(return_value=fake_page_node_for_id(page_id, "Catalog"))
     await pull_file(mock_client, "abc123", state, tmp_path, force=False)
 
-    old_rel = page_path(slugify(file_name), f"catalog-{page_id.replace(':', '-')}")
+    old_rel = page_path(f"{slugify(file_name)}-abc123", f"catalog-{page_id.replace(':', '-')}")
     old_abs = tmp_path / old_rel
     assert old_abs.exists()
     old_sidecar = old_abs.with_suffix(".tokens.json")
@@ -1993,19 +2014,19 @@ async def test_pull_file_removed_page_prunes_manifest_and_files(tmp_path: Path):
     state.manifest.files["abc123"].pages["100:1"] = PageEntry(
         page_name="Legacy",
         page_slug="legacy-100-1",
-        md_path="figma/web-app/pages/legacy-100-1.md",
+        md_path="figma/web-app-abc123/pages/legacy-100-1.md",
         page_hash="oldhash",
         last_refreshed_at="2026-03-01T00:00:00Z",
-        component_md_paths=["figma/web-app/components/legacy-components-100-2.md"],
+        component_md_paths=["figma/web-app-abc123/components/legacy-components-100-2.md"],
     )
     state.save()
 
-    page_md = tmp_path / "figma/web-app/pages/legacy-100-1.md"
+    page_md = tmp_path / "figma/web-app-abc123/pages/legacy-100-1.md"
     page_md.parent.mkdir(parents=True, exist_ok=True)
     page_md.write_text("legacy")
     page_sidecar = page_md.with_suffix(".tokens.json")
     page_sidecar.write_text("{}")
-    comp_md = tmp_path / "figma/web-app/components/legacy-components-100-2.md"
+    comp_md = tmp_path / "figma/web-app-abc123/components/legacy-components-100-2.md"
     comp_md.parent.mkdir(parents=True, exist_ok=True)
     comp_md.write_text("legacy-comp")
 


### PR DESCRIPTION
## What this fixes

This patch addresses three production issues observed in `gigaverse-app/linear-git`:

1. File slug collisions when multiple tracked files share the same name (e.g. `Web App`).
2. Per-file orphan pruning deleting artifacts that belong to other tracked files.
3. Missing `*.tokens.json` sidecars not being backfilled for unchanged pages.

## Changes

- Add collision-safe file slug resolver (`file_slug_for_key`) that appends `-{file_key[:8]}` only when base slugs collide.
- Use collision-safe slug resolution throughout `pull_file`.
- Add file-level reconcile guard so unchanged-file fast skip is bypassed when:
  - expected md path needs reconcile,
  - md file is missing,
  - token sidecar is missing,
  - component path prefix no longer matches resolved file slug.
- Make orphan pruning cross-file safe by using global expected generated paths from the manifest, preventing deletion of another file's artifacts.
- Backfill token sidecars on unchanged pages when sidecar is missing.
- Update format docs with collision-safe file-slug behavior.

## Tests

Added/updated regression coverage:

- `tests/test_figma_paths_and_state.py`
  - `test_file_slug_for_key_uses_plain_slug_when_unique`
  - `test_file_slug_for_key_adds_key_suffix_when_slug_collides`
- `tests/test_pull_logic.py`
  - `test_pull_file_backfills_missing_sidecar_on_unchanged_page`
  - `test_pull_file_unchanged_skip_does_not_prune_other_file_paths_in_candidate_dir`
  - updated unchanged-skip orphan prune test to include current sidecar (new invariant)

Validated with:

```bash
uv run python -m pytest -q tests/test_figma_paths_and_state.py tests/test_pull_logic.py
```

(101 passed)

## Related incident

- linear-git issue: https://github.com/gigaverse-app/linear-git/issues/20
