### PR TITLE
ci: guard sync pull loop with per-batch timeout

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -85,6 +85,7 @@ jobs:
           # starving downstream enrich jobs indefinitely.
           MAX_BATCHES=180
           MAX_IDLE_HAS_MORE_BATCHES=3
+          BATCH_TIMEOUT_SECONDS=900
           idle_has_more=0
 
           BATCH=0
@@ -97,10 +98,19 @@ jobs:
 
             echo "--- batch $BATCH ---"
 
+            set +e
             if [ -n "$FORCE_FLAG" ]; then
-              figmaclaw pull $FORCE_FLAG | tee /tmp/figmaclaw-out.txt || true
+              timeout "$BATCH_TIMEOUT_SECONDS" figmaclaw pull $FORCE_FLAG | tee /tmp/figmaclaw-out.txt
+              pull_status=${PIPESTATUS[0]}
             else
-              figmaclaw pull --max-pages 5 | tee /tmp/figmaclaw-out.txt || true
+              timeout "$BATCH_TIMEOUT_SECONDS" figmaclaw pull --max-pages 5 | tee /tmp/figmaclaw-out.txt
+              pull_status=${PIPESTATUS[0]}
+            fi
+            set -e
+
+            if [ "$pull_status" -eq 124 ]; then
+              echo "figmaclaw pull timed out after ${BATCH_TIMEOUT_SECONDS}s; stopping checkpoint loop early."
+              break
             fi
 
             git pull --no-rebase --ff-only origin main


### PR DESCRIPTION
## Summary
- wrap each `figmaclaw pull` batch in `timeout 900s`
- if a batch times out, stop the checkpoint loop early

## Why
In `linear-git`, sync runs can sit in a single pull batch with no progress for a long time.
Existing `HAS_MORE`/idle guards only trigger after a batch returns. This change
ensures a stuck batch cannot monopolize the run indefinitely.

## Validation
- pre-commit checks passed locally (yaml + hooks)
- workflow-only change; no Python runtime behavior changed
