### PR TITLE
Fix legacy token sidecars: migrate unchanged pages to schema v2

### DIFF
--- a/figmaclaw/pull_logic.py
+++ b/figmaclaw/pull_logic.py
@@ -37,6 +37,7 @@ from __future__ import annotations
 
 import asyncio
 import datetime
+import json
 import logging
 from collections.abc import Callable
 from pathlib import Path
@@ -67,6 +68,7 @@ from figmaclaw.token_catalog import load_catalog, merge_bindings, save_catalog
 from figmaclaw.token_scan import PageTokenScan, scan_page
 
 log = logging.getLogger(__name__)
+TOKEN_SIDECAR_SCHEMA_VERSION = 2
 
 
 def _all_manifest_generated_paths(state: FigmaSyncState) -> set[str]:
@@ -279,7 +281,7 @@ def _write_token_sidecar(
         }
 
     sidecar = {
-        "schema_version": 2,
+        "schema_version": TOKEN_SIDECAR_SCHEMA_VERSION,
         "file_key": file_key,
         "page_node_id": page_node_id,
         "generated_at": now,
@@ -292,6 +294,28 @@ def _write_token_sidecar(
     }
 
     write_json_if_changed(sidecar_path, sidecar, ignore_keys=frozenset({"generated_at"}))
+
+
+def _sidecar_needs_backfill(sidecar_path: Path) -> bool:
+    """Return True when a sidecar is missing or uses a legacy schema."""
+    if not sidecar_path.exists():
+        return True
+    try:
+        payload = json.loads(sidecar_path.read_text())
+    except Exception:
+        # Corrupt sidecars should be repaired by the next pull.
+        return True
+    schema_version = payload.get("schema_version")
+    if not isinstance(schema_version, int):
+        return True
+    return schema_version < TOKEN_SIDECAR_SCHEMA_VERSION
+
+
+def _screen_artifacts_need_reconcile(md_abs: Path) -> bool:
+    """Return True when screen markdown/sidecar artifacts are missing or stale."""
+    if not md_abs.exists():
+        return True
+    return _sidecar_needs_backfill(md_abs.with_suffix(".tokens.json"))
 
 
 def _node_suffix_from_relpath(rel_path: str) -> str | None:
@@ -538,7 +562,7 @@ async def pull_file(
                     local_reconcile_needed = True
                     break
                 md_abs = repo_root / page.md_path
-                if not md_abs.exists() or not md_abs.with_suffix(".tokens.json").exists():
+                if _screen_artifacts_need_reconcile(md_abs):
                     local_reconcile_needed = True
                     break
             for comp_rel in page.component_md_paths:
@@ -737,9 +761,7 @@ async def pull_file(
         needs_sidecar_backfill = False
         if content_unchanged and previous_entry and previous_entry.md_path:
             md_abs = repo_root / previous_entry.md_path
-            needs_sidecar_backfill = (
-                md_abs.exists() and not md_abs.with_suffix(".tokens.json").exists()
-            )
+            needs_sidecar_backfill = _screen_artifacts_need_reconcile(md_abs)
 
         if (
             content_unchanged

--- a/tests/smoke/test_figma_api_smoke.py
+++ b/tests/smoke/test_figma_api_smoke.py
@@ -8,6 +8,7 @@ These tests are skipped by default in CI.
 
 from __future__ import annotations
 
+import json
 import os
 import re
 from pathlib import Path
@@ -321,6 +322,54 @@ async def test_pull_backfills_missing_sidecar_on_unchanged_page_real_api(
 
     assert backfill.skipped_file is False
     assert target_sidecar.exists()
+
+
+@pytest.mark.smoke
+@pytest.mark.asyncio
+async def test_pull_migrates_legacy_sidecar_schema_on_unchanged_page_real_api(
+    tmp_path,
+    api_key: str,  # type: ignore[no-untyped-def]
+) -> None:
+    """Smoke: unchanged pages with legacy sidecar schema are rewritten to schema v2."""
+    state = FigmaSyncState(tmp_path)
+    state.load()
+    state.add_tracked_file(TEST_FILE_KEY_LSN_BRANDING, "LSN Branding")
+    state.manifest.files[TEST_FILE_KEY_LSN_BRANDING].version = "v0"
+
+    async with FigmaClient(api_key=api_key) as client:
+        first = await pull_file(
+            client, TEST_FILE_KEY_LSN_BRANDING, state, tmp_path, force=False, max_pages=2
+        )
+        assert first.pages_written + first.pages_schema_upgraded > 0
+
+        pages = state.manifest.files[TEST_FILE_KEY_LSN_BRANDING].pages
+        assert pages
+        target_sidecar: Path | None = None
+        for entry in pages.values():
+            if not entry.md_path:
+                continue
+            sidecar = (tmp_path / entry.md_path).with_suffix(".tokens.json")
+            if "cover-0-1.tokens.json" in str(sidecar):
+                continue
+            if sidecar.exists():
+                target_sidecar = sidecar
+                break
+
+        assert target_sidecar is not None, (
+            "expected a non-cover sidecar to exist after initial pull"
+        )
+
+        payload = json.loads(target_sidecar.read_text())
+        payload.pop("schema_version", None)
+        target_sidecar.write_text(json.dumps(payload, separators=(",", ":"), sort_keys=True))
+        mutated = json.loads(target_sidecar.read_text())
+        assert "schema_version" not in mutated
+
+        migrated = await pull_file(client, TEST_FILE_KEY_LSN_BRANDING, state, tmp_path, force=False)
+
+    assert migrated.skipped_file is False
+    rewritten = json.loads(target_sidecar.read_text())
+    assert rewritten.get("schema_version") == 2
 
 
 @pytest.mark.smoke

--- a/tests/test_pull_logic.py
+++ b/tests/test_pull_logic.py
@@ -22,6 +22,7 @@ Current: see test_schema_upgrade_does_not_cause_infinite_loop_with_max_pages (v2
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -195,7 +196,7 @@ async def test_pull_file_skips_page_when_hash_unchanged(tmp_path: Path):
     existing_md = tmp_path / "figma/web-app-abc123/pages/onboarding-7741-45837.md"
     existing_md.parent.mkdir(parents=True, exist_ok=True)
     existing_md.write_text("---\n---\n")
-    existing_md.with_suffix(".tokens.json").write_text("{}")
+    existing_md.with_suffix(".tokens.json").write_text('{"schema_version":2}')
 
     mock_client = MagicMock(spec=FigmaClient)
     mock_client.get_file_meta = AsyncMock(return_value=fake_file_meta("v2"))
@@ -641,7 +642,7 @@ async def test_pull_file_skipped_pages_do_not_trigger_on_page_written(tmp_path: 
     existing_md = tmp_path / "figma/web-app-abc123/pages/onboarding-7741-45837.md"
     existing_md.parent.mkdir(parents=True, exist_ok=True)
     existing_md.write_text("---\n---\n")
-    existing_md.with_suffix(".tokens.json").write_text("{}")
+    existing_md.with_suffix(".tokens.json").write_text('{"schema_version":2}')
 
     mock_client = MagicMock(spec=FigmaClient)
     mock_client.get_file_meta = AsyncMock(return_value=fake_file_meta("v2"))
@@ -1710,6 +1711,56 @@ async def test_pull_file_backfills_missing_sidecar_on_unchanged_page(tmp_path: P
 
 
 @pytest.mark.asyncio
+async def test_pull_file_migrates_legacy_sidecar_on_unchanged_page(tmp_path: Path):
+    """INVARIANT: unchanged pages with legacy sidecar schema are re-processed to v2."""
+    from figmaclaw.figma_hash import compute_page_hash
+
+    page_id = "7741:45837"
+    file_key = "abc123"
+    page_node = fake_page_node_with_children()
+    page_hash = compute_page_hash(page_node)
+
+    state = FigmaSyncState(tmp_path)
+    state.load()
+    state.add_tracked_file(file_key, "Web App")
+    state.manifest.files[file_key].version = "v2"
+    state.manifest.files[file_key].last_modified = "2026-03-31T12:00:00Z"
+    state.manifest.files[file_key].pull_schema_version = CURRENT_PULL_SCHEMA_VERSION
+    md_rel = "figma/web-app-abc123/pages/onboarding-7741-45837.md"
+    state.manifest.files[file_key].pages[page_id] = PageEntry(
+        page_name="Onboarding",
+        page_slug="onboarding-7741-45837",
+        md_path=md_rel,
+        page_hash=page_hash,
+        last_refreshed_at="2026-03-31T12:00:00Z",
+    )
+    state.save()
+
+    md_abs = tmp_path / md_rel
+    md_abs.parent.mkdir(parents=True, exist_ok=True)
+    md_abs.write_text(
+        "---\nfile_key: abc123\npage_node_id: '7741:45837'\nframes: ['11:1']\n---\n\n# body\n"
+    )
+    sidecar = md_abs.with_suffix(".tokens.json")
+    sidecar.write_text(
+        '{"file_key":"abc123","page_node_id":"7741:45837","summary":{"raw":1,"stale":0,"valid":0},"frames":{}}'
+    )
+
+    mock_client = MagicMock(spec=FigmaClient)
+    mock_client.get_file_meta = AsyncMock(return_value=fake_file_meta("v2", "2026-03-31T12:00:00Z"))
+    mock_client.get_page = AsyncMock(return_value=page_node)
+    mock_client.get_component_sets = AsyncMock(return_value=[])
+    mock_client.get_nodes = AsyncMock(return_value=fake_get_nodes_response())
+
+    result = await pull_file(mock_client, file_key, state, tmp_path, force=False)
+
+    assert result.skipped_file is False
+    assert sidecar.exists()
+    payload = json.loads(sidecar.read_text())
+    assert payload["schema_version"] == 2
+
+
+@pytest.mark.asyncio
 async def test_pull_file_page_rename_moves_path_and_prunes_old(tmp_path: Path):
     """INVARIANT: renaming a page keeps exactly one page file path (old path is pruned)."""
     page_id = "100:1"
@@ -1881,7 +1932,7 @@ async def test_pull_file_unchanged_run_prunes_existing_generated_orphans(tmp_pat
     current_md = tmp_path / "figma/web-app-abc123/pages/current-100-1.md"
     current_md.parent.mkdir(parents=True, exist_ok=True)
     current_md.write_text("current")
-    current_md.with_suffix(".tokens.json").write_text("{}")
+    current_md.with_suffix(".tokens.json").write_text('{"schema_version":2}')
 
     orphan_md = tmp_path / "figma/web-app-abc123/pages/legacy-100-99.md"
     orphan_md.write_text("orphan")
@@ -1939,8 +1990,8 @@ async def test_pull_file_unchanged_skip_does_not_prune_other_file_paths_in_candi
     beta.parent.mkdir(parents=True, exist_ok=True)
     alpha.write_text("alpha")
     beta.write_text("beta")
-    alpha.with_suffix(".tokens.json").write_text("{}")
-    beta.with_suffix(".tokens.json").write_text("{}")
+    alpha.with_suffix(".tokens.json").write_text('{"schema_version":2}')
+    beta.with_suffix(".tokens.json").write_text('{"schema_version":2}')
 
     mock_client = MagicMock(spec=FigmaClient)
     mock_client.get_file_meta = AsyncMock(return_value=fake_file_meta("v2", "2026-03-31T12:00:00Z"))


### PR DESCRIPTION
## Summary
This fixes why legacy `.tokens.json` sidecars can persist forever even after the compact sidecar rollout.

## Root Cause
`pull_file()` only treated sidecars as unhealthy when they were **missing**.
For unchanged pages:
- file-level skip considered `*.tokens.json` existence only
- page-level skip considered `*.tokens.json` existence only

So sidecars with legacy payloads (missing/old `schema_version`) were treated as valid and never rewritten.

## Fix
- Add sidecar health checks in `pull_logic`:
  - `_sidecar_needs_backfill(sidecar_path)`
  - `_screen_artifacts_need_reconcile(md_abs)`
- Treat these cases as reconcile/backfill required:
  - sidecar missing
  - sidecar unreadable/corrupt JSON
  - missing `schema_version`
  - `schema_version < 2`
- Reuse this logic in both:
  - file-level unchanged fast-skip guard
  - page-level unchanged skip guard
- Keep sidecar writer schema explicit via `TOKEN_SIDECAR_SCHEMA_VERSION` constant.

## TDD
### New failing test (added first)
- `tests/test_pull_logic.py::test_pull_file_migrates_legacy_sidecar_on_unchanged_page`

This failed before the fix with `result.skipped_file is True`.

### Smoke proof
- `tests/smoke/test_figma_api_smoke.py::test_pull_migrates_legacy_sidecar_schema_on_unchanged_page_real_api`

Real-API flow:
1. Pull page and produce sidecar.
2. Remove `schema_version` to simulate legacy sidecar.
3. Pull again unchanged.
4. Assert sidecar rewritten with `schema_version == 2`.

## Verification
- Full CI-equivalent suite:
  - `uv run python -m pytest -q --junitxml=test-results/pytest-junit.xml --cov=figmaclaw --cov-report=term-missing --cov-report=xml:test-results/coverage.xml --cov-fail-under=70`
  - Result: `735 passed, 16 skipped`, coverage `74.81%`
- Sidecar-focused unit suites:
  - `uv run python -m pytest -q tests/test_pull_logic.py tests/test_compact_sidecar.py tests/test_sidecar_idempotency.py`
  - Result: `101 passed`
- Real API smoke subset:
  - `uv run python -m pytest -q tests/smoke/test_figma_api_smoke.py -k "backfills_missing_sidecar_on_unchanged_page_real_api or migrates_legacy_sidecar_schema_on_unchanged_page_real_api or migrates_legacy_unkeyed_paths_to_full_key_slug_real_api or collision_safe_file_dirs_and_sidecar_backfill" -m smoke`
  - Result: `4 passed`
