### PR TITLE
refactor: DRY sync checkpoint loop

### DIFF
--- a/scripts/checkpoint_pull_loop.sh
+++ b/scripts/checkpoint_pull_loop.sh
@@ -21,9 +21,8 @@ fi
 run_pull_batch() {
   set +e
   timeout "$BATCH_TIMEOUT_SECONDS" figmaclaw pull "${PULL_ARGS[@]}" | tee "$FIGMACLAW_OUT_PATH"
-  local status=${PIPESTATUS[0]}
+  PULL_STATUS=${PIPESTATUS[0]}
   set -e
-  echo "$status"
 }
 
 commit_if_changed() {
@@ -42,6 +41,7 @@ commit_if_changed() {
 }
 
 idle_has_more=0
+PULL_STATUS=0
 BATCH=0
 while true; do
   BATCH=$((BATCH + 1))
@@ -52,7 +52,8 @@ while true; do
 
   echo "--- batch $BATCH ---"
 
-  pull_status="$(run_pull_batch)"
+  run_pull_batch
+  pull_status="$PULL_STATUS"
 
   if [ "$pull_status" -eq 124 ]; then
     echo "figmaclaw pull timed out after ${BATCH_TIMEOUT_SECONDS}s; stopping checkpoint loop early."

--- a/scripts/checkpoint_pull_loop.sh
+++ b/scripts/checkpoint_pull_loop.sh
@@ -8,12 +8,38 @@ INPUT_FORCE="${INPUT_FORCE:-false}"
 MAX_BATCHES="${MAX_BATCHES:-180}"
 MAX_IDLE_HAS_MORE_BATCHES="${MAX_IDLE_HAS_MORE_BATCHES:-3}"
 BATCH_TIMEOUT_SECONDS="${BATCH_TIMEOUT_SECONDS:-900}"
+MAX_PAGES_PER_BATCH="${MAX_PAGES_PER_BATCH:-5}"
 FIGMACLAW_OUT_PATH="${FIGMACLAW_OUT_PATH:-/tmp/figmaclaw-out.txt}"
 
-FORCE_FLAG=""
+declare -a PULL_ARGS
 if [ "$INPUT_FORCE" = "true" ]; then
-  FORCE_FLAG="--force"
+  PULL_ARGS=(--force)
+else
+  PULL_ARGS=(--max-pages "$MAX_PAGES_PER_BATCH")
 fi
+
+run_pull_batch() {
+  set +e
+  timeout "$BATCH_TIMEOUT_SECONDS" figmaclaw pull "${PULL_ARGS[@]}" | tee "$FIGMACLAW_OUT_PATH"
+  local status=${PIPESTATUS[0]}
+  set -e
+  echo "$status"
+}
+
+commit_if_changed() {
+  git pull --no-rebase --ff-only origin main
+  git add figma/ .figma-sync/
+  if git diff --cached --quiet; then
+    echo "false"
+    return
+  fi
+
+  COMMIT_MSG="$(grep '^COMMIT_MSG:' "$FIGMACLAW_OUT_PATH" | head -1 | sed 's/^COMMIT_MSG://' | tr -d '\n\r')"
+  COMMIT_MSG="${COMMIT_MSG:-sync: figmaclaw — checkpoint batch $BATCH}"
+  git commit -m "${COMMIT_MSG}"
+  git push
+  echo "true"
+}
 
 idle_has_more=0
 BATCH=0
@@ -26,31 +52,14 @@ while true; do
 
   echo "--- batch $BATCH ---"
 
-  set +e
-  if [ -n "$FORCE_FLAG" ]; then
-    timeout "$BATCH_TIMEOUT_SECONDS" figmaclaw pull $FORCE_FLAG | tee "$FIGMACLAW_OUT_PATH"
-    pull_status=${PIPESTATUS[0]}
-  else
-    timeout "$BATCH_TIMEOUT_SECONDS" figmaclaw pull --max-pages 5 | tee "$FIGMACLAW_OUT_PATH"
-    pull_status=${PIPESTATUS[0]}
-  fi
-  set -e
+  pull_status="$(run_pull_batch)"
 
   if [ "$pull_status" -eq 124 ]; then
     echo "figmaclaw pull timed out after ${BATCH_TIMEOUT_SECONDS}s; stopping checkpoint loop early."
     break
   fi
 
-  git pull --no-rebase --ff-only origin main
-  git add figma/ .figma-sync/
-  committed=false
-  if ! git diff --cached --quiet; then
-    COMMIT_MSG="$(grep '^COMMIT_MSG:' "$FIGMACLAW_OUT_PATH" | head -1 | sed 's/^COMMIT_MSG://' | tr -d '\n\r')"
-    COMMIT_MSG="${COMMIT_MSG:-sync: figmaclaw — checkpoint batch $BATCH}"
-    git commit -m "${COMMIT_MSG}"
-    git push
-    committed=true
-  fi
+  committed="$(commit_if_changed)"
 
   if grep -q '^HAS_MORE:true' "$FIGMACLAW_OUT_PATH"; then
     if [ "$committed" = false ]; then
@@ -67,5 +76,5 @@ while true; do
     break
   fi
 
-  [ -n "$FORCE_FLAG" ] && break
+  [ "$INPUT_FORCE" = "true" ] && break
 done

--- a/tests/test_checkpoint_pull_loop.py
+++ b/tests/test_checkpoint_pull_loop.py
@@ -25,10 +25,12 @@ def _setup_fake_bin(tmp_path: Path, *, scenario: str, git_dirty: str, timeout_mo
         """#!/usr/bin/env bash
 set -euo pipefail
 COUNT_FILE="${COUNT_FILE:?}"
+ARGS_FILE="${ARGS_FILE:?}"
 count=0
 if [ -f "$COUNT_FILE" ]; then count="$(cat "$COUNT_FILE")"; fi
 count=$((count+1))
 echo "$count" > "$COUNT_FILE"
+printf '%s\n' "$*" >> "$ARGS_FILE"
 echo "COMMIT_MSG:sync: figmaclaw — checkpoint batch $count"
 case "${SCENARIO:?}" in
   has_more_forever) echo "HAS_MORE:true" ;;
@@ -78,6 +80,7 @@ def _run_loop(
     out_path = tmp_path / "figmaclaw-out.txt"
     trace = tmp_path / "git-trace.txt"
     count = tmp_path / "count.txt"
+    args = tmp_path / "pull-args.txt"
 
     bin_dir = _setup_fake_bin(
         tmp_path, scenario=scenario, git_dirty=git_dirty, timeout_mode=timeout_mode
@@ -90,12 +93,14 @@ def _run_loop(
             "COUNT_FILE": str(count),
             "TRACE_FILE": str(trace),
             "FIGMACLAW_OUT_PATH": str(out_path),
+            "ARGS_FILE": str(args),
             "SCENARIO": scenario,
             "GIT_DIRTY": git_dirty,
             "TIMEOUT_MODE": timeout_mode,
             "MAX_BATCHES": "10",
             "MAX_IDLE_HAS_MORE_BATCHES": "3",
             "BATCH_TIMEOUT_SECONDS": "1",
+            "MAX_PAGES_PER_BATCH": "5",
             "INPUT_FORCE": "false",
         }
     )
@@ -160,3 +165,27 @@ def test_continues_when_has_more_and_commits_then_stops_on_false(tmp_path: Path)
     )
     count = int((tmp_path / "count.txt").read_text())
     assert count == 2
+
+
+def test_non_force_uses_max_pages_limit(tmp_path: Path) -> None:
+    _run_loop(
+        tmp_path,
+        scenario="single_done",
+        git_dirty="1",
+        timeout_mode="pass",
+        MAX_PAGES_PER_BATCH="7",
+    )
+    args = (tmp_path / "pull-args.txt").read_text().strip()
+    assert args == "pull --max-pages 7"
+
+
+def test_force_uses_force_flag_only(tmp_path: Path) -> None:
+    _run_loop(
+        tmp_path,
+        scenario="single_done",
+        git_dirty="1",
+        timeout_mode="pass",
+        INPUT_FORCE="true",
+    )
+    args = (tmp_path / "pull-args.txt").read_text().strip()
+    assert args == "pull --force"


### PR DESCRIPTION
## Summary
- DRY refactor of `scripts/checkpoint_pull_loop.sh`
  - single pull invocation path via `PULL_ARGS`
  - extracted `run_pull_batch` and `commit_if_changed`
  - configurable `MAX_PAGES_PER_BATCH` (default 5)
- Added tests for CLI arg behavior:
  - non-force mode uses `--max-pages N`
  - force mode uses `--force` only
- Follow-up fix:
  - preserve pull exit status in `PULL_STATUS` variable (avoid command-substitution mixing with stdout)

## Why
This reduces duplication in the sync loop and makes force/non-force semantics explicit and test-covered.

## Verification
- `bash -n scripts/checkpoint_pull_loop.sh`
- `uv run pytest tests/test_checkpoint_pull_loop.py -q`
- `uv run pytest tests/test_pull_logic.py tests/test_claude_run.py -q`
