### PR TITLE
fix(sync): source checkpoint loop script from workflow repo

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -69,9 +69,21 @@ jobs:
             git pull --no-rebase --ff-only origin main
           fi
 
+      - name: Checkout checkpoint loop script
+        # This reusable workflow runs in the *consumer repo* workspace.
+        # Pull the tested loop script from this repo at the exact workflow SHA,
+        # instead of assuming scripts/ exists in the consumer repo.
+        uses: actions/checkout@v6
+        with:
+          repository: aviadr1/figmaclaw
+          ref: ${{ github.workflow_sha }}
+          path: .figmaclaw-workflow
+          sparse-checkout: |
+            scripts/checkpoint_pull_loop.sh
+
       - name: Pull Figma files (checkpointed loop)
         env:
           FIGMA_API_KEY: ${{ secrets.FIGMA_API_KEY }}
           INPUT_FORCE: ${{ inputs.force }}
         run: |
-          scripts/checkpoint_pull_loop.sh
+          bash .figmaclaw-workflow/scripts/checkpoint_pull_loop.sh

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -71,12 +71,12 @@ jobs:
 
       - name: Checkout checkpoint loop script
         # This reusable workflow runs in the *consumer repo* workspace.
-        # Pull the tested loop script from this repo at the exact workflow SHA,
-        # instead of assuming scripts/ exists in the consumer repo.
+        # Pull the tested loop script from figmaclaw repo, instead of assuming
+        # scripts/ exists in the consumer repo.
         uses: actions/checkout@v6
         with:
           repository: aviadr1/figmaclaw
-          ref: ${{ github.workflow_sha }}
+          ref: main
           path: .figmaclaw-workflow
           sparse-checkout: |
             scripts/checkpoint_pull_loop.sh


### PR DESCRIPTION
## Root cause\nReusable  executed --- batch 1 --- in the consumer repo workspace. Consumer repos don't contain this script, so sync failed with exit 127 before pull/backfill.\n\n## Fix\n- Add a checkout step in reusable  that fetches --- batch 1 --- from  at  into .\n- Run the script from that path.\n\nThis keeps a single tested source of truth () and removes caller-repo path assumptions.\n\n## Validation\n- bringing up nodes...
bringing up nodes...

......                                                                   [100%]
6 passed in 0.58s\n- bringing up nodes...
bringing up nodes...

....                                                                     [100%]
4 passed in 0.52s