### PR TITLE
fix: queue placeholder pages for re-enrichment

### DIFF
--- a/figmaclaw/commands/claude_run.py
+++ b/figmaclaw/commands/claude_run.py
@@ -119,7 +119,8 @@ def enrichment_info(md_path: Path) -> tuple[bool, int]:
 
     Reads the file directly — no subprocess, no Figma API.  Checks:
 
-    * Has ``enriched_hash`` in frontmatter?  → already enriched → skip.
+    * Body still has placeholder rows?       → needs enrichment.
+    * Else has ``enriched_hash`` in fm?      → already enriched → skip.
     * Counts body table rows for a frame-size estimate.
     """
     try:
@@ -131,15 +132,23 @@ def enrichment_info(md_path: Path) -> tuple[bool, int]:
     if "file_key:" not in text:
         return False, 0
 
-    # Fast frontmatter check — enriched files have this field
-    if "enriched_hash:" in (text.split("\n---")[0] if "\n---" in text else ""):
-        return False, 0
-
     # Count frames from body table rows (| name | `node_id` | desc |)
     frame_count = 0
+    has_placeholder = False
     for line in text.splitlines():
         if line.startswith("| ") and "`" in line and "Node ID" not in line and "---" not in line:
             frame_count += 1
+        if is_placeholder_row(line):
+            has_placeholder = True
+
+    # Placeholder rows are a hard signal that this page still needs enrichment,
+    # even if frontmatter was previously marked enriched.
+    if has_placeholder:
+        return True, frame_count
+
+    # Fast frontmatter check — enriched files without placeholders can be skipped.
+    if "enriched_hash:" in (text.split("\n---")[0] if "\n---" in text else ""):
+        return False, 0
 
     return True, frame_count
 

--- a/tests/smoke/test_claude_run_smoke.py
+++ b/tests/smoke/test_claude_run_smoke.py
@@ -1,0 +1,64 @@
+"""Smoke tests for claude-run enrichment selection.
+
+These are local integration smoke tests (no network) that exercise the real
+CLI path used in CI for selecting files to enrich.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from figmaclaw.main import cli
+
+
+def _write_page(path: Path, *, enriched: bool, placeholder: bool) -> None:
+    desc = "(no description yet)" if placeholder else "already described"
+    fm = [
+        "---",
+        "file_key: smoke123",
+        'page_node_id: "0:1"',
+    ]
+    if enriched:
+        fm.append('enriched_hash: "sha256:abc"')
+    fm.extend(
+        [
+            "---",
+            "",
+            "| Screen | Node ID | Description |",
+            "|--------|---------|-------------|",
+            f"| A | `1:1` | {desc} |",
+        ]
+    )
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("\n".join(fm))
+
+
+@pytest.mark.smoke
+def test_claude_run_needs_enrichment_backfills_placeholder_pages(tmp_path: Path) -> None:
+    """Smoke: enriched_hash pages with placeholders are still queued for enrichment."""
+    pages = tmp_path / "figma" / "web-app" / "pages"
+    md_placeholder = pages / "legacy-placeholder.md"
+    md_clean = pages / "already-enriched.md"
+    _write_page(md_placeholder, enriched=True, placeholder=True)
+    _write_page(md_clean, enriched=True, placeholder=False)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        [
+            "--repo-dir",
+            str(tmp_path),
+            "claude-run",
+            str(tmp_path / "figma"),
+            "--needs-enrichment",
+            "--dry-run",
+        ],
+    )
+
+    assert result.exit_code == 0
+    out = result.output
+    assert str(md_placeholder) in out
+    assert str(md_clean) not in out

--- a/tests/test_claude_run.py
+++ b/tests/test_claude_run.py
@@ -105,6 +105,30 @@ class TestEnrichmentInfo:
         assert needs is False
         assert count == 0
 
+    def test_enriched_hash_with_placeholders_still_needs_enrichment(self, tmp_path: Path) -> None:
+        """Placeholder rows must override enriched_hash and force re-enrichment."""
+        md = tmp_path / "page.md"
+        md.write_text(
+            textwrap.dedent("""\
+            ---
+            file_key: abc123
+            page_node_id: "0:1"
+            enriched_hash: "sha256:abcdef1234567890"
+            enriched_at: "2026-04-01T00:00:00Z"
+            ---
+
+            # Page Title
+
+            | Screen | Node ID | Description |
+            |--------|---------|-------------|
+            | Login  | `1:1`   | (no description yet) |
+            | Home   | `1:2`   | (no description yet) |
+        """)
+        )
+        needs, count = enrichment_info(md)
+        assert needs is True
+        assert count == 2
+
     def test_counts_frame_rows_correctly(self, tmp_path: Path) -> None:
         """Frame count = table rows with backtick node IDs, excluding header/separator."""
         md = tmp_path / "page.md"
@@ -237,6 +261,23 @@ class TestCollectFiles:
         )
         assert len(result) == 1
         assert result[0].name == "pending.md"
+
+    def test_needs_enrichment_keeps_enriched_file_when_placeholders_exist(
+        self, tmp_path: Path
+    ) -> None:
+        """Enriched files with placeholders must remain in the enrichment queue."""
+        pages = tmp_path / "figma" / "pages"
+        self._make_page(pages / "enriched.md", enriched=True)
+        self._make_page(pages / "pending.md", enriched=False)
+        text = (pages / "enriched.md").read_text()
+        (pages / "enriched.md").write_text(
+            text.replace("| Screen0 | `1:0` | desc |", "| Screen0 | `1:0` | (no description yet) |")
+        )
+
+        result = collect_files(
+            tmp_path / "figma", "**/*.md", changed_only=False, needs_enrichment=True
+        )
+        assert sorted(p.name for p in result) == ["enriched.md", "pending.md"]
 
     def test_needs_enrichment_skips_files_above_max_frames(self, tmp_path: Path) -> None:
         """Files with more than max_frames are filtered out."""


### PR DESCRIPTION
## Summary
- treat `(no description yet)` rows as a hard needs-enrichment signal in `claude-run`
- keep enriched-hash pages in queue when placeholders remain
- add unit tests and a smoke CLI test covering the regression

## Root cause
`claude-run --needs-enrichment` only checked for `enriched_hash` in frontmatter.
Legacy pages could be marked enriched while still containing placeholder rows,
so enrichment jobs skipped them forever.

## Verification
- `uv run pytest tests/test_claude_run.py tests/smoke/test_claude_run_smoke.py -q`
- `uv run pytest -m smoke tests/smoke/test_claude_run_smoke.py -q`
- `uv run ruff check figmaclaw/commands/claude_run.py tests/test_claude_run.py tests/smoke/test_claude_run_smoke.py`
