### PR TITLE
fix: preserve component descriptions during pull and legacy-path migration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -204,7 +204,6 @@ jobs:
         env:
           FIGMACLAW_REQUIRE_LIVE_SMOKE: "1"
           FIGMA_API_KEY: ${{ secrets.FIGMA_API_KEY }}
-          FIGMA_WEBHOOK_TEAM_ID: ${{ secrets.FIGMA_WEBHOOK_TEAM_ID }}
         run: >
           uv run python -m pytest -q
           -m smoke_api
@@ -237,6 +236,15 @@ jobs:
         run: |
           if [ -z "${FIGMA_API_KEY}" ]; then
             echo "::error::Missing required secret FIGMA_API_KEY for smoke-webhook job."
+            exit 1
+          fi
+
+      - name: Validate FIGMA_WEBHOOK_TEAM_ID secret is configured
+        env:
+          FIGMA_WEBHOOK_TEAM_ID: ${{ secrets.FIGMA_WEBHOOK_TEAM_ID }}
+        run: |
+          if [ -z "${FIGMA_WEBHOOK_TEAM_ID}" ]; then
+            echo "::error::Missing required secret FIGMA_WEBHOOK_TEAM_ID for smoke-webhook job."
             exit 1
           fi
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -189,6 +189,7 @@ jobs:
   smoke-api:
     name: smoke-api-ci
     runs-on: ubuntu-latest
+    timeout-minutes: 20
 
     steps:
       - name: Checkout
@@ -234,6 +235,7 @@ jobs:
         run: >
           uv run python -m pytest -q
           -m smoke_api
+          -n 0
           -rs
 
       - name: No Python-impacting changes

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -239,20 +239,10 @@ jobs:
             exit 1
           fi
 
-      - name: Validate FIGMA_WEBHOOK_TEAM_ID secret is configured
-        env:
-          FIGMA_WEBHOOK_TEAM_ID: ${{ secrets.FIGMA_WEBHOOK_TEAM_ID }}
-        run: |
-          if [ -z "${FIGMA_WEBHOOK_TEAM_ID}" ]; then
-            echo "::error::Missing required secret FIGMA_WEBHOOK_TEAM_ID for smoke-webhook job."
-            exit 1
-          fi
-
       - name: Run enforced live webhook smoke
         env:
           FIGMACLAW_REQUIRE_LIVE_SMOKE: "1"
           FIGMA_API_KEY: ${{ secrets.FIGMA_API_KEY }}
-          FIGMA_WEBHOOK_TEAM_ID: ${{ secrets.FIGMA_WEBHOOK_TEAM_ID }}
         run: >
           uv run python -m pytest -q
           -m smoke_webhook

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -187,6 +187,7 @@ jobs:
         run: echo "No Python or dependency changes; skipping tests."
 
   smoke-api:
+    name: smoke-api-ci
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,7 +152,7 @@ jobs:
         if: steps.changed.outputs.any_changed == 'true'
         run: >
           uv run python -m pytest -q
-          -m "not smoke"
+          -m "not smoke_api and not smoke_webhook and not smoke_mcp"
           --junitxml=test-results/pytest-junit.xml
           --cov=figmaclaw
           --cov-report=term-missing
@@ -185,3 +185,46 @@ jobs:
       - name: No Python-impacting changes
         if: steps.changed.outputs.any_changed != 'true'
         run: echo "No Python or dependency changes; skipping tests."
+
+  smoke-api:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Detect changed Python files
+        id: changed
+        uses: tj-actions/changed-files@22103cc46bda19c2b464ffe86db46df6922fd323 # v47.0.5
+        with:
+          files: |
+            **/*.py
+
+      - name: Set up Python
+        if: steps.changed.outputs.any_changed == 'true'
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.12"
+
+      - name: Install uv
+        if: steps.changed.outputs.any_changed == 'true'
+        run: python -m pip install --upgrade uv
+
+      - name: Sync dependencies
+        if: steps.changed.outputs.any_changed == 'true'
+        run: uv sync --dev
+
+      - name: Run enforced live API smoke
+        if: steps.changed.outputs.any_changed == 'true'
+        env:
+          FIGMACLAW_REQUIRE_LIVE_SMOKE: "1"
+          FIGMA_API_KEY: ${{ secrets.FIGMA_API_KEY }}
+          FIGMA_WEBHOOK_TEAM_ID: ${{ secrets.FIGMA_WEBHOOK_TEAM_ID }}
+        run: >
+          uv run python -m pytest -q
+          -m smoke_api
+          -rs
+
+      - name: No Python-impacting changes
+        if: steps.changed.outputs.any_changed != 'true'
+        run: echo "No Python or dependency changes; skipping smoke-api."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -214,6 +214,16 @@ jobs:
         if: steps.changed.outputs.any_changed == 'true'
         run: uv sync --dev
 
+      - name: Validate FIGMA_API_KEY secret is configured
+        if: steps.changed.outputs.any_changed == 'true'
+        env:
+          FIGMA_API_KEY: ${{ secrets.FIGMA_API_KEY }}
+        run: |
+          if [ -z "${FIGMA_API_KEY}" ]; then
+            echo "::error::Missing required secret FIGMA_API_KEY for smoke-api job."
+            exit 1
+          fi
+
       - name: Run enforced live API smoke
         if: steps.changed.outputs.any_changed == 'true'
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,29 +127,18 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: Detect changed Python files
-        id: changed
-        uses: tj-actions/changed-files@22103cc46bda19c2b464ffe86db46df6922fd323 # v47.0.5
-        with:
-          files: |
-            **/*.py
-
       - name: Set up Python
-        if: steps.changed.outputs.any_changed == 'true'
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.12"
 
       - name: Install uv
-        if: steps.changed.outputs.any_changed == 'true'
         run: python -m pip install --upgrade uv
 
       - name: Sync dependencies
-        if: steps.changed.outputs.any_changed == 'true'
         run: uv sync --dev
 
       - name: Run tests with coverage gate
-        if: steps.changed.outputs.any_changed == 'true'
         run: >
           uv run python -m pytest -q
           -m "not smoke_api and not smoke_webhook and not smoke_mcp"
@@ -160,7 +149,7 @@ jobs:
           --cov-fail-under=70
 
       - name: Upload test artifacts
-        if: always() && steps.changed.outputs.any_changed == 'true'
+        if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: test-results
@@ -182,10 +171,6 @@ jobs:
           flags: unittests
           fail_ci_if_error: false
 
-      - name: No Python-impacting changes
-        if: steps.changed.outputs.any_changed != 'true'
-        run: echo "No Python or dependency changes; skipping tests."
-
   smoke-api:
     name: smoke-api-ci
     runs-on: ubuntu-latest
@@ -195,29 +180,18 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: Detect changed Python files
-        id: changed
-        uses: tj-actions/changed-files@22103cc46bda19c2b464ffe86db46df6922fd323 # v47.0.5
-        with:
-          files: |
-            **/*.py
-
       - name: Set up Python
-        if: steps.changed.outputs.any_changed == 'true'
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.12"
 
       - name: Install uv
-        if: steps.changed.outputs.any_changed == 'true'
         run: python -m pip install --upgrade uv
 
       - name: Sync dependencies
-        if: steps.changed.outputs.any_changed == 'true'
         run: uv sync --dev
 
       - name: Validate FIGMA_API_KEY secret is configured
-        if: steps.changed.outputs.any_changed == 'true'
         env:
           FIGMA_API_KEY: ${{ secrets.FIGMA_API_KEY }}
         run: |
@@ -227,7 +201,6 @@ jobs:
           fi
 
       - name: Run enforced live API smoke
-        if: steps.changed.outputs.any_changed == 'true'
         env:
           FIGMACLAW_REQUIRE_LIVE_SMOKE: "1"
           FIGMA_API_KEY: ${{ secrets.FIGMA_API_KEY }}
@@ -238,6 +211,81 @@ jobs:
           -n 0
           -rs
 
-      - name: No Python-impacting changes
-        if: steps.changed.outputs.any_changed != 'true'
-        run: echo "No Python or dependency changes; skipping smoke-api."
+  smoke-webhook:
+    name: smoke-webhook-ci
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.12"
+
+      - name: Install uv
+        run: python -m pip install --upgrade uv
+
+      - name: Sync dependencies
+        run: uv sync --dev
+
+      - name: Validate FIGMA_API_KEY secret is configured
+        env:
+          FIGMA_API_KEY: ${{ secrets.FIGMA_API_KEY }}
+        run: |
+          if [ -z "${FIGMA_API_KEY}" ]; then
+            echo "::error::Missing required secret FIGMA_API_KEY for smoke-webhook job."
+            exit 1
+          fi
+
+      - name: Run enforced live webhook smoke
+        env:
+          FIGMACLAW_REQUIRE_LIVE_SMOKE: "1"
+          FIGMA_API_KEY: ${{ secrets.FIGMA_API_KEY }}
+          FIGMA_WEBHOOK_TEAM_ID: ${{ secrets.FIGMA_WEBHOOK_TEAM_ID }}
+        run: >
+          uv run python -m pytest -q
+          -m smoke_webhook
+          -n 0
+          -rs
+
+  smoke-mcp:
+    name: smoke-mcp-ci
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.12"
+
+      - name: Install uv
+        run: python -m pip install --upgrade uv
+
+      - name: Sync dependencies
+        run: uv sync --dev
+
+      - name: Validate FIGMA_MCP_TOKEN secret is configured
+        env:
+          FIGMA_MCP_TOKEN: ${{ secrets.FIGMA_MCP_TOKEN }}
+        run: |
+          if [ -z "${FIGMA_MCP_TOKEN}" ]; then
+            echo "::error::Missing required secret FIGMA_MCP_TOKEN for smoke-mcp job."
+            exit 1
+          fi
+
+      - name: Run enforced live MCP smoke
+        env:
+          FIGMACLAW_REQUIRE_LIVE_SMOKE: "1"
+          FIGMA_MCP_TOKEN: ${{ secrets.FIGMA_MCP_TOKEN }}
+        run: >
+          uv run python -m pytest -q
+          -m smoke_mcp
+          -n 0
+          -rs

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -19,6 +19,7 @@ concurrency:
 
 jobs:
   smoke-api:
+    name: smoke-api-dispatch
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -2,13 +2,6 @@ name: Smoke
 
 on:
   workflow_dispatch:
-  pull_request:
-    paths:
-      - "figmaclaw/**/*.py"
-      - "tests/smoke/**/*.py"
-      - ".github/workflows/smoke.yml"
-      - "pyproject.toml"
-      - "uv.lock"
 
 permissions:
   contents: read

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -21,6 +21,7 @@ jobs:
   smoke-api:
     name: smoke-api-dispatch
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -53,4 +54,4 @@ jobs:
           FIGMACLAW_REQUIRE_LIVE_SMOKE: "1"
           FIGMA_API_KEY: ${{ secrets.FIGMA_API_KEY }}
           FIGMA_WEBHOOK_TEAM_ID: ${{ secrets.FIGMA_WEBHOOK_TEAM_ID }}
-        run: uv run pytest -q -m smoke_api -rs
+        run: uv run pytest -q -m smoke_api -n 0 -rs

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -18,7 +18,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  smoke:
+  smoke-api:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -38,8 +38,18 @@ jobs:
       - name: Sync dependencies
         run: uv sync --dev
 
-      - name: Run smoke tests
+      - name: Validate FIGMA_API_KEY secret is configured
         env:
           FIGMA_API_KEY: ${{ secrets.FIGMA_API_KEY }}
+        run: |
+          if [ -z "${FIGMA_API_KEY}" ]; then
+            echo "::error::Missing required secret FIGMA_API_KEY for smoke-api workflow."
+            exit 1
+          fi
+
+      - name: Run enforced live API smoke tests
+        env:
+          FIGMACLAW_REQUIRE_LIVE_SMOKE: "1"
+          FIGMA_API_KEY: ${{ secrets.FIGMA_API_KEY }}
           FIGMA_WEBHOOK_TEAM_ID: ${{ secrets.FIGMA_WEBHOOK_TEAM_ID }}
-        run: uv run pytest -q -m smoke
+        run: uv run pytest -q -m smoke_api -rs

--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ Designer saves in Figma
 ## Documentation
 
 - Installation and CI setup: [docs/INSTALL.md](docs/INSTALL.md)
+- Token auth and rotation: [docs/token-auth-and-rotation.md](docs/token-auth-and-rotation.md)
 - Markdown schema: [docs/figmaclaw-md-format.md](docs/figmaclaw-md-format.md)
 - Body preservation design: [docs/body-preservation-design.md](docs/body-preservation-design.md)
 - Body preservation invariants: [docs/body-preservation-invariants.md](docs/body-preservation-invariants.md)

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -20,11 +20,14 @@ Upgrade: `uv tool install --force git+https://github.com/aviadr1/figmaclaw`
 | Variable | When needed | Description |
 |---|---|---|
 | `FIGMA_API_KEY` | Always | Figma personal access token. Generate at https://www.figma.com/developers/api#access-tokens (format: `figd_...`) |
+| `FIGMA_MCP_TOKEN` | MCP smoke tests | Figma MCP OAuth access token used by `smoke_mcp` and `figmaclaw/figma_mcp.py` |
 | `FIGMA_WEBHOOK_SECRET` | Webhooks | Passcode for validating webhook payloads |
 | `FIGMA_TEAM_ID` | Auto-discovery | Your Figma team ID (for `figmaclaw list`) |
 | `CLAUDE_CODE_OAUTH_TOKEN` | CI enrichment | Claude Code CLI auth for LLM-powered description generation |
 
 Set them in your shell or as GitHub Actions secrets (see CI setup below).
+
+Token creation, lifetime, and rotation details: [docs/token-auth-and-rotation.md](token-auth-and-rotation.md)
 
 ## Quick start — local
 

--- a/docs/token-auth-and-rotation.md
+++ b/docs/token-auth-and-rotation.md
@@ -1,0 +1,132 @@
+# Figma Token Auth and Rotation
+
+This document defines which token is used where in `figmaclaw`, how to create it, how long it lives, and how to rotate it safely in CI.
+
+As of April 15, 2026.
+
+## Token matrix
+
+| Variable | Used for | Token type | Where used in repo |
+|---|---|---|---|
+| `FIGMA_API_KEY` | Figma REST API calls (pull, list, webhooks, REST smoke tests) | Personal Access Token (PAT) or OAuth REST access token | `figmaclaw/figma_client.py`, `smoke-api-ci`, `smoke-webhook-ci` |
+| `FIGMA_MCP_TOKEN` | Figma MCP server (`https://mcp.figma.com/mcp`) | MCP OAuth access token (Bearer) | `figmaclaw/figma_mcp.py`, `smoke-mcp-ci` |
+
+## Can a PAT be used for `FIGMA_MCP_TOKEN`?
+
+No.
+
+- Figma's MCP docs require signing in via the MCP OAuth flow in a supported MCP client.
+- Figma REST docs explicitly separate REST scopes/tokens from MCP and state that MCP handles its own OAuth flow.
+
+Implication: PATs are valid for REST API auth, but are not the supported auth mechanism for the MCP endpoint in this repo.
+
+## How to create `FIGMA_MCP_TOKEN`
+
+### Recommended (Claude Code + remote MCP)
+
+1. Add the MCP server:
+   - `claude mcp add --transport http figma https://mcp.figma.com/mcp`
+2. Start Claude Code and run `/mcp`.
+3. Select `figma` and click `Authenticate`.
+4. Complete browser auth and click `Allow access`.
+5. Confirm Claude shows successful connection.
+
+At this point, Claude stores MCP OAuth credentials in `~/.claude/.credentials.json`.
+
+### Export token into environment for local smoke runs
+
+Use a non-echo extraction to avoid printing secrets in logs:
+
+```bash
+export FIGMA_MCP_TOKEN="$(
+python - <<'PY'
+import json
+from pathlib import Path
+
+p = Path.home() / ".claude" / ".credentials.json"
+d = json.loads(p.read_text())
+m = d.get("mcpOAuth") or {}
+for k, v in m.items():
+    if "figma" in k.lower() and isinstance(v, dict):
+        tok = (v.get("accessToken") or "").strip()
+        if tok:
+            print(tok)
+            raise SystemExit(0)
+raise SystemExit("No Figma MCP token found in ~/.claude/.credentials.json")
+PY
+)"
+```
+
+Then run:
+
+```bash
+uv run pytest -m smoke_mcp tests/smoke/test_figma_mcp_smoke.py -v -n 0
+```
+
+### Set for GitHub Actions
+
+```bash
+gh secret set FIGMA_MCP_TOKEN --repo <owner>/<repo> --body "$FIGMA_MCP_TOKEN"
+```
+
+In this repo, `smoke-mcp-ci` already fails loudly when this secret is missing.
+
+## How to create `FIGMA_API_KEY` (PAT for REST)
+
+1. Open Figma account settings -> Security.
+2. Generate a new personal access token.
+3. Choose required scopes.
+4. Set an expiration and copy the token once.
+5. Store it in:
+   - local `.env` / shell as `FIGMA_API_KEY`
+   - GitHub Actions secret `FIGMA_API_KEY`
+
+## Lifetime and expiry policy
+
+### PAT (`FIGMA_API_KEY`)
+
+- Figma policy (April 28, 2025): PATs now have a maximum expiry of 90 days; non-expiring PATs can no longer be created.
+- Treat PAT rotation as mandatory.
+
+### MCP OAuth token (`FIGMA_MCP_TOKEN`)
+
+- Figma MCP docs do not currently publish a stable, explicit MCP-token TTL in the MCP setup pages.
+- Do not assume non-expiring behavior.
+- Operational policy: treat as expiring credentials and rotate proactively on the same cadence as PATs (90-day max window) or sooner.
+
+## Rotation runbook (CI-safe)
+
+1. Re-authenticate MCP in Claude (`/mcp` -> `figma` -> `Authenticate`) to refresh token source.
+2. Re-export `FIGMA_MCP_TOKEN` from `~/.claude/.credentials.json`.
+3. Update GitHub secret:
+   - `gh secret set FIGMA_MCP_TOKEN --repo <owner>/<repo> --body "$FIGMA_MCP_TOKEN"`
+4. Rotate REST PAT and update `FIGMA_API_KEY` similarly.
+5. Validate immediately:
+   - `smoke-api-ci`
+   - `smoke-webhook-ci`
+   - `smoke-mcp-ci`
+
+## Security requirements
+
+- Never commit tokens to git.
+- Never print token values in CI logs.
+- Keep token scope minimal (for REST PAT).
+- Use repository/org secrets for CI, not plaintext workflow vars.
+- Prefer short-lived credentials plus regular rotation over long-lived static secrets.
+
+## Repo behavior that enforces this
+
+- `tests/smoke/live_gate.py` fails loudly when required smoke credentials are missing.
+- `.github/workflows/ci.yml` validates required secrets before each smoke job and exits non-zero if missing.
+- `figmaclaw/figma_mcp.py` supports:
+  1. `FIGMA_MCP_TOKEN` env var
+  2. fallback to Claude credentials (`~/.claude/.credentials.json`)
+
+## Primary sources
+
+- Figma MCP remote setup: https://developers.figma.com/docs/figma-mcp-server/remote-server-installation/
+- Figma MCP access/limits: https://developers.figma.com/docs/figma-mcp-server/plans-access-and-permissions/
+- REST authentication and token model: https://developers.figma.com/docs/rest-api/authentication/
+- REST scopes page (MCP handles own OAuth flow): https://developers.figma.com/docs/rest-api/scopes/
+- REST changelog (PAT max 90-day expiry): https://developers.figma.com/docs/rest-api/changelog/
+- PAT management help article: https://help.figma.com/hc/en-us/articles/8085703771159-Manage-personal-access-tokens

--- a/figmaclaw/commands/claude_run.py
+++ b/figmaclaw/commands/claude_run.py
@@ -37,6 +37,8 @@ from figmaclaw.budget import BudgetDecision, decide_next_batch, load_per_frame_h
 from figmaclaw.figma_md_parse import section_line_ranges
 from figmaclaw.figma_schema import PLACEHOLDER_DESCRIPTION, is_placeholder_row
 from figmaclaw.verdict import (
+    EXIT_RED,
+    RunVerdict,
     compute_verdict,
     count_commits_since,
     format_step_summary,
@@ -571,6 +573,7 @@ def claude_run_cmd(
     budget_exhausted = False
     budget_stop_reason: str | None = None
     phantom_files: list[str] = []
+    dispatch_crashed = False
 
     # Sha snapshot before any work — used to count commits that actually
     # landed, which is the only honest signal that useful work was done.
@@ -885,6 +888,7 @@ def claude_run_cmd(
             err=True,
         )
         traceback.print_exc(file=sys.stderr)
+        dispatch_crashed = True
         errors += 1
 
     # ---- Compute verdict and exit ----
@@ -897,6 +901,12 @@ def claude_run_cmd(
         budget_exhausted=budget_exhausted,
         skipped_no_work=skipped_no_work,
     )
+    if dispatch_crashed:
+        verdict = RunVerdict(
+            label="RED (dispatch crash)",
+            exit_code=EXIT_RED,
+            row="row 8",
+        )
 
     click.echo(
         f"[claude-run] Done: files_selected={files_selected} "

--- a/figmaclaw/figma_render.py
+++ b/figmaclaw/figma_render.py
@@ -206,6 +206,30 @@ def build_page_frontmatter(
     )
 
 
+def build_component_frontmatter(
+    section: FigmaSection,
+    page: FigmaPage,
+    *,
+    component_set_keys: dict[str, str] | None = None,
+    enriched_hash: str | None = None,
+    enriched_at: str | None = None,
+    enriched_frame_hashes: dict[str, str] | None = None,
+) -> str:
+    """Build YAML frontmatter for a component-library section markdown file."""
+    frame_ids: list[str] = [f.node_id for f in section.frames]
+    return _build_frontmatter(
+        file_key=page.file_key,
+        page_node_id=page.page_node_id,
+        section_node_id=section.node_id,
+        frame_ids=frame_ids,
+        flows=[],
+        component_set_keys=component_set_keys,
+        enriched_hash=enriched_hash,
+        enriched_at=enriched_at,
+        enriched_frame_hashes=enriched_frame_hashes,
+    )
+
+
 def scaffold_page(
     page: FigmaPage,
     entry: PageEntry,
@@ -327,18 +351,7 @@ def render_component_section(
     """
     parts: list[str] = []
 
-    frame_ids: list[str] = [f.node_id for f in section.frames]
-
-    parts.append(
-        _build_frontmatter(
-            file_key=page.file_key,
-            page_node_id=page.page_node_id,
-            section_node_id=section.node_id,
-            frame_ids=frame_ids,
-            flows=[],
-            component_set_keys=component_set_keys,
-        )
-    )
+    parts.append(build_component_frontmatter(section, page, component_set_keys=component_set_keys))
     parts.append("")
 
     # H1: file / page / section — normalized so empty names don't leak

--- a/figmaclaw/pull_logic.py
+++ b/figmaclaw/pull_logic.py
@@ -166,12 +166,7 @@ def update_page_frontmatter(
     out_path = repo_root / entry.md_path
     assert out_path.exists(), f"update_page_frontmatter requires existing file: {out_path}"
 
-    from figmaclaw.figma_parse import split_frontmatter
-
     md_text = out_path.read_text()
-    parts = split_frontmatter(md_text)
-    assert parts is not None, f"Failed to parse frontmatter from {out_path}"
-    _, body = parts
 
     # Preserve enrichment state from existing frontmatter (set by enrich pass, not pull pass)
     existing_fm = parse_frontmatter(md_text)
@@ -188,7 +183,7 @@ def update_page_frontmatter(
         raw_tokens=raw_tokens,
         frame_sections=frame_sections,
     )
-    out_path.write_text(f"{new_fm}\n{body}")
+    _rewrite_frontmatter_preserving_body(out_path, md_text, new_fm)
     return out_path
 
 
@@ -221,12 +216,7 @@ def update_component_frontmatter(
     out_path = repo_root / md_rel_path
     assert out_path.exists(), f"update_component_frontmatter requires existing file: {out_path}"
 
-    from figmaclaw.figma_parse import split_frontmatter
-
     md_text = out_path.read_text()
-    parts = split_frontmatter(md_text)
-    assert parts is not None, f"Failed to parse frontmatter from {out_path}"
-    _, body = parts
 
     # Preserve enrichment state from existing frontmatter (set by enrich pass, not pull pass)
     existing_fm = parse_frontmatter(md_text)
@@ -242,8 +232,18 @@ def update_component_frontmatter(
         enriched_at=enriched_at,
         enriched_frame_hashes=enriched_frame_hashes or None,
     )
-    out_path.write_text(f"{new_fm}\n{body}")
+    _rewrite_frontmatter_preserving_body(out_path, md_text, new_fm)
     return out_path
+
+
+def _rewrite_frontmatter_preserving_body(out_path: Path, md_text: str, new_fm: str) -> None:
+    """Rewrite frontmatter while preserving markdown body byte-for-byte."""
+    from figmaclaw.figma_parse import split_frontmatter
+
+    parts = split_frontmatter(md_text)
+    assert parts is not None, f"Failed to parse frontmatter from {out_path}"
+    _, body = parts
+    out_path.write_text(f"{new_fm}\n{body}")
 
 
 def _aggregate_issues(issues: list) -> list[dict]:
@@ -909,10 +909,8 @@ async def pull_file(
             # Skipped for schema-only upgrades: content is unchanged so token data can't have changed.
             token_scan: PageTokenScan | None = None
             raw_tokens: dict[str, RawTokenCounts] | None = None
-            should_scan_tokens = (
-                screen_frame_ids
-                and not schema_only
-                and (not content_unchanged or needs_sidecar_backfill)
+            should_scan_tokens = screen_frame_ids and (
+                needs_sidecar_backfill or (not schema_only and not content_unchanged)
             )
             if should_scan_tokens:
                 try:

--- a/figmaclaw/pull_logic.py
+++ b/figmaclaw/pull_logic.py
@@ -56,7 +56,12 @@ from figmaclaw.figma_hash import compute_frame_hashes, compute_page_hash
 from figmaclaw.figma_models import FigmaPage, FigmaSection, from_page_node
 from figmaclaw.figma_parse import parse_flows, parse_frontmatter
 from figmaclaw.figma_paths import component_path, page_path, slugify
-from figmaclaw.figma_render import build_page_frontmatter, render_component_section, scaffold_page
+from figmaclaw.figma_render import (
+    build_component_frontmatter,
+    build_page_frontmatter,
+    render_component_section,
+    scaffold_page,
+)
 from figmaclaw.figma_sync_state import FigmaSyncState, PageEntry
 from figmaclaw.figma_utils import write_json_if_changed
 from figmaclaw.prune_utils import (
@@ -201,6 +206,43 @@ def write_component_section(
     out_path.write_text(
         render_component_section(section, page, component_set_keys=component_set_keys)
     )
+    return out_path
+
+
+def update_component_frontmatter(
+    repo_root: Path,
+    section: FigmaSection,
+    page: FigmaPage,
+    md_rel_path: str,
+    *,
+    component_set_keys: dict[str, str] | None = None,
+) -> Path:
+    """Update ONLY frontmatter of an existing component section markdown file."""
+    out_path = repo_root / md_rel_path
+    assert out_path.exists(), f"update_component_frontmatter requires existing file: {out_path}"
+
+    from figmaclaw.figma_parse import split_frontmatter
+
+    md_text = out_path.read_text()
+    parts = split_frontmatter(md_text)
+    assert parts is not None, f"Failed to parse frontmatter from {out_path}"
+    _, body = parts
+
+    # Preserve enrichment state from existing frontmatter (set by enrich pass, not pull pass)
+    existing_fm = parse_frontmatter(md_text)
+    enriched_hash = existing_fm.enriched_hash if existing_fm else None
+    enriched_at = existing_fm.enriched_at if existing_fm else None
+    enriched_frame_hashes = existing_fm.enriched_frame_hashes if existing_fm else None
+
+    new_fm = build_component_frontmatter(
+        section,
+        page,
+        component_set_keys=component_set_keys,
+        enriched_hash=enriched_hash,
+        enriched_at=enriched_at,
+        enriched_frame_hashes=enriched_frame_hashes or None,
+    )
+    out_path.write_text(f"{new_fm}\n{body}")
     return out_path
 
 
@@ -959,13 +1001,23 @@ async def pull_file(
                         move_sidecar=False,
                     )
                 sect_keys = _build_component_set_keys(page.page_node_id, component_sets)
-                written = write_component_section(
-                    repo_root,
-                    section,
-                    page,
-                    comp_rel,
-                    component_set_keys=sect_keys or None,
-                )
+                comp_abs = repo_root / comp_rel
+                if comp_abs.exists():
+                    written = update_component_frontmatter(
+                        repo_root,
+                        section,
+                        page,
+                        comp_rel,
+                        component_set_keys=sect_keys or None,
+                    )
+                else:
+                    written = write_component_section(
+                        repo_root,
+                        section,
+                        page,
+                        comp_rel,
+                        component_set_keys=sect_keys or None,
+                    )
                 written_component_rels.append(str(written.relative_to(repo_root)))
 
             if written_component_rels:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ dev = [
     "pytest>=9.0.3",
     "pytest-asyncio>=1.3.0",
     "pytest-httpx>=0.36.2",
+    "pytest-xdist>=3.8.0",
     "basedpyright>=1.39.0",
     "ruff>=0.15.10",
     "pre-commit>=4.5.1",
@@ -35,6 +36,7 @@ dev = [
     "pytest>=9.0.3",
     "pytest-asyncio>=1.3.0",
     "pytest-httpx>=0.36.2",
+    "pytest-xdist>=3.8.0",
     "basedpyright>=1.39.0",
     "ruff>=0.15.10",
     "pre-commit>=4.5.1",
@@ -61,8 +63,12 @@ reportMissingTypeStubs = false
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
+addopts = "-n auto"
 markers = [
-    "smoke: marks tests as smoke tests requiring real credentials (deselect with '-m \"not smoke\"')",
+    "smoke: local smoke/integration tests that do not require live credentials",
+    "smoke_api: live Figma REST smoke tests (requires FIGMA_API_KEY; hard-fail if missing)",
+    "smoke_webhook: live webhook smoke tests (requires webhook permission)",
+    "smoke_mcp: live Figma MCP smoke tests (requires FIGMA_MCP_TOKEN/credentials)",
 ]
 testpaths = ["tests"]
 

--- a/tests/env_utils.py
+++ b/tests/env_utils.py
@@ -1,0 +1,23 @@
+"""Minimal .env loader for tests (no external dependency)."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+
+def load_repo_dotenv(repo_root: Path) -> None:
+    """Load KEY=VALUE pairs from repo .env into os.environ if not already set."""
+    env_path = repo_root / ".env"
+    if not env_path.exists():
+        return
+
+    for raw_line in env_path.read_text().splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, value = line.split("=", 1)
+        key = key.strip()
+        value = value.strip().strip("'").strip('"')
+        if key and key not in os.environ:
+            os.environ[key] = value

--- a/tests/smoke/live_gate.py
+++ b/tests/smoke/live_gate.py
@@ -1,0 +1,23 @@
+"""Helpers to enforce credentialed live smoke execution."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from tests.env_utils import load_repo_dotenv
+
+load_repo_dotenv(Path(__file__).resolve().parents[2])
+
+
+def require_live_credential(value: str, *, name: str, hint: str) -> str:
+    """Return credential value or fail loudly when missing."""
+    if value:
+        return value
+
+    message = f"{name} not set. {hint}"
+    if os.environ.get("FIGMACLAW_REQUIRE_LIVE_SMOKE", "").strip() == "1":
+        pytest.fail(message)
+    pytest.fail(message)

--- a/tests/smoke/test_figma_api_smoke.py
+++ b/tests/smoke/test_figma_api_smoke.py
@@ -1,9 +1,7 @@
 """Smoke tests against the real Figma API.
 
-Requires FIGMA_API_KEY env var. Run with:
-    uv run pytest -m smoke
-
-These tests are skipped by default in CI.
+Requires FIGMA_API_KEY env var (loaded from repo .env when available). Run with:
+    uv run pytest -m smoke_api
 """
 
 from __future__ import annotations
@@ -24,6 +22,7 @@ from figmaclaw.figma_parse import parse_frontmatter
 from figmaclaw.figma_render import scaffold_page
 from figmaclaw.figma_sync_state import FigmaSyncState, PageEntry
 from figmaclaw.pull_logic import pull_file
+from tests.smoke.live_gate import require_live_credential
 
 # The Web App file used in linear-git
 TEST_FILE_KEY = "hOV4QMBnDIG5s5OYkSrX9E"
@@ -41,10 +40,11 @@ _DEFAULT_WEBHOOK_TEAM_ID = "1314645078360119627"
 
 @pytest.fixture
 def api_key() -> str:
-    key = os.environ.get("FIGMA_API_KEY", "")
-    if not key:
-        pytest.skip("FIGMA_API_KEY not set")
-    return key
+    return require_live_credential(
+        os.environ.get("FIGMA_API_KEY", ""),
+        name="FIGMA_API_KEY",
+        hint="Export FIGMA_API_KEY to run real Figma API smoke tests.",
+    )
 
 
 @pytest.fixture
@@ -57,7 +57,7 @@ def webhook_team_id() -> str:
     return os.environ.get("FIGMA_WEBHOOK_TEAM_ID", _DEFAULT_WEBHOOK_TEAM_ID)
 
 
-@pytest.mark.smoke
+@pytest.mark.smoke_api
 @pytest.mark.asyncio
 async def test_get_file_meta_returns_version(api_key: str) -> None:
     """Smoke: get_file_meta hits real API and returns version + pages."""
@@ -71,7 +71,7 @@ async def test_get_file_meta_returns_version(api_key: str) -> None:
     assert all(p.type == "CANVAS" for p in pages)
 
 
-@pytest.mark.smoke
+@pytest.mark.smoke_api
 @pytest.mark.asyncio
 async def test_get_page_returns_canvas_with_sections(api_key: str) -> None:
     """Smoke: get_page returns the CANVAS document node directly with SECTION children."""
@@ -86,7 +86,7 @@ async def test_get_page_returns_canvas_with_sections(api_key: str) -> None:
     assert "SECTION" in section_types
 
 
-@pytest.mark.smoke
+@pytest.mark.smoke_api
 @pytest.mark.asyncio
 async def test_from_page_node_matches_real_api_structure(api_key: str) -> None:
     """Smoke: from_page_node builds a FigmaPage with the correct number of sections.
@@ -116,7 +116,7 @@ async def test_from_page_node_matches_real_api_structure(api_key: str) -> None:
         assert len(section.frames) > 0, f"Section {section.name!r} has no frames"
 
 
-@pytest.mark.smoke
+@pytest.mark.smoke_api
 @pytest.mark.asyncio
 async def test_render_and_parse_round_trip_against_real_page(api_key: str) -> None:
     """Smoke: scaffold_page + parse_frontmatter round-trips correctly for a real Figma page.
@@ -155,7 +155,7 @@ async def test_render_and_parse_round_trip_against_real_page(api_key: str) -> No
     assert "| Screen |" in md
 
 
-@pytest.mark.smoke
+@pytest.mark.smoke_webhook
 @pytest.mark.asyncio
 async def test_list_webhooks_returns_list(api_key: str, webhook_team_id: str) -> None:
     """Smoke: list_webhooks returns a list (may be empty) for personal team."""
@@ -164,7 +164,7 @@ async def test_list_webhooks_returns_list(api_key: str, webhook_team_id: str) ->
             webhooks = await client.list_webhooks(team_id=webhook_team_id)
         except httpx.HTTPStatusError as exc:
             if exc.response.status_code in {401, 403}:
-                pytest.skip(
+                pytest.fail(
                     "Token lacks webhook-list permission for team "
                     f"{webhook_team_id}; set FIGMA_WEBHOOK_TEAM_ID to an authorized team."
                 )
@@ -173,7 +173,7 @@ async def test_list_webhooks_returns_list(api_key: str, webhook_team_id: str) ->
     assert isinstance(webhooks, list)
 
 
-@pytest.mark.smoke
+@pytest.mark.smoke_api
 @pytest.mark.asyncio
 async def test_pull_writes_frame_sections_inventory(tmp_path, api_key: str) -> None:  # type: ignore[no-untyped-def]
     """Smoke: pull_file writes frame_sections with section-level inventory fields."""
@@ -210,7 +210,7 @@ async def test_pull_writes_frame_sections_inventory(tmp_path, api_key: str) -> N
     assert "raw_count:" in md_text
 
 
-@pytest.mark.smoke
+@pytest.mark.smoke_api
 @pytest.mark.asyncio
 async def test_pull_is_idempotent_for_written_page_markdown(tmp_path, api_key: str) -> None:  # type: ignore[no-untyped-def]
     """Smoke: two unchanged pulls produce identical markdown for an already written page."""
@@ -243,7 +243,7 @@ async def test_pull_is_idempotent_for_written_page_markdown(tmp_path, api_key: s
     assert md_before == md_after
 
 
-@pytest.mark.smoke
+@pytest.mark.smoke_api
 @pytest.mark.asyncio
 async def test_pull_collision_safe_file_dirs_and_sidecar_backfill(
     tmp_path,
@@ -281,7 +281,7 @@ async def test_pull_collision_safe_file_dirs_and_sidecar_backfill(
         assert Path(entry_a.md_path).parts[1] != Path(entry_b.md_path).parts[1]
 
 
-@pytest.mark.smoke
+@pytest.mark.smoke_api
 @pytest.mark.asyncio
 async def test_pull_backfills_missing_sidecar_on_unchanged_page_real_api(
     tmp_path,
@@ -324,7 +324,7 @@ async def test_pull_backfills_missing_sidecar_on_unchanged_page_real_api(
     assert target_sidecar.exists()
 
 
-@pytest.mark.smoke
+@pytest.mark.smoke_api
 @pytest.mark.asyncio
 async def test_pull_migrates_legacy_sidecar_schema_on_unchanged_page_real_api(
     tmp_path,
@@ -372,7 +372,7 @@ async def test_pull_migrates_legacy_sidecar_schema_on_unchanged_page_real_api(
     assert rewritten.get("schema_version") == 2
 
 
-@pytest.mark.smoke
+@pytest.mark.smoke_api
 @pytest.mark.asyncio
 async def test_pull_migrates_legacy_unkeyed_paths_to_full_key_slug_real_api(
     tmp_path,
@@ -435,7 +435,7 @@ async def test_pull_migrates_legacy_unkeyed_paths_to_full_key_slug_real_api(
         assert keyed_sidecar.exists()
 
 
-@pytest.mark.smoke
+@pytest.mark.smoke_api
 @pytest.mark.asyncio
 async def test_schema_upgrade_backfills_instance_component_ids_without_body_rewrite(
     tmp_path,
@@ -476,7 +476,7 @@ async def test_schema_upgrade_backfills_instance_component_ids_without_body_rewr
     assert "instance_component_ids:" in text_after
 
 
-@pytest.mark.smoke
+@pytest.mark.smoke_api
 @pytest.mark.asyncio
 async def test_build_context_generates_valid_call_specs_from_real_pull_data(
     tmp_path,

--- a/tests/smoke/test_figma_api_smoke.py
+++ b/tests/smoke/test_figma_api_smoke.py
@@ -54,7 +54,8 @@ def webhook_team_id() -> str:
     Use FIGMA_WEBHOOK_TEAM_ID in CI to point at a team where the token has webhook-read
     permission. Falls back to a known personal team ID for local smoke runs.
     """
-    return os.environ.get("FIGMA_WEBHOOK_TEAM_ID", _DEFAULT_WEBHOOK_TEAM_ID)
+    team_id = os.environ.get("FIGMA_WEBHOOK_TEAM_ID", "").strip()
+    return team_id or _DEFAULT_WEBHOOK_TEAM_ID
 
 
 @pytest.mark.smoke_api

--- a/tests/smoke/test_figma_api_smoke.py
+++ b/tests/smoke/test_figma_api_smoke.py
@@ -11,7 +11,6 @@ import os
 import re
 from pathlib import Path
 
-import httpx
 import pytest
 
 from figmaclaw.commands.build_context import _run as build_context_run
@@ -35,8 +34,6 @@ TEST_PAGE_NODE_ID = "7741:45837"
 # Confirmed from live API: 8 SECTION children on this page
 EXPECTED_SECTION_COUNT = 8
 
-_DEFAULT_WEBHOOK_TEAM_ID = "1314645078360119627"
-
 
 @pytest.fixture
 def api_key() -> str:
@@ -45,17 +42,6 @@ def api_key() -> str:
         name="FIGMA_API_KEY",
         hint="Export FIGMA_API_KEY to run real Figma API smoke tests.",
     )
-
-
-@pytest.fixture
-def webhook_team_id() -> str:
-    """Optional team ID used for webhook-listing smoke test.
-
-    Use FIGMA_WEBHOOK_TEAM_ID in CI to point at a team where the token has webhook-read
-    permission. Falls back to a known personal team ID for local smoke runs.
-    """
-    team_id = os.environ.get("FIGMA_WEBHOOK_TEAM_ID", "").strip()
-    return team_id or _DEFAULT_WEBHOOK_TEAM_ID
 
 
 @pytest.mark.smoke_api
@@ -158,18 +144,10 @@ async def test_render_and_parse_round_trip_against_real_page(api_key: str) -> No
 
 @pytest.mark.smoke_webhook
 @pytest.mark.asyncio
-async def test_list_webhooks_returns_list(api_key: str, webhook_team_id: str) -> None:
-    """Smoke: list_webhooks returns a list (may be empty) for personal team."""
+async def test_list_file_webhooks_returns_list(api_key: str) -> None:
+    """Smoke: list_file_webhooks returns a list (may be empty) for a tracked file."""
     async with FigmaClient(api_key=api_key) as client:
-        try:
-            webhooks = await client.list_webhooks(team_id=webhook_team_id)
-        except httpx.HTTPStatusError as exc:
-            if exc.response.status_code in {401, 403}:
-                pytest.fail(
-                    "Token lacks webhook-list permission for team "
-                    f"{webhook_team_id}; set FIGMA_WEBHOOK_TEAM_ID to an authorized team."
-                )
-            raise
+        webhooks = await client.list_file_webhooks(file_key=TEST_FILE_KEY)
 
     assert isinstance(webhooks, list)
 

--- a/tests/smoke/test_figma_mcp_smoke.py
+++ b/tests/smoke/test_figma_mcp_smoke.py
@@ -2,14 +2,17 @@
 
 Requires a valid OAuth token (FIGMA_MCP_TOKEN env var or ~/.claude/.credentials.json).
 Run with:
-    uv run pytest -m smoke tests/smoke/test_figma_mcp_smoke.py -v
+    uv run pytest -m smoke_mcp tests/smoke/test_figma_mcp_smoke.py -v
 """
 
 from __future__ import annotations
 
+import os
+
 import pytest
 
 from figmaclaw.figma_mcp import FigmaMcpClient, FigmaMcpError
+from tests.smoke.live_gate import require_live_credential
 
 # Web App file used in linear-git
 TEST_FILE_KEY = "hOV4QMBnDIG5s5OYkSrX9E"
@@ -17,13 +20,18 @@ TEST_FILE_KEY = "hOV4QMBnDIG5s5OYkSrX9E"
 
 @pytest.fixture
 def mcp_client() -> FigmaMcpClient:
+    require_live_credential(
+        os.environ.get("FIGMA_MCP_TOKEN", ""),
+        name="FIGMA_MCP_TOKEN",
+        hint="Set FIGMA_MCP_TOKEN in .env or environment for MCP smoke tests.",
+    )
     try:
         return FigmaMcpClient.auto()
     except FigmaMcpError as exc:
-        pytest.skip(f"No MCP credentials available: {exc}")
+        pytest.fail(f"MCP credentials are invalid/unusable: {exc}")
 
 
-@pytest.mark.smoke
+@pytest.mark.smoke_mcp
 @pytest.mark.asyncio
 async def test_use_figma_returns_page_count(mcp_client: FigmaMcpClient) -> None:
     """Smoke: use_figma() executes JS in Figma and returns a real result."""
@@ -36,7 +44,7 @@ async def test_use_figma_returns_page_count(mcp_client: FigmaMcpClient) -> None:
     assert not result.get("isError", False), f"MCP returned isError=True: {result}"
 
 
-@pytest.mark.smoke
+@pytest.mark.smoke_mcp
 @pytest.mark.asyncio
 async def test_session_reuse_makes_two_calls(mcp_client: FigmaMcpClient) -> None:
     """Smoke: session() context manager can execute multiple tools/call requests

--- a/tests/test_apply_webhook.py
+++ b/tests/test_apply_webhook.py
@@ -236,3 +236,39 @@ async def test_apply_webhook_file_delete_prunes_artifacts(tmp_path: Path, capsys
     state2.load()
     assert "abc123" not in state2.manifest.tracked_files
     assert "abc123" not in state2.manifest.files
+
+
+@pytest.mark.asyncio
+async def test_apply_webhook_missing_file_key_and_file_id_skips(tmp_path: Path, capsys):
+    """INVARIANT: payloads without file_key/file_id are ignored safely."""
+    payload = json.dumps({"event_type": "FILE_UPDATE", "passcode": "secret"})
+
+    from figmaclaw.commands.apply_webhook import _run
+
+    await _run(
+        api_key="fake_key",
+        repo_dir=tmp_path,
+        payload=payload,
+        webhook_secret=None,
+    )
+
+    out = capsys.readouterr().out
+    assert "missing file_key/file_id" in out.lower()
+    assert "COMMIT_MSG:" not in out
+
+
+@pytest.mark.asyncio
+async def test_apply_webhook_file_delete_untracked_is_noop(tmp_path: Path, capsys):
+    """INVARIANT: FILE_DELETE on an untracked file is reported as a skip, no commit message."""
+    from figmaclaw.commands.apply_webhook import _run
+
+    await _run(
+        api_key="fake_key",
+        repo_dir=tmp_path,
+        payload=_make_payload("not-tracked", event_type="FILE_DELETE"),
+        webhook_secret=None,
+    )
+
+    out = capsys.readouterr().out
+    assert "is not tracked — skipping." in out
+    assert "COMMIT_MSG:" not in out

--- a/tests/test_claude_run.py
+++ b/tests/test_claude_run.py
@@ -14,9 +14,11 @@ from __future__ import annotations
 import py_compile
 import textwrap
 from pathlib import Path
+from unittest.mock import Mock
 
 from click.testing import CliRunner
 
+from figmaclaw.commands import claude_run as claude_run_mod
 from figmaclaw.commands.claude_run import (
     build_prompt,
     collect_files,
@@ -632,3 +634,185 @@ class TestBuildPromptSectionPlaceholders:
         assert "10:1" in result
         assert "Auth" in result
         assert str(md) in result
+
+
+class TestClaudeRunExecutionBranches:
+    """Execution-path regressions not covered by selection-only tests."""
+
+    @staticmethod
+    def _write_placeholder_page(path: Path) -> None:
+        path.write_text(
+            textwrap.dedent("""\
+            ---
+            file_key: abc123
+            page_node_id: "0:1"
+            ---
+
+            | Screen | Node ID | Description |
+            |--------|---------|-------------|
+            | Login  | `1:1`   | (no description yet) |
+        """)
+        )
+
+    @staticmethod
+    def _budget_decision(should_start: bool, reason: str) -> claude_run_mod.BudgetDecision:
+        return claude_run_mod.BudgetDecision(
+            should_start=should_start,
+            reason=reason,
+            predicted_seconds=1.0,
+            remaining_seconds=1000.0,
+            per_frame_estimate=1.0,
+            history_used=0,
+        )
+
+    def test_budget_exhaustion_stops_before_claude_call(self, tmp_path: Path, monkeypatch) -> None:
+        md = tmp_path / "page.md"
+        self._write_placeholder_page(md)
+
+        monkeypatch.setattr(
+            claude_run_mod,
+            "decide_next_batch",
+            lambda **_: self._budget_decision(False, "[budget] stop before first batch"),
+        )
+        run_mock = Mock(side_effect=AssertionError("claude should not run when budget stops"))
+        monkeypatch.setattr(claude_run_mod, "_run_claude", run_mock)
+        monkeypatch.setattr(claude_run_mod, "count_commits_since", lambda *_args, **_kwargs: 0)
+        monkeypatch.setattr(
+            claude_run_mod.subprocess,
+            "run",
+            lambda *args, **kwargs: Mock(stdout="", returncode=0),
+        )
+
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            [
+                "--repo-dir",
+                str(tmp_path),
+                "claude-run",
+                str(md),
+                "--prompt",
+                "noop {file_path}",
+            ],
+        )
+
+        assert result.exit_code == 0
+        assert "[budget] stop before first batch" in result.output
+        assert run_mock.call_count == 0
+
+    def test_section_mode_phantom_selection_is_red(self, tmp_path: Path, monkeypatch) -> None:
+        md = tmp_path / "page.md"
+        self._write_placeholder_page(md)
+
+        monkeypatch.setattr(claude_run_mod, "enrichment_info", lambda _p: (True, 120))
+        monkeypatch.setattr(claude_run_mod, "pending_sections", lambda _p: [])
+        monkeypatch.setattr(claude_run_mod, "needs_finalization", lambda _p: False)
+        monkeypatch.setattr(
+            claude_run_mod.subprocess,
+            "run",
+            lambda *args, **kwargs: Mock(stdout="", returncode=0),
+        )
+
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            [
+                "--repo-dir",
+                str(tmp_path),
+                "claude-run",
+                str(md),
+                "--prompt",
+                "noop {file_path}",
+                "--section-mode",
+            ],
+        )
+
+        assert result.exit_code == 2
+        assert "PHANTOM SELECTION" in result.output
+        assert "Verdict (row 5)" in result.output
+
+    def test_section_mode_stuck_detection_breaks_after_retries(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        md = tmp_path / "page.md"
+        self._write_placeholder_page(md)
+
+        sections = [{"node_id": "10:1", "name": "Auth", "pending_frames": 2}]
+        # Initial load + two post-batch refreshes; third loop detects "stuck" and exits.
+        pending = [sections, sections, sections]
+
+        monkeypatch.setattr(claude_run_mod, "enrichment_info", lambda _p: (True, 120))
+        monkeypatch.setattr(claude_run_mod, "pending_sections", lambda _p: pending.pop(0))
+        monkeypatch.setattr(claude_run_mod, "needs_finalization", lambda _p: False)
+        monkeypatch.setattr(
+            claude_run_mod,
+            "decide_next_batch",
+            lambda **_: self._budget_decision(True, "[budget] go"),
+        )
+        monkeypatch.setattr(
+            claude_run_mod,
+            "_run_claude",
+            lambda **_: claude_run_mod.ClaudeResult(exit_code=0),
+        )
+        monkeypatch.setattr(claude_run_mod, "count_commits_since", lambda *_args, **_kwargs: 1)
+        monkeypatch.setattr(
+            claude_run_mod.subprocess,
+            "run",
+            lambda *args, **kwargs: Mock(stdout="", returncode=0),
+        )
+
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            [
+                "--repo-dir",
+                str(tmp_path),
+                "claude-run",
+                str(md),
+                "--prompt",
+                "noop {file_path}",
+                "--section-mode",
+            ],
+        )
+
+        assert result.exit_code == 0
+        assert "STUCK:" in result.output
+        assert "Verdict (row 2)" in result.output
+
+    def test_dispatch_crash_is_always_red(self, tmp_path: Path, monkeypatch) -> None:
+        md = tmp_path / "page.md"
+        self._write_placeholder_page(md)
+
+        monkeypatch.setattr(claude_run_mod, "enrichment_info", lambda _p: (True, 1))
+        monkeypatch.setattr(
+            claude_run_mod,
+            "decide_next_batch",
+            lambda **_: self._budget_decision(True, "[budget] go"),
+        )
+        monkeypatch.setattr(
+            claude_run_mod,
+            "_run_claude",
+            lambda **_: (_ for _ in ()).throw(RuntimeError("boom")),
+        )
+        monkeypatch.setattr(claude_run_mod, "count_commits_since", lambda *_args, **_kwargs: 0)
+        monkeypatch.setattr(
+            claude_run_mod.subprocess,
+            "run",
+            lambda *args, **kwargs: Mock(stdout="", returncode=0),
+        )
+
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            [
+                "--repo-dir",
+                str(tmp_path),
+                "claude-run",
+                str(md),
+                "--prompt",
+                "noop {file_path}",
+            ],
+        )
+
+        assert "CRASH in dispatch loop: RuntimeError: boom" in result.output
+        assert result.exit_code == 2

--- a/tests/test_env_utils.py
+++ b/tests/test_env_utils.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from tests.env_utils import load_repo_dotenv
+
+
+def test_load_repo_dotenv_loads_missing_env_vars(tmp_path: Path, monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    monkeypatch.delenv("FIGMA_API_KEY", raising=False)
+    (tmp_path / ".env").write_text("FIGMA_API_KEY=test-key\n")
+
+    load_repo_dotenv(tmp_path)
+
+    assert __import__("os").environ.get("FIGMA_API_KEY") == "test-key"
+
+
+def test_load_repo_dotenv_does_not_override_existing_vars(tmp_path: Path, monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    monkeypatch.setenv("FIGMA_API_KEY", "already-set")
+    (tmp_path / ".env").write_text("FIGMA_API_KEY=from-dotenv\n")
+
+    load_repo_dotenv(tmp_path)
+
+    assert __import__("os").environ.get("FIGMA_API_KEY") == "already-set"

--- a/tests/test_figma_client.py
+++ b/tests/test_figma_client.py
@@ -268,6 +268,77 @@ async def test_list_webhooks_returns_list():
 
 
 @pytest.mark.asyncio
+async def test_list_file_webhooks_returns_list():
+    """INVARIANT: list_file_webhooks uses context=file query and returns list."""
+    with respx.mock:
+        route = respx.get("https://api.figma.com/v2/webhooks").mock(
+            return_value=httpx.Response(200, json={"webhooks": [{"id": "wh1"}]})
+        )
+        async with FigmaClient(api_key="figd_test") as client:
+            webhooks = await client.list_file_webhooks(file_key=FILE_KEY)
+
+    assert isinstance(webhooks, list)
+    assert webhooks[0]["id"] == "wh1"
+    url = str(route.calls[0].request.url)
+    assert "context=file" in url
+    assert f"context_id={FILE_KEY}" in url
+
+
+@pytest.mark.asyncio
+async def test_create_file_webhook_posts_context_file_payload():
+    """INVARIANT: create_file_webhook posts v2 payload with context=file + context_id."""
+    with respx.mock:
+        route = respx.post("https://api.figma.com/v2/webhooks").mock(
+            return_value=httpx.Response(200, json={"id": "wh_file"})
+        )
+        async with FigmaClient(api_key="figd_test") as client:
+            payload = await client.create_file_webhook(
+                file_key=FILE_KEY,
+                endpoint="https://example.com/hook",
+                passcode="secret",
+                description="desc",
+            )
+
+    assert payload["id"] == "wh_file"
+    body = route.calls[0].request.content.decode()
+    assert '"context":"file"' in body
+    assert f'"context_id":"{FILE_KEY}"' in body
+
+
+@pytest.mark.asyncio
+async def test_create_webhook_posts_team_payload():
+    """INVARIANT: create_webhook posts v2 payload with team_id field."""
+    with respx.mock:
+        route = respx.post("https://api.figma.com/v2/webhooks").mock(
+            return_value=httpx.Response(200, json={"id": "wh_team"})
+        )
+        async with FigmaClient(api_key="figd_test") as client:
+            payload = await client.create_webhook(
+                team_id="team123",
+                endpoint="https://example.com/hook",
+                passcode="secret",
+            )
+
+    assert payload["id"] == "wh_team"
+    body = route.calls[0].request.content.decode()
+    assert '"team_id":"team123"' in body
+
+
+@pytest.mark.asyncio
+async def test_delete_webhook_calls_delete_endpoint():
+    """INVARIANT: delete_webhook hits /v2/webhooks/{id}."""
+    webhook_id = "wh_to_delete"
+    with respx.mock:
+        route = respx.delete(f"https://api.figma.com/v2/webhooks/{webhook_id}").mock(
+            return_value=httpx.Response(200, json={})
+        )
+        async with FigmaClient(api_key="figd_test") as client:
+            await client.delete_webhook(webhook_id)
+
+    assert len(route.calls) == 1
+
+
+@pytest.mark.asyncio
 async def test_list_team_projects_returns_projects():
     """INVARIANT: list_team_projects returns the projects list from the API."""
     team_id = "1314617533998771588"

--- a/tests/test_inspect.py
+++ b/tests/test_inspect.py
@@ -13,7 +13,6 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
-import pytest
 from click.testing import CliRunner
 
 from figmaclaw.figma_models import FigmaFrame, FigmaPage, FigmaSection
@@ -453,9 +452,27 @@ def test_inspect_reports_enrichment_should_update_when_below_current_but_above_r
         MIN_REQUIRED_ENRICHMENT_SCHEMA_VERSION,
     )
 
-    # This test is only meaningful when CURRENT > MIN_REQUIRED (SHOULD bucket exists)
+    # If CURRENT == MIN_REQUIRED, SHOULD bucket collapses and should_update must be False.
     if CURRENT_ENRICHMENT_SCHEMA_VERSION <= MIN_REQUIRED_ENRICHMENT_SCHEMA_VERSION:
-        pytest.skip("No SHOULD bucket: CURRENT == MIN_REQUIRED")
+        md_path = _write_md_with_enrichment(
+            tmp_path, enriched_schema_version=MIN_REQUIRED_ENRICHMENT_SCHEMA_VERSION
+        )
+
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            [
+                "--repo-dir",
+                str(tmp_path),
+                "inspect",
+                str(md_path),
+                "--json",
+            ],
+        )
+        data = json.loads(result.output)
+        assert data["enrichment_must_update"] is False
+        assert data["enrichment_should_update"] is False
+        return
 
     # Enrich at MIN_REQUIRED — valid but not latest
     md_path = _write_md_with_enrichment(

--- a/tests/test_list_cmd.py
+++ b/tests/test_list_cmd.py
@@ -62,7 +62,8 @@ def mock_client():
 
 def test_list_cmd_requires_figma_api_key(runner: CliRunner, tmp_path: Path):
     """INVARIANT: list exits with an error if FIGMA_API_KEY is not set."""
-    env = {k: v for k, v in os.environ.items() if k != "FIGMA_API_KEY"}
+    env = dict(os.environ)
+    env["FIGMA_API_KEY"] = ""
     result = runner.invoke(cli, ["--repo-dir", str(tmp_path), "list", TEAM_ID], env=env)
     assert result.exit_code != 0
     assert "FIGMA_API_KEY" in result.output

--- a/tests/test_live_gate.py
+++ b/tests/test_live_gate.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+import pytest
+from _pytest.outcomes import Failed
+
+from tests.smoke.live_gate import require_live_credential
+
+
+def test_require_live_credential_returns_value_when_present() -> None:
+    value = require_live_credential("token-123", name="FIGMA_API_KEY", hint="set it")
+    assert value == "token-123"
+
+
+def test_require_live_credential_fails_when_missing(monkeypatch) -> None:  # type: ignore[no-untyped-def]
+    monkeypatch.delenv("FIGMACLAW_REQUIRE_LIVE_SMOKE", raising=False)
+    with pytest.raises(Failed):
+        require_live_credential("", name="FIGMA_API_KEY", hint="set it")

--- a/tests/test_low_coverage_commands.py
+++ b/tests/test_low_coverage_commands.py
@@ -1,0 +1,280 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from figmaclaw import git_utils
+from figmaclaw.commands.self_cmd import self_group
+from figmaclaw.commands.track import _run as track_run
+from figmaclaw.figma_sync_state import FigmaSyncState
+from figmaclaw.main import cli
+
+
+def test_mark_stale_clears_enrichment_and_can_commit(tmp_path: Path) -> None:
+    md = tmp_path / "figma" / "web-app" / "pages" / "p.md"
+    md.parent.mkdir(parents=True)
+    md.write_text(
+        """---
+file_key: abc123
+page_node_id: "1:1"
+frames: ["2:2"]
+flows: [["2:2", "2:3"]]
+enriched_hash: oldhash
+enriched_at: '2026-01-01T00:00:00Z'
+enriched_frame_hashes: {"2:2": aa}
+---
+# Body\n\nreal prose\n""",
+        encoding="utf-8",
+    )
+
+    runner = CliRunner()
+    with patch("figmaclaw.commands.mark_stale.git_commit", return_value=True) as gc:
+        result = runner.invoke(
+            cli,
+            ["--repo-dir", str(tmp_path), "mark-stale", str(md), "--auto-commit"],
+            catch_exceptions=False,
+        )
+
+    assert result.exit_code == 0
+    text = md.read_text(encoding="utf-8")
+    assert "enriched_hash" not in text
+    assert "enriched_at" not in text
+    assert "enriched_frame_hashes" not in text
+    assert "# Body" in text
+    gc.assert_called_once()
+    assert "committed:" in result.output
+
+
+def test_mark_stale_handles_already_stale_and_no_frontmatter(tmp_path: Path) -> None:
+    stale = tmp_path / "stale.md"
+    stale.write_text(
+        """---
+file_key: abc123
+page_node_id: "1:1"
+frames: ["2:2"]
+---
+Body\n""",
+        encoding="utf-8",
+    )
+    plain = tmp_path / "plain.md"
+    plain.write_text("# not figmaclaw\n", encoding="utf-8")
+
+    runner = CliRunner()
+    res1 = runner.invoke(
+        cli, ["--repo-dir", str(tmp_path), "mark-stale", str(stale)], catch_exceptions=False
+    )
+    assert res1.exit_code == 0
+    assert "already not enriched" in res1.output
+
+    res2 = runner.invoke(cli, ["--repo-dir", str(tmp_path), "mark-stale", str(plain)])
+    assert res2.exit_code == 2
+    assert "no figmaclaw frontmatter" in res2.output
+
+
+def test_suggest_tokens_dry_run_and_frame_filtered_write(tmp_path: Path) -> None:
+    sidecar = tmp_path / "page.tokens.json"
+    sidecar.write_text(
+        json.dumps(
+            {
+                "frames": {
+                    "11:1": {
+                        "name": "Login Screen",
+                        "issues": [
+                            {
+                                "property": "fill",
+                                "current_value": {"r": 1},
+                                "hex": "#FF0000",
+                                "count": 2,
+                            },
+                            {"property": "gap", "current_value": 8.0, "count": 3},
+                        ],
+                    },
+                    "11:2": {
+                        "name": "Settings",
+                        "issues": [
+                            {"property": "radius", "current_value": 12, "count": 1},
+                        ],
+                    },
+                }
+            },
+            ensure_ascii=False,
+        ),
+        encoding="utf-8",
+    )
+
+    catalog = SimpleNamespace(
+        variables={
+            "a": SimpleNamespace(hex="#FFFFFF", numeric_value=None),
+            "b": SimpleNamespace(hex=None, numeric_value=8),
+        }
+    )
+
+    def fake_suggest(work_sidecar: dict, _catalog: object) -> None:
+        for frame in work_sidecar.get("frames", {}).values():
+            for issue in frame.get("issues", []):
+                prop = issue.get("property")
+                if prop == "fill":
+                    issue["suggest_status"] = "auto"
+                elif prop == "gap":
+                    issue["suggest_status"] = "ambiguous"
+                else:
+                    issue["suggest_status"] = "no_match"
+        work_sidecar["suggested_at"] = "2026-04-15T12:00:00Z"
+
+    runner = CliRunner()
+    with (
+        patch("figmaclaw.commands.suggest_tokens.load_catalog", return_value=catalog),
+        patch("figmaclaw.commands.suggest_tokens.suggest_for_sidecar", side_effect=fake_suggest),
+    ):
+        dry = runner.invoke(
+            cli,
+            ["--repo-dir", str(tmp_path), "suggest-tokens", "--sidecar", str(sidecar), "--dry-run"],
+            catch_exceptions=False,
+        )
+        assert dry.exit_code == 0
+        assert "Catalog: 2 variables (1 color, 1 numeric)" in dry.output
+        assert "auto:" in dry.output and "2" in dry.output
+        assert "ambiguous:" in dry.output and "3" in dry.output
+        assert "no_match:" in dry.output and "1" in dry.output
+        after_dry = json.loads(sidecar.read_text(encoding="utf-8"))
+        assert "suggest_status" not in json.dumps(after_dry)
+
+        write = runner.invoke(
+            cli,
+            [
+                "--repo-dir",
+                str(tmp_path),
+                "suggest-tokens",
+                "--sidecar",
+                str(sidecar),
+                "--frame",
+                "login",
+            ],
+            catch_exceptions=False,
+        )
+        assert write.exit_code == 0
+        assert "Wrote updated sidecar" in write.output
+
+    written = json.loads(sidecar.read_text(encoding="utf-8"))
+    login_issues = written["frames"]["11:1"]["issues"]
+    assert login_issues[0]["suggest_status"] == "auto"
+    assert login_issues[1]["suggest_status"] == "ambiguous"
+    # Filtered write should not alter non-matching frame
+    assert "suggest_status" not in written["frames"]["11:2"]["issues"][0]
+    assert written["suggested_at"] == "2026-04-15T12:00:00Z"
+
+
+def test_self_skill_list_print_specific_and_not_found(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    skills_dir = tmp_path / "skills"
+    skills_dir.mkdir()
+    (skills_dir / "alpha.md").write_text("alpha body\n", encoding="utf-8")
+    (skills_dir / "beta.md").write_text("beta body\n", encoding="utf-8")
+    monkeypatch.setattr("figmaclaw.commands.self_cmd._SKILLS_DIR", skills_dir)
+
+    runner = CliRunner()
+    listed = runner.invoke(self_group, ["skill", "--list"], catch_exceptions=False)
+    assert listed.exit_code == 0
+    assert "alpha" in listed.output and "beta" in listed.output
+
+    one = runner.invoke(self_group, ["skill", "alpha"], catch_exceptions=False)
+    assert one.exit_code == 0
+    assert one.output == "alpha body\n"
+
+    missing = runner.invoke(self_group, ["skill", "missing"])
+    assert missing.exit_code != 0
+    assert "not found" in missing.output
+
+
+@pytest.mark.asyncio
+async def test_track_run_updates_state_and_optional_pull(tmp_path: Path) -> None:
+    client = MagicMock()
+    client.get_file_meta = AsyncMock(return_value=SimpleNamespace(name="Web App"))
+
+    ctx = MagicMock()
+    ctx.__aenter__ = AsyncMock(return_value=client)
+    ctx.__aexit__ = AsyncMock(return_value=None)
+
+    with (
+        patch("figmaclaw.commands.track.FigmaClient", return_value=ctx),
+        patch(
+            "figmaclaw.commands.track.pull_file",
+            AsyncMock(
+                return_value=SimpleNamespace(pages_written=1, md_paths=["figma/web-app/pages/p.md"])
+            ),
+        ) as pull,
+    ):
+        await track_run("api-key", tmp_path, "abc123", no_pull=True)
+        pull.assert_not_awaited()
+
+        await track_run("api-key", tmp_path, "abc123", no_pull=False)
+        pull.assert_awaited()
+
+    state = FigmaSyncState(tmp_path)
+    state.load()
+    assert "abc123" in state.manifest.tracked_files
+    assert state.manifest.files["abc123"].file_name == "Web App"
+
+
+def test_track_cmd_requires_api_key(tmp_path: Path) -> None:
+    runner = CliRunner()
+    result = runner.invoke(
+        cli, ["--repo-dir", str(tmp_path), "track", "abc123"], env={"FIGMA_API_KEY": ""}
+    )
+    assert result.exit_code != 0
+    assert "FIGMA_API_KEY" in result.output
+
+
+def test_git_utils_commit_and_push_retry(tmp_path: Path) -> None:
+    recorded: list[list[str]] = []
+
+    class R:
+        def __init__(self, rc: int):
+            self.returncode = rc
+
+    def fake_run(cmd: list[str], check: bool = False):  # noqa: ARG001
+        recorded.append(cmd)
+        if cmd[-1] == "push":
+            return R(1 if sum(1 for c in recorded if c[-1] == "push") == 1 else 0)
+        if cmd[-3:] == ["diff", "--cached", "--quiet"]:
+            return R(1)
+        return R(0)
+
+    with patch("subprocess.run", side_effect=fake_run):
+        committed = git_utils.git_commit(tmp_path, ["a.md"], "msg")
+        assert committed is True
+        git_utils.git_push(tmp_path)
+
+    # commit path: add -> diff -> commit
+    assert any("add" in cmd and "a.md" in cmd for cmd in recorded)
+    assert any("commit" in cmd for cmd in recorded)
+    # push retry path: push -> pull --no-rebase -> push
+    push_cmds = [cmd for cmd in recorded if cmd[-1] == "push"]
+    assert len(push_cmds) == 2
+    assert any(cmd[-2:] == ["pull", "--no-rebase"] for cmd in recorded)
+
+
+def test_git_utils_commit_returns_false_on_no_diff(tmp_path: Path) -> None:
+    class R:
+        def __init__(self, rc: int):
+            self.returncode = rc
+
+    calls: list[list[str]] = []
+
+    def fake_run(cmd: list[str], check: bool = False):  # noqa: ARG001
+        calls.append(cmd)
+        if cmd[-3:] == ["diff", "--cached", "--quiet"]:
+            return R(0)
+        return R(0)
+
+    with patch("subprocess.run", side_effect=fake_run):
+        committed = git_utils.git_commit(tmp_path, ["a.md"], "msg")
+
+    assert committed is False
+    assert not any(cmd[-1] == "commit" for cmd in calls)

--- a/tests/test_pull_logic.py
+++ b/tests/test_pull_logic.py
@@ -1925,6 +1925,106 @@ async def test_pull_file_migrates_legacy_sidecar_on_unchanged_page(tmp_path: Pat
 
 
 @pytest.mark.asyncio
+async def test_pull_file_backfills_missing_sidecar_on_unchanged_page_when_schema_stale(
+    tmp_path: Path,
+):
+    """INVARIANT: sidecar backfill still happens during schema-only upgrade runs."""
+    from figmaclaw.figma_hash import compute_page_hash
+
+    page_id = "7741:45837"
+    file_key = "abc123"
+    page_node = fake_page_node_with_children()
+    page_hash = compute_page_hash(page_node)
+
+    state = FigmaSyncState(tmp_path)
+    state.load()
+    state.add_tracked_file(file_key, "Web App")
+    state.manifest.files[file_key].version = "v2"
+    state.manifest.files[file_key].last_modified = "2026-03-31T12:00:00Z"
+    state.manifest.files[file_key].pull_schema_version = max(0, CURRENT_PULL_SCHEMA_VERSION - 1)
+    md_rel = "figma/web-app-abc123/pages/onboarding-7741-45837.md"
+    state.manifest.files[file_key].pages[page_id] = PageEntry(
+        page_name="Onboarding",
+        page_slug="onboarding-7741-45837",
+        md_path=md_rel,
+        page_hash=page_hash,
+        last_refreshed_at="2026-03-31T12:00:00Z",
+    )
+    state.save()
+
+    md_abs = tmp_path / md_rel
+    md_abs.parent.mkdir(parents=True, exist_ok=True)
+    md_abs.write_text(
+        "---\nfile_key: abc123\npage_node_id: '7741:45837'\nframes: ['11:1']\n---\n\n# body\n"
+    )
+    assert not md_abs.with_suffix(".tokens.json").exists()
+
+    mock_client = MagicMock(spec=FigmaClient)
+    mock_client.get_file_meta = AsyncMock(return_value=fake_file_meta("v2", "2026-03-31T12:00:00Z"))
+    mock_client.get_page = AsyncMock(return_value=page_node)
+    mock_client.get_component_sets = AsyncMock(return_value=[])
+    mock_client.get_nodes = AsyncMock(return_value=fake_get_nodes_response())
+
+    result = await pull_file(mock_client, file_key, state, tmp_path, force=False)
+
+    assert result.skipped_file is False
+    assert result.pages_schema_upgraded == 1
+    assert md_abs.with_suffix(".tokens.json").exists()
+
+
+@pytest.mark.asyncio
+async def test_pull_file_migrates_legacy_sidecar_on_unchanged_page_when_schema_stale(
+    tmp_path: Path,
+):
+    """INVARIANT: legacy sidecar schema migrates to v2 even during schema-only upgrades."""
+    from figmaclaw.figma_hash import compute_page_hash
+
+    page_id = "7741:45837"
+    file_key = "abc123"
+    page_node = fake_page_node_with_children()
+    page_hash = compute_page_hash(page_node)
+
+    state = FigmaSyncState(tmp_path)
+    state.load()
+    state.add_tracked_file(file_key, "Web App")
+    state.manifest.files[file_key].version = "v2"
+    state.manifest.files[file_key].last_modified = "2026-03-31T12:00:00Z"
+    state.manifest.files[file_key].pull_schema_version = max(0, CURRENT_PULL_SCHEMA_VERSION - 1)
+    md_rel = "figma/web-app-abc123/pages/onboarding-7741-45837.md"
+    state.manifest.files[file_key].pages[page_id] = PageEntry(
+        page_name="Onboarding",
+        page_slug="onboarding-7741-45837",
+        md_path=md_rel,
+        page_hash=page_hash,
+        last_refreshed_at="2026-03-31T12:00:00Z",
+    )
+    state.save()
+
+    md_abs = tmp_path / md_rel
+    md_abs.parent.mkdir(parents=True, exist_ok=True)
+    md_abs.write_text(
+        "---\nfile_key: abc123\npage_node_id: '7741:45837'\nframes: ['11:1']\n---\n\n# body\n"
+    )
+    sidecar = md_abs.with_suffix(".tokens.json")
+    sidecar.write_text(
+        '{"file_key":"abc123","page_node_id":"7741:45837","summary":{"raw":1,"stale":0,"valid":0},"frames":{}}'
+    )
+
+    mock_client = MagicMock(spec=FigmaClient)
+    mock_client.get_file_meta = AsyncMock(return_value=fake_file_meta("v2", "2026-03-31T12:00:00Z"))
+    mock_client.get_page = AsyncMock(return_value=page_node)
+    mock_client.get_component_sets = AsyncMock(return_value=[])
+    mock_client.get_nodes = AsyncMock(return_value=fake_get_nodes_response())
+
+    result = await pull_file(mock_client, file_key, state, tmp_path, force=False)
+
+    assert result.skipped_file is False
+    assert result.pages_schema_upgraded == 1
+    payload = json.loads(sidecar.read_text())
+    assert payload["schema_version"] == 2
+
+
+@pytest.mark.asyncio
 async def test_pull_file_page_rename_moves_path_and_prunes_old(tmp_path: Path):
     """INVARIANT: renaming a page keeps exactly one page file path (old path is pruned)."""
     page_id = "100:1"

--- a/tests/test_pull_logic.py
+++ b/tests/test_pull_logic.py
@@ -319,6 +319,170 @@ async def test_pull_file_writes_component_section_with_frame_ids(pull_env: PullE
 
 
 @pytest.mark.asyncio
+async def test_pull_file_preserves_existing_component_descriptions_on_changed_page(tmp_path: Path):
+    """INVARIANT: pull_file must not rewrite existing component body prose on updates."""
+    state = FigmaSyncState(tmp_path)
+    state.load()
+    state.add_tracked_file("abc123", "Web App")
+    state.manifest.files["abc123"].version = "v1"
+    state.manifest.files["abc123"].pages["7741:45837"] = PageEntry(
+        page_name="Components",
+        page_slug="components-7741-45837",
+        md_path=None,
+        page_hash="0000000000000000",
+        last_refreshed_at="2026-03-30T00:00:00Z",
+        component_md_paths=["figma/web-app-abc123/components/buttons-20-1.md"],
+    )
+
+    comp_path = tmp_path / "figma/web-app-abc123/components/buttons-20-1.md"
+    comp_path.parent.mkdir(parents=True, exist_ok=True)
+    comp_path.write_text(
+        """---
+file_key: abc123
+page_node_id: '7741:45837'
+section_node_id: '20:1'
+frames: ['30:1', '30:2']
+enriched_hash: keep-me
+---
+
+# Web App / Components / buttons
+
+[Open in Figma](https://www.figma.com/design/abc123?node-id=20-1)
+
+## Variants (`20:1`)
+
+| Variant | Node ID | Description |
+|---------|---------|-------------|
+| Button / Primary | `30:1` | Keep this existing description |
+| Button / Secondary | `30:2` | Keep this too |
+"""
+    )
+
+    mock_client = MagicMock(spec=FigmaClient)
+    mock_client.get_file_meta = AsyncMock(return_value=fake_file_meta("v2"))
+    mock_client.get_page = AsyncMock(return_value=fake_component_page_node())
+    mock_client.get_component_sets = AsyncMock(return_value=[])
+
+    await pull_file(mock_client, "abc123", state, tmp_path, force=False)
+
+    updated = comp_path.read_text()
+    assert "Keep this existing description" in updated
+    assert "Keep this too" in updated
+    assert "(no description yet)" not in updated
+
+
+@pytest.mark.asyncio
+async def test_pull_file_migrates_legacy_component_path_without_losing_descriptions(tmp_path: Path):
+    """INVARIANT: legacy component path migration keeps existing human-written descriptions."""
+    state = FigmaSyncState(tmp_path)
+    state.load()
+    state.add_tracked_file("abc123", "Web App")
+    state.manifest.files["abc123"].version = "v1"
+    state.manifest.files["abc123"].pages["7741:45837"] = PageEntry(
+        page_name="Components",
+        page_slug="components-7741-45837",
+        md_path=None,
+        page_hash="0000000000000000",
+        last_refreshed_at="2026-03-30T00:00:00Z",
+        component_md_paths=["figma/web-app/components/buttons-20-1.md"],  # legacy path
+    )
+
+    legacy_path = tmp_path / "figma/web-app/components/buttons-20-1.md"
+    legacy_path.parent.mkdir(parents=True, exist_ok=True)
+    legacy_path.write_text(
+        """---
+file_key: abc123
+page_node_id: '7741:45837'
+section_node_id: '20:1'
+frames: ['30:1', '30:2']
+---
+
+# Web App / Components / buttons
+
+[Open in Figma](https://www.figma.com/design/abc123?node-id=20-1)
+
+## Variants (`20:1`)
+
+| Variant | Node ID | Description |
+|---------|---------|-------------|
+| Button / Primary | `30:1` | Legacy migrated description |
+| Button / Secondary | `30:2` | Another legacy description |
+"""
+    )
+
+    mock_client = MagicMock(spec=FigmaClient)
+    mock_client.get_file_meta = AsyncMock(return_value=fake_file_meta("v2"))
+    mock_client.get_page = AsyncMock(return_value=fake_component_page_node())
+    mock_client.get_component_sets = AsyncMock(return_value=[])
+
+    await pull_file(mock_client, "abc123", state, tmp_path, force=False)
+
+    new_path = tmp_path / "figma/web-app-abc123/components/buttons-20-1.md"
+    assert new_path.exists()
+    migrated = new_path.read_text()
+    assert "Legacy migrated description" in migrated
+    assert "Another legacy description" in migrated
+    assert "(no description yet)" not in migrated
+
+
+@pytest.mark.asyncio
+async def test_pull_file_component_description_preservation_is_idempotent(tmp_path: Path):
+    """INVARIANT: component description preservation remains stable across repeated pulls."""
+    state = FigmaSyncState(tmp_path)
+    state.load()
+    state.add_tracked_file("abc123", "Web App")
+    state.manifest.files["abc123"].version = "v1"
+    state.manifest.files["abc123"].pages["7741:45837"] = PageEntry(
+        page_name="Components",
+        page_slug="components-7741-45837",
+        md_path=None,
+        page_hash="0000000000000000",
+        last_refreshed_at="2026-03-30T00:00:00Z",
+        component_md_paths=["figma/web-app-abc123/components/buttons-20-1.md"],
+    )
+
+    comp_path = tmp_path / "figma/web-app-abc123/components/buttons-20-1.md"
+    comp_path.parent.mkdir(parents=True, exist_ok=True)
+    comp_path.write_text(
+        """---
+file_key: abc123
+page_node_id: '7741:45837'
+section_node_id: '20:1'
+frames: ['30:1', '30:2']
+---
+
+# Web App / Components / buttons
+
+[Open in Figma](https://www.figma.com/design/abc123?node-id=20-1)
+
+## Variants (`20:1`)
+
+| Variant | Node ID | Description |
+|---------|---------|-------------|
+| Button / Primary | `30:1` | Idempotent description A |
+| Button / Secondary | `30:2` | Idempotent description B |
+"""
+    )
+
+    mock_client = MagicMock(spec=FigmaClient)
+    mock_client.get_component_sets = AsyncMock(return_value=[])
+    mock_client.get_page = AsyncMock(return_value=fake_component_page_node())
+
+    # First run: content-changed path should preserve body prose.
+    mock_client.get_file_meta = AsyncMock(return_value=fake_file_meta("v2"))
+    await pull_file(mock_client, "abc123", state, tmp_path, force=False)
+    first = comp_path.read_text()
+    assert "Idempotent description A" in first
+    assert "Idempotent description B" in first
+
+    # Second run: unchanged file-level metadata should skip with no body churn.
+    mock_client.get_file_meta = AsyncMock(return_value=fake_file_meta("v2", "2026-03-31T12:00:00Z"))
+    await pull_file(mock_client, "abc123", state, tmp_path, force=False)
+    second = comp_path.read_text()
+    assert second == first
+
+
+@pytest.mark.asyncio
 async def test_pull_file_preserves_existing_descriptions(tmp_path: Path):
     """INVARIANT: pull_file preserves frame descriptions from existing .md for unchanged frames."""
     # Pre-write a .md with existing descriptions at the slug-based path

--- a/tests/test_pull_logic.py
+++ b/tests/test_pull_logic.py
@@ -986,7 +986,7 @@ async def test_pull_cmd_skips_unchanged_files_via_listing(tmp_path: Path):
     )
     mock_client.get_file_meta = AsyncMock()
 
-    with patch.object(FigmaClient, "__new__", return_value=mock_client):
+    with patch("figmaclaw.commands.pull.FigmaClient", return_value=mock_client):
         await _run("key", tmp_path, None, False, None, False, 10, "team123", "all")
 
     mock_client.get_file_meta.assert_not_called()
@@ -1018,7 +1018,7 @@ async def test_pull_cmd_pulls_files_whose_listing_last_modified_changed(tmp_path
         }
     )
 
-    with patch.object(FigmaClient, "__new__", return_value=mock_client):
+    with patch("figmaclaw.commands.pull.FigmaClient", return_value=mock_client):
         await _run("key", tmp_path, None, False, None, False, 10, "team123", "all")
 
     mock_client.get_file_meta.assert_called_once_with("fileA")
@@ -1040,7 +1040,7 @@ async def test_pull_cmd_skips_figjam_files_not_in_listing(tmp_path: Path):
     mock_client.list_project_files = AsyncMock(return_value=[])  # FigJam not in listing
     mock_client.get_file_meta = AsyncMock()
 
-    with patch.object(FigmaClient, "__new__", return_value=mock_client):
+    with patch("figmaclaw.commands.pull.FigmaClient", return_value=mock_client):
         await _run("key", tmp_path, None, False, None, False, 10, "team123", "all")
 
     mock_client.get_file_meta.assert_not_called()
@@ -1073,7 +1073,7 @@ async def test_pull_cmd_stamps_listing_last_modified_after_failed_get_file_meta(
     mock_pull = AsyncMock(return_value=failed_result)
 
     with (
-        patch.object(FigmaClient, "__new__", return_value=mock_client),
+        patch("figmaclaw.commands.pull.FigmaClient", return_value=mock_client),
         patch("figmaclaw.commands.pull.pull_file", mock_pull),
     ):
         await _run("key", tmp_path, None, False, None, False, 10, "team123", "all")
@@ -1105,7 +1105,7 @@ async def test_pull_cmd_forwards_prune_flag_to_pull_file(tmp_path: Path):
     )
 
     with (
-        patch.object(FigmaClient, "__new__", return_value=mock_client),
+        patch("figmaclaw.commands.pull.FigmaClient", return_value=mock_client),
         patch(
             "figmaclaw.commands.pull.pull_file",
             AsyncMock(return_value=PullResult(file_key="fileA", skipped_file=True)),
@@ -2025,6 +2025,158 @@ async def test_pull_file_migrates_legacy_sidecar_on_unchanged_page_when_schema_s
 
 
 @pytest.mark.asyncio
+async def test_pull_file_repairs_corrupt_sidecar_on_unchanged_page(tmp_path: Path):
+    """INVARIANT: unreadable sidecar JSON is treated as stale and repaired on next pull."""
+    from figmaclaw.figma_hash import compute_page_hash
+
+    page_id = "7741:45837"
+    file_key = "abc123"
+    page_node = fake_page_node_with_children()
+    page_hash = compute_page_hash(page_node)
+
+    state = FigmaSyncState(tmp_path)
+    state.load()
+    state.add_tracked_file(file_key, "Web App")
+    state.manifest.files[file_key].version = "v2"
+    state.manifest.files[file_key].last_modified = "2026-03-31T12:00:00Z"
+    state.manifest.files[file_key].pull_schema_version = CURRENT_PULL_SCHEMA_VERSION
+    md_rel = "figma/web-app-abc123/pages/onboarding-7741-45837.md"
+    state.manifest.files[file_key].pages[page_id] = PageEntry(
+        page_name="Onboarding",
+        page_slug="onboarding-7741-45837",
+        md_path=md_rel,
+        page_hash=page_hash,
+        last_refreshed_at="2026-03-31T12:00:00Z",
+    )
+    state.save()
+
+    md_abs = tmp_path / md_rel
+    md_abs.parent.mkdir(parents=True, exist_ok=True)
+    md_abs.write_text(
+        "---\nfile_key: abc123\npage_node_id: '7741:45837'\nframes: ['11:1']\n---\n\n# body\n"
+    )
+    sidecar = md_abs.with_suffix(".tokens.json")
+    sidecar.write_text("{not json")
+
+    mock_client = MagicMock(spec=FigmaClient)
+    mock_client.get_file_meta = AsyncMock(return_value=fake_file_meta("v2", "2026-03-31T12:00:00Z"))
+    mock_client.get_page = AsyncMock(return_value=page_node)
+    mock_client.get_component_sets = AsyncMock(return_value=[])
+    mock_client.get_nodes = AsyncMock(return_value=fake_get_nodes_response())
+
+    result = await pull_file(mock_client, file_key, state, tmp_path, force=False)
+
+    assert result.skipped_file is False
+    payload = json.loads(sidecar.read_text())
+    assert payload["schema_version"] == 2
+
+
+@pytest.mark.asyncio
+async def test_pull_file_migration_prunes_old_when_new_screen_path_already_exists(tmp_path: Path):
+    """INVARIANT: if old/new generated screen paths both exist, old md+sidecar are deleted."""
+    page_id = "100:1"
+    old_page_name = "Showcase LSN"
+    new_page_name = "Showcase V2"
+    file_name = "Web App"
+
+    state = FigmaSyncState(tmp_path)
+    state.load()
+    state.add_tracked_file("abc123", file_name)
+    state.manifest.files["abc123"].version = "v1"
+
+    mock_client = MagicMock(spec=FigmaClient)
+    mock_client.get_component_sets = AsyncMock(return_value=[])
+    mock_client.get_nodes = AsyncMock(return_value={})
+
+    mock_client.get_file_meta = AsyncMock(
+        return_value=_custom_file_meta(
+            version="v2", file_name=file_name, page_id=page_id, page_name=old_page_name
+        )
+    )
+    mock_client.get_page = AsyncMock(return_value=fake_page_node_for_id(page_id, old_page_name))
+    await pull_file(mock_client, "abc123", state, tmp_path, force=False)
+
+    old_rel = page_path(
+        f"{slugify(file_name)}-abc123", f"{slugify(old_page_name)}-{page_id.replace(':', '-')}"
+    )
+    new_rel = page_path(
+        f"{slugify(file_name)}-abc123", f"{slugify(new_page_name)}-{page_id.replace(':', '-')}"
+    )
+    old_abs = tmp_path / old_rel
+    new_abs = tmp_path / new_rel
+    old_sidecar = old_abs.with_suffix(".tokens.json")
+    new_sidecar = new_abs.with_suffix(".tokens.json")
+    old_sidecar.write_text("{}")
+    new_abs.parent.mkdir(parents=True, exist_ok=True)
+    new_abs.write_text(old_abs.read_text())
+    new_sidecar.write_text("{}")
+
+    mock_client.get_file_meta = AsyncMock(
+        return_value=_custom_file_meta(
+            version="v3", file_name=file_name, page_id=page_id, page_name=new_page_name
+        )
+    )
+    mock_client.get_page = AsyncMock(return_value=fake_page_node_for_id(page_id, new_page_name))
+    await pull_file(mock_client, "abc123", state, tmp_path, force=False)
+
+    assert new_abs.exists()
+    assert new_sidecar.exists()
+    assert not old_abs.exists()
+    assert not old_sidecar.exists()
+
+
+@pytest.mark.asyncio
+async def test_pull_file_continues_when_token_scan_raises(tmp_path: Path):
+    """INVARIANT: token scan failures don't abort pull/page frontmatter writes."""
+    state = FigmaSyncState(tmp_path)
+    state.load()
+    state.add_tracked_file("abc123", "Web App")
+    state.manifest.files["abc123"].version = "v1"
+
+    mock_client = MagicMock(spec=FigmaClient)
+    mock_client.get_file_meta = AsyncMock(return_value=fake_file_meta("v2", "2026-03-31T12:00:00Z"))
+    mock_client.get_page = AsyncMock(return_value=fake_page_node_with_children())
+    mock_client.get_component_sets = AsyncMock(return_value=[])
+    mock_client.get_nodes = AsyncMock(return_value=fake_get_nodes_response())
+
+    with patch("figmaclaw.pull_logic.scan_page", side_effect=RuntimeError("scan boom")):
+        result = await pull_file(mock_client, "abc123", state, tmp_path, force=False)
+
+    assert result.pages_written == 1
+    page_rel = next(iter(state.manifest.files["abc123"].pages.values())).md_path
+    assert page_rel is not None
+    page_md = tmp_path / page_rel
+    assert page_md.exists()
+    # token_scan failed, so sidecar write should be skipped for this pull.
+    assert not page_md.with_suffix(".tokens.json").exists()
+
+
+@pytest.mark.asyncio
+async def test_pull_file_continues_when_sidecar_write_raises(tmp_path: Path):
+    """INVARIANT: sidecar write failures are logged but do not abort pull."""
+    state = FigmaSyncState(tmp_path)
+    state.load()
+    state.add_tracked_file("abc123", "Web App")
+    state.manifest.files["abc123"].version = "v1"
+
+    mock_client = MagicMock(spec=FigmaClient)
+    mock_client.get_file_meta = AsyncMock(return_value=fake_file_meta("v2", "2026-03-31T12:00:00Z"))
+    mock_client.get_page = AsyncMock(return_value=fake_page_node_with_children())
+    mock_client.get_component_sets = AsyncMock(return_value=[])
+    mock_client.get_nodes = AsyncMock(return_value=fake_get_nodes_response())
+
+    with patch("figmaclaw.pull_logic._write_token_sidecar", side_effect=RuntimeError("write boom")):
+        result = await pull_file(mock_client, "abc123", state, tmp_path, force=False)
+
+    assert result.pages_written == 1
+    page_rel = next(iter(state.manifest.files["abc123"].pages.values())).md_path
+    assert page_rel is not None
+    page_md = tmp_path / page_rel
+    assert page_md.exists()
+    assert not page_md.with_suffix(".tokens.json").exists()
+
+
+@pytest.mark.asyncio
 async def test_pull_file_page_rename_moves_path_and_prunes_old(tmp_path: Path):
     """INVARIANT: renaming a page keeps exactly one page file path (old path is pruned)."""
     page_id = "100:1"
@@ -2446,7 +2598,7 @@ async def test_pull_cmd_no_access_prunes_artifacts_and_untracks(tmp_path: Path):
 
     no_access_result = PullResult(file_key="restricted_key", no_access=True, skipped_file=True)
     with (
-        patch.object(FigmaClient, "__new__", return_value=mock_client),
+        patch("figmaclaw.commands.pull.FigmaClient", return_value=mock_client),
         patch("figmaclaw.commands.pull.pull_file", AsyncMock(return_value=no_access_result)),
     ):
         await _run("key", tmp_path, None, False, None, False, 10, None, "all")

--- a/tests/test_stream_format.py
+++ b/tests/test_stream_format.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from figmaclaw.main import cli
+
+
+def test_stream_format_ok_and_tool_lines(tmp_path: Path, monkeypatch) -> None:
+    summary = tmp_path / "summary.md"
+    monkeypatch.setenv("GITHUB_STEP_SUMMARY", str(summary))
+
+    msgs = [
+        {
+            "type": "system",
+            "model": "gpt",
+            "tools": ["Bash", "Read"],
+            "mcp_servers": [{"name": "plugin:figma", "status": "connected"}],
+            "permissionMode": "default",
+        },
+        {
+            "type": "assistant",
+            "message": {
+                "content": [
+                    {"type": "text", "text": "hello"},
+                    {"type": "tool_use", "name": "Bash", "input": {"command": "echo hi"}},
+                    {"type": "tool_use", "name": "Read", "input": {"file_path": "x.md"}},
+                ]
+            },
+        },
+        {"type": "result", "num_turns": 2, "duration_ms": 1200, "total_cost_usd": 0.1234},
+    ]
+    payload = "\n".join(json.dumps(m) for m in msgs) + "\n"
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["stream-format"], input=payload)
+
+    assert result.exit_code == 0
+    assert "[init]" in result.output
+    assert "  > Bash: echo hi" in result.output
+    assert "  > Read: x.md" in result.output
+    assert "[result] status=ok" in result.output
+    text = summary.read_text()
+    assert "claude-run result" in text
+    assert "$0.1234" in text
+
+
+def test_stream_format_error_exit_and_invalid_json_passthrough(tmp_path: Path, monkeypatch) -> None:
+    summary = tmp_path / "summary.md"
+    monkeypatch.setenv("GITHUB_STEP_SUMMARY", str(summary))
+
+    msgs = [
+        "not-json",
+        json.dumps({"type": "error", "error": "boom"}),
+        json.dumps({"type": "result", "is_error": True, "result": "failed", "duration_ms": 10}),
+    ]
+    payload = "\n".join(msgs) + "\n"
+
+    runner = CliRunner()
+    result = runner.invoke(cli, ["stream-format"], input=payload)
+
+    assert result.exit_code == 1
+    assert "not-json" in result.output
+    assert "[ERROR] boom" in result.output
+    assert "[error] failed" in result.output
+    assert "Errors" in summary.read_text()

--- a/uv.lock
+++ b/uv.lock
@@ -169,6 +169,15 @@ wheels = [
 ]
 
 [[package]]
+name = "execnet"
+version = "2.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bf/89/780e11f9588d9e7128a3f87788354c7946a9cbb1401ad38a48c4db9a4f07/execnet-2.1.2.tar.gz", hash = "sha256:63d83bfdd9a23e35b9c6a3261412324f964c2ec8dcd8d3c6916ee9373e0befcd", size = 166622, upload-time = "2025-11-12T09:56:37.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ab/84/02fc1827e8cdded4aa65baef11296a9bbe595c474f0d6d758af082d849fd/execnet-2.1.2-py3-none-any.whl", hash = "sha256:67fba928dd5a544b783f6056f449e5e3931a5c378b128bc18501f7ea79e296ec", size = 40708, upload-time = "2025-11-12T09:56:36.333Z" },
+]
+
+[[package]]
 name = "figmaclaw"
 version = "0.1.86"
 source = { editable = "." }
@@ -188,6 +197,7 @@ dev = [
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-httpx" },
+    { name = "pytest-xdist" },
     { name = "ruff" },
 ]
 
@@ -199,6 +209,7 @@ dev = [
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
     { name = "pytest-httpx" },
+    { name = "pytest-xdist" },
     { name = "respx" },
     { name = "ruff" },
 ]
@@ -213,6 +224,7 @@ requires-dist = [
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.3" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=1.3.0" },
     { name = "pytest-httpx", marker = "extra == 'dev'", specifier = ">=0.36.2" },
+    { name = "pytest-xdist", marker = "extra == 'dev'", specifier = ">=3.8.0" },
     { name = "python-frontmatter", specifier = ">=1.1" },
     { name = "pyyaml", specifier = ">=6.0.3" },
     { name = "rich", specifier = ">=13.7" },
@@ -228,6 +240,7 @@ dev = [
     { name = "pytest-asyncio", specifier = ">=1.3.0" },
     { name = "pytest-cov", specifier = ">=7.1.0" },
     { name = "pytest-httpx", specifier = ">=0.36.2" },
+    { name = "pytest-xdist", specifier = ">=3.8.0" },
     { name = "respx", specifier = ">=0.23.1" },
     { name = "ruff", specifier = ">=0.15.10" },
 ]
@@ -543,6 +556,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/4e/42/f53c58570e80d503ade9dd42ce57f2915d14bcbe25f6308138143950d1d6/pytest_httpx-0.36.2.tar.gz", hash = "sha256:05a56527484f7f4e8c856419ea379b8dc359c36801c4992fdb330f294c690356", size = 57683, upload-time = "2026-04-09T13:57:19.837Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1e/55/1fa65f8e4fceb19dd6daa867c162ad845d547f6058cd92b4b02384a44777/pytest_httpx-0.36.2-py3-none-any.whl", hash = "sha256:d42ebd5679442dc7bfb0c48e0767b6562e9bc4534d805127b0084171886a5e22", size = 20315, upload-time = "2026-04-09T13:57:18.587Z" },
+]
+
+[[package]]
+name = "pytest-xdist"
+version = "3.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "execnet" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/78/b4/439b179d1ff526791eb921115fca8e44e596a13efeda518b9d845a619450/pytest_xdist-3.8.0.tar.gz", hash = "sha256:7e578125ec9bc6050861aa93f2d59f1d8d085595d6551c2c90b6f4fad8d3a9f1", size = 88069, upload-time = "2025-07-01T13:30:59.346Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/31/d4e37e9e550c2b92a9cbc2e4d0b7420a27224968580b5a447f420847c975/pytest_xdist-3.8.0-py3-none-any.whl", hash = "sha256:202ca578cfeb7370784a8c33d6d05bc6e13b4f25b5053c30a152269fd10f0b88", size = 46396, upload-time = "2025-07-01T13:30:56.632Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Problem proved
### Root cause
1. Prior fix `#92` (`8322fb2`) only changed `claude_run` selection/requeue behavior (placeholder detection), not pull-write invariants.
2. `pull_file` still rewrote component markdown bodies during pull, so described rows could be replaced with `(no description yet)`.
3. A second root cause was uncovered by live smoke:
   - In `pull_logic`, `schema_only` path suppressed token scan/write even when sidecar backfill was required.
   - Result: missing/legacy sidecars were **not** repaired during schema-stale unchanged-page runs.

### Red tests (before fix)
- `tests/test_pull_logic.py::test_pull_file_preserves_existing_component_descriptions_on_changed_page`
- `tests/test_pull_logic.py::test_pull_file_migrates_legacy_component_path_without_losing_descriptions`
- `tests/test_pull_logic.py::test_pull_file_component_description_preservation_is_idempotent`

Command:
- `uv run pytest -q tests/test_pull_logic.py -k "preserves_existing_component_descriptions_on_changed_page or migrates_legacy_component_path_without_losing_descriptions or component_description_preservation_is_idempotent"`

Observed (before fix): 3 failures with component descriptions overwritten by `(no description yet)`.

Also reproduced live failures (before schema-only backfill fix):
- `test_pull_backfills_missing_sidecar_on_unchanged_page_real_api`
- `test_pull_migrates_legacy_sidecar_schema_on_unchanged_page_real_api`

## Fix implemented
### Code hardening
- `figmaclaw/pull_logic.py`
  - Preserve component file body prose by updating frontmatter only for existing component files.
  - DRY refactor: shared frontmatter/body rewrite helper used by both page and component frontmatter updates.
  - Fixed schema-stale sidecar bug:
    - token scan/write now runs when sidecar reconcile is needed, even in schema-only runs.
- `figmaclaw/figma_render.py`
  - Added reusable `build_component_frontmatter()` to centralize component frontmatter generation.

### Test hardening
- Added regression/idempotency tests for component body preservation:
  - changed-page preservation
  - legacy-path migration preservation
  - repeated-pull idempotency
- Added schema-stale sidecar regressions:
  - missing sidecar backfilled during schema-only run
  - legacy sidecar schema migrated during schema-only run
- Added tests for smoke credential gate and `.env` loader:
  - `tests/test_env_utils.py`
  - `tests/test_live_gate.py`

### Smoke/credential enforcement
- Added `tests/smoke/live_gate.py` for hard-fail credential checks.
- Added `tests/env_utils.py` and load logic in smoke gate for `.env` support.
- Removed silent skip behavior from live smoke credential paths (fail loudly on missing creds).
- Split smoke markers for explicit policy:
  - `smoke_api`, `smoke_webhook`, `smoke_mcp`.

### CI policy hardening
- `.github/workflows/ci.yml`:
  - Main test job excludes only live markers explicitly: `not smoke_api and not smoke_webhook and not smoke_mcp`.
  - Added dedicated `smoke-api` job with `FIGMACLAW_REQUIRE_LIVE_SMOKE=1` and required `FIGMA_API_KEY` secret.
  - Live smoke is now explicit and enforceable, not silently skipped by marker broad-brush.
- `pyproject.toml`:
  - Default pytest parallelism enabled via `addopts = "-n auto"`.
  - Added marker registry entries for smoke categories.
  - Added `pytest-xdist` dev dependency.

## Validation
### Green results after fixes
- Targeted component regressions:
  - `3 passed`
- Pull suite:
  - `78 passed`
- Non-live test suite (CI-equivalent marker selection):
  - `752 passed`
- Coverage gate command (CI-equivalent):
  - `752 passed`
  - total coverage `75.32%` (`--cov-fail-under=70` passes)
  - key modules:
    - `figmaclaw/pull_logic.py`: `93%`
    - `figmaclaw/figma_render.py`: `95%`

### Smoke enforcement proof
- With blank key, smoke fixture hard-fails (not skip):
  - `FIGMA_API_KEY='' uv run pytest -q tests/smoke/test_figma_api_smoke.py::test_get_file_meta_returns_version -rs`
  - Result: setup `Failed: FIGMA_API_KEY not set...`

### Previously broken live tests now green
- `uv run pytest -q tests/smoke/test_figma_api_smoke.py -k "test_pull_backfills_missing_sidecar_on_unchanged_page_real_api or test_pull_migrates_legacy_sidecar_schema_on_unchanged_page_real_api" -rs`
- Result: `2 passed`

## File-by-file summary
- `.github/workflows/ci.yml`
  - explicit live smoke job + explicit non-live marker selection
- `figmaclaw/pull_logic.py`
  - component body preservation + schema-only sidecar backfill fix + DRY helper
- `pyproject.toml`
  - default pytest parallelism, new smoke markers, xdist dependency
- `tests/smoke/test_figma_api_smoke.py`
  - marker split and hard-fail webhook-permission path
- `tests/smoke/test_figma_mcp_smoke.py`
  - marker split and hard-fail credential path
- `tests/test_inspect.py`
  - removed skip-only branch; deterministic assertion branch
- `tests/test_list_cmd.py`
  - deterministic env-clearing for key-missing test under parallel runs
- `tests/test_pull_logic.py`
  - added component/body/idempotency and schema-stale sidecar regressions
- `tests/env_utils.py` (new)
  - repo `.env` loader
- `tests/smoke/live_gate.py` (new)
  - fail-loud credential enforcement
- `tests/test_env_utils.py` (new)
  - `.env` loader tests
- `tests/test_live_gate.py` (new)
  - live gate behavior tests
- `uv.lock`
  - lock updates for xdist and transitive deps

## PRs / commits
- PR: https://github.com/aviadr1/figmaclaw/pull/96
- Commit `962b5a7`: preserve component markdown body across pull/path migration
- Commit `c72440d`: enforce live smoke, default parallel pytest, schema-stale sidecar backfill fix, and hardening tests

## Residual risks
1. `smoke_webhook` and `smoke_mcp` are now explicit categories but not yet required in CI by default.
   - Mitigation: add dedicated jobs once corresponding secrets/permissions are guaranteed in CI.
2. Live smoke runtime remains network-dependent.
   - Mitigation: keep non-live regression suite as primary deterministic gate, live smoke as explicit integration gate.
