### PR TITLE
fix: prune orphan census files and unify slug/state handling

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -69,9 +69,21 @@ jobs:
             git pull --no-rebase --ff-only origin main
           fi
 
+      - name: Checkout checkpoint loop script
+        # This reusable workflow runs in the *consumer repo* workspace.
+        # Pull the tested loop script from this repo at the exact workflow SHA,
+        # instead of assuming scripts/ exists in the consumer repo.
+        uses: actions/checkout@v6
+        with:
+          repository: aviadr1/figmaclaw
+          ref: ${{ github.workflow_sha }}
+          path: .figmaclaw-workflow
+          sparse-checkout: |
+            scripts/checkpoint_pull_loop.sh
+
       - name: Pull Figma files (checkpointed loop)
         env:
           FIGMA_API_KEY: ${{ secrets.FIGMA_API_KEY }}
           INPUT_FORCE: ${{ inputs.force }}
         run: |
-          scripts/checkpoint_pull_loop.sh
+          bash .figmaclaw-workflow/scripts/checkpoint_pull_loop.sh

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -71,12 +71,12 @@ jobs:
 
       - name: Checkout checkpoint loop script
         # This reusable workflow runs in the *consumer repo* workspace.
-        # Pull the tested loop script from this repo at the exact workflow SHA,
-        # instead of assuming scripts/ exists in the consumer repo.
+        # Pull the tested loop script from figmaclaw repo, instead of assuming
+        # scripts/ exists in the consumer repo.
         uses: actions/checkout@v6
         with:
           repository: aviadr1/figmaclaw
-          ref: ${{ github.workflow_sha }}
+          ref: main
           path: .figmaclaw-workflow
           sparse-checkout: |
             scripts/checkpoint_pull_loop.sh

--- a/figmaclaw/commands/_shared.py
+++ b/figmaclaw/commands/_shared.py
@@ -1,0 +1,33 @@
+"""Shared command helpers for figmaclaw command modules."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import click
+
+from figmaclaw.figma_sync_state import FigmaSyncState
+
+
+def require_figma_api_key() -> str:
+    """Return FIGMA_API_KEY or raise a consistent usage error."""
+    api_key = os.environ.get("FIGMA_API_KEY", "")
+    if not api_key:
+        raise click.UsageError("FIGMA_API_KEY environment variable is not set.")
+    return api_key
+
+
+def load_state(repo_dir: Path) -> FigmaSyncState:
+    """Load and return Figma sync state for this repo."""
+    state = FigmaSyncState(repo_dir)
+    state.load()
+    return state
+
+
+def require_tracked_files(state: FigmaSyncState) -> bool:
+    """Return False with a standard message when no tracked files exist."""
+    if state.manifest.tracked_files:
+        return True
+    click.echo("No tracked files. Run 'figmaclaw track <file-key>' first.")
+    return False

--- a/figmaclaw/commands/_shared.py
+++ b/figmaclaw/commands/_shared.py
@@ -9,12 +9,16 @@ import click
 
 from figmaclaw.figma_sync_state import FigmaSyncState
 
+FIGMA_API_KEY_ENV = "FIGMA_API_KEY"
+FIGMA_WEBHOOK_SECRET_ENV = "FIGMA_WEBHOOK_SECRET"
+FIGMA_WEBHOOK_PAYLOAD_ENV = "FIGMA_WEBHOOK_PAYLOAD"
+
 
 def require_figma_api_key() -> str:
     """Return FIGMA_API_KEY or raise a consistent usage error."""
-    api_key = os.environ.get("FIGMA_API_KEY", "")
+    api_key = os.environ.get(FIGMA_API_KEY_ENV, "")
     if not api_key:
-        raise click.UsageError("FIGMA_API_KEY environment variable is not set.")
+        raise click.UsageError(f"{FIGMA_API_KEY_ENV} environment variable is not set.")
     return api_key
 
 

--- a/figmaclaw/commands/apply_webhook.py
+++ b/figmaclaw/commands/apply_webhook.py
@@ -9,7 +9,12 @@ from pathlib import Path
 
 import click
 
-from figmaclaw.commands._shared import load_state, require_figma_api_key
+from figmaclaw.commands._shared import (
+    FIGMA_WEBHOOK_PAYLOAD_ENV,
+    FIGMA_WEBHOOK_SECRET_ENV,
+    load_state,
+    require_figma_api_key,
+)
 from figmaclaw.commands.pull import _git_commit_page
 from figmaclaw.figma_client import FigmaClient
 from figmaclaw.git_utils import git_push as _git_push
@@ -37,11 +42,11 @@ def apply_webhook_cmd(ctx: click.Context, auto_commit: bool, push_every: int) ->
     repo_dir = Path(ctx.obj["repo_dir"])
     api_key = require_figma_api_key()
 
-    payload = os.environ.get("FIGMA_WEBHOOK_PAYLOAD", "")
+    payload = os.environ.get(FIGMA_WEBHOOK_PAYLOAD_ENV, "")
     if not payload:
-        raise click.UsageError("FIGMA_WEBHOOK_PAYLOAD environment variable is not set.")
+        raise click.UsageError(f"{FIGMA_WEBHOOK_PAYLOAD_ENV} environment variable is not set.")
 
-    webhook_secret = os.environ.get("FIGMA_WEBHOOK_SECRET") or None
+    webhook_secret = os.environ.get(FIGMA_WEBHOOK_SECRET_ENV) or None
 
     try:
         asyncio.run(

--- a/figmaclaw/commands/apply_webhook.py
+++ b/figmaclaw/commands/apply_webhook.py
@@ -9,9 +9,9 @@ from pathlib import Path
 
 import click
 
+from figmaclaw.commands._shared import load_state, require_figma_api_key
 from figmaclaw.commands.pull import _git_commit_page
 from figmaclaw.figma_client import FigmaClient
-from figmaclaw.figma_sync_state import FigmaSyncState
 from figmaclaw.git_utils import git_push as _git_push
 from figmaclaw.prune_utils import prune_file_artifacts_from_manifest
 from figmaclaw.pull_logic import pull_file
@@ -35,9 +35,7 @@ class WebhookAuthError(Exception):
 def apply_webhook_cmd(ctx: click.Context, auto_commit: bool, push_every: int) -> None:
     """Process a Figma webhook payload from FIGMA_WEBHOOK_PAYLOAD env var."""
     repo_dir = Path(ctx.obj["repo_dir"])
-    api_key = os.environ.get("FIGMA_API_KEY", "")
-    if not api_key:
-        raise click.UsageError("FIGMA_API_KEY environment variable is not set.")
+    api_key = require_figma_api_key()
 
     payload = os.environ.get("FIGMA_WEBHOOK_PAYLOAD", "")
     if not payload:
@@ -83,8 +81,7 @@ async def _run(
         click.echo("Webhook payload missing file_key/file_id — skipping.")
         return
 
-    state = FigmaSyncState(repo_dir)
-    state.load()
+    state = load_state(repo_dir)
 
     if event_type == "FILE_DELETE":
         had_file = file_key in state.manifest.files or file_key in state.manifest.tracked_files

--- a/figmaclaw/commands/apply_webhook.py
+++ b/figmaclaw/commands/apply_webhook.py
@@ -20,6 +20,7 @@ from figmaclaw.figma_client import FigmaClient
 from figmaclaw.git_utils import git_push as _git_push
 from figmaclaw.prune_utils import prune_file_artifacts_from_manifest
 from figmaclaw.pull_logic import pull_file
+from figmaclaw.status_markers import COMMIT_MSG_PREFIX
 
 
 class WebhookAuthError(Exception):
@@ -100,7 +101,9 @@ async def _run(
         if had_file:
             state.manifest.skipped_files[file_key] = "deleted via FILE_DELETE webhook"
             state.save()
-            click.echo(f"COMMIT_MSG:sync: figmaclaw apply-webhook — file deleted [{file_key}]")
+            click.echo(
+                f"{COMMIT_MSG_PREFIX}sync: figmaclaw apply-webhook — file deleted [{file_key}]"
+            )
             click.echo(f"{file_key}: pruned {removed_paths} generated path(s) after FILE_DELETE.")
         else:
             click.echo(f"File {file_key!r} is not tracked — skipping.")
@@ -137,6 +140,8 @@ async def _run(
 
     if result.pages_written > 0:
         n = result.pages_written
-        click.echo(f"COMMIT_MSG:sync: figmaclaw apply-webhook — {n} page(s) updated [{file_key}]")
+        click.echo(
+            f"{COMMIT_MSG_PREFIX}sync: figmaclaw apply-webhook — {n} page(s) updated [{file_key}]"
+        )
     else:
         click.echo(f"{file_key}: no pages changed.")

--- a/figmaclaw/commands/build_context.py
+++ b/figmaclaw/commands/build_context.py
@@ -25,11 +25,11 @@ from __future__ import annotations
 
 import asyncio
 import json
-import os
 from pathlib import Path
 
 import click
 
+from figmaclaw.commands._shared import require_figma_api_key
 from figmaclaw.figma_client import FigmaClient
 from figmaclaw.figma_mcp import FigmaMcpError
 from figmaclaw.figma_parse import parse_frontmatter
@@ -113,9 +113,7 @@ def build_context_cmd(
     Fetches SVG or PNG for each section via the Figma REST API.
     Outputs JSON call specs by default; executes them with --execute.
     """
-    api_key = os.environ.get("FIGMA_API_KEY", "")
-    if not api_key:
-        raise click.UsageError("FIGMA_API_KEY environment variable is not set.")
+    api_key = require_figma_api_key()
     if not execute_calls and (resume_from != 0 or continue_on_error):
         raise click.UsageError("--resume-from/--continue-on-error require --execute")
 

--- a/figmaclaw/commands/census.py
+++ b/figmaclaw/commands/census.py
@@ -47,7 +47,7 @@ import click
 import yaml
 
 from figmaclaw.figma_client import FigmaClient
-from figmaclaw.figma_paths import census_path, slugify
+from figmaclaw.figma_paths import census_path, file_slug_for_key
 from figmaclaw.figma_sync_state import FigmaSyncState
 from figmaclaw.git_utils import git_commit
 
@@ -190,7 +190,7 @@ async def _run(
 
             file_entry = state.manifest.files.get(key)
             file_name = file_entry.file_name if file_entry else key
-            file_slug = slugify(file_name, fallback=key)
+            file_slug = file_slug_for_key(file_name, key)
 
             try:
                 component_sets = await client.get_component_sets(key)

--- a/figmaclaw/commands/census.py
+++ b/figmaclaw/commands/census.py
@@ -49,6 +49,7 @@ from figmaclaw.commands._shared import load_state, require_figma_api_key, requir
 from figmaclaw.figma_client import FigmaClient
 from figmaclaw.figma_paths import census_path, file_slug_for_key
 from figmaclaw.git_utils import git_commit
+from figmaclaw.status_markers import COMMIT_MSG_PREFIX
 
 # ── Hash ─────────────────────────────────────────────────────────────────────
 
@@ -231,4 +232,4 @@ async def _run(
                     click.echo("  ✓ committed")
 
     if written:
-        click.echo(f"COMMIT_MSG:sync: figmaclaw census — {len(written)} file(s) updated")
+        click.echo(f"{COMMIT_MSG_PREFIX}sync: figmaclaw census — {len(written)} file(s) updated")

--- a/figmaclaw/commands/census.py
+++ b/figmaclaw/commands/census.py
@@ -38,7 +38,6 @@ from __future__ import annotations
 import asyncio
 import hashlib
 import json
-import os
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
@@ -46,9 +45,9 @@ from typing import Any
 import click
 import yaml
 
+from figmaclaw.commands._shared import load_state, require_figma_api_key, require_tracked_files
 from figmaclaw.figma_client import FigmaClient
 from figmaclaw.figma_paths import census_path, file_slug_for_key
-from figmaclaw.figma_sync_state import FigmaSyncState
 from figmaclaw.git_utils import git_commit
 
 # ── Hash ─────────────────────────────────────────────────────────────────────
@@ -153,9 +152,7 @@ def census_cmd(
     component sets. Only updates the file when the component registry changes.
     """
     repo_dir = Path(ctx.obj["repo_dir"])
-    api_key = os.environ.get("FIGMA_API_KEY", "")
-    if not api_key:
-        raise click.UsageError("FIGMA_API_KEY environment variable is not set.")
+    api_key = require_figma_api_key()
 
     asyncio.run(_run(api_key, repo_dir, file_key, auto_commit, force))
 
@@ -167,11 +164,8 @@ async def _run(
     auto_commit: bool,
     force: bool,
 ) -> None:
-    state = FigmaSyncState(repo_dir)
-    state.load()
-
-    if not state.manifest.tracked_files:
-        click.echo("No tracked files. Run 'figmaclaw track <file-key>' first.")
+    state = load_state(repo_dir)
+    if not require_tracked_files(state):
         return
 
     keys = [file_key] if file_key else list(state.manifest.tracked_files)

--- a/figmaclaw/commands/diff.py
+++ b/figmaclaw/commands/diff.py
@@ -13,7 +13,6 @@ from __future__ import annotations
 
 import asyncio
 import json
-import os
 import re
 from dataclasses import dataclass, field
 from datetime import UTC, datetime, timedelta
@@ -22,6 +21,7 @@ from typing import Any
 
 import click
 
+from figmaclaw.commands._shared import require_figma_api_key
 from figmaclaw.figma_api_models import VersionSummary
 from figmaclaw.figma_client import FigmaClient
 from figmaclaw.figma_models import FigmaFrame, from_page_node
@@ -579,9 +579,7 @@ def diff_cmd(
 
     TARGET is the directory with tracked .md files (default: figma/).
     """
-    api_key = os.environ.get("FIGMA_API_KEY", "")
-    if not api_key:
-        raise click.ClickException("FIGMA_API_KEY environment variable is not set.")
+    api_key = require_figma_api_key()
 
     repo_dir = Path(ctx.obj["repo_dir"])
     resolved = repo_dir / target

--- a/figmaclaw/commands/image_urls.py
+++ b/figmaclaw/commands/image_urls.py
@@ -8,15 +8,14 @@ from __future__ import annotations
 
 import asyncio
 import json
-import os
 from pathlib import Path
 
 import click
 
+from figmaclaw.commands._shared import require_figma_api_key
 from figmaclaw.figma_client import FigmaClient
 from figmaclaw.figma_parse import parse_frontmatter
-
-_FIGMA_IMAGE_BATCH = 50
+from figmaclaw.image_export import DEFAULT_IMAGE_BATCH_SIZE, get_image_urls_batched
 
 
 @click.command("image-urls")
@@ -56,9 +55,7 @@ def image_urls_cmd(
 
     Output: {"file_key": "...", "images": {"node_id": "url", ...}}
     """
-    api_key = os.environ.get("FIGMA_API_KEY", "")
-    if not api_key:
-        raise click.UsageError("FIGMA_API_KEY environment variable is not set.")
+    api_key = require_figma_api_key()
 
     repo_dir = Path(ctx.obj["repo_dir"])
     result = asyncio.run(_run(api_key, repo_dir, md_path, nodes, scale, img_format))
@@ -94,15 +91,13 @@ async def _run(
         return {"file_key": file_key, "images": {}}
 
     async with FigmaClient(api_key) as client:
-        all_urls: dict[str, str | None] = {}
-        for i in range(0, len(node_ids), _FIGMA_IMAGE_BATCH):
-            batch = node_ids[i : i + _FIGMA_IMAGE_BATCH]
-            urls = await client.get_image_urls(
-                file_key,
-                batch,
-                scale=scale,
-                format=img_format,
-            )
-            all_urls.update(urls)
+        all_urls = await get_image_urls_batched(
+            client,
+            file_key,
+            node_ids,
+            batch_size=DEFAULT_IMAGE_BATCH_SIZE,
+            scale=scale,
+            format=img_format,
+        )
 
     return {"file_key": file_key, "images": all_urls}

--- a/figmaclaw/commands/inspect.py
+++ b/figmaclaw/commands/inspect.py
@@ -28,6 +28,7 @@ from figmaclaw.figma_md_parse import section_line_ranges
 from figmaclaw.figma_parse import parse_frontmatter
 from figmaclaw.figma_schema import is_placeholder_row
 from figmaclaw.schema_status import enrichment_schema_status, is_pull_schema_stale
+from figmaclaw.staleness import stale_frame_ids_from_manifest
 
 SECTION_THRESHOLD = 80
 
@@ -61,24 +62,13 @@ def _stale_frame_ids(
     except Exception:
         return set()  # no manifest — can't determine staleness
 
-    file_entry = state.manifest.files.get(file_key)
-    if file_entry is None:
-        return set()
-    page_entry = file_entry.pages.get(page_node_id)
-    if page_entry is None:
-        return set()
-
-    current = page_entry.frame_hashes
-    enriched = enriched_frame_hashes or {}
-    stale: set[str] = set()
-    for nid, h in current.items():
-        if nid not in enriched or enriched[nid] != h:
-            stale.add(nid)
-    # Also frames in enriched but not in current (removed frames)
-    for nid in enriched:
-        if nid not in current:
-            stale.add(nid)
-    return stale
+    stale = stale_frame_ids_from_manifest(
+        state,
+        file_key=file_key,
+        page_node_id=page_node_id,
+        enriched_frame_hashes=enriched_frame_hashes,
+    )
+    return stale or set()
 
 
 @click.command("inspect")

--- a/figmaclaw/commands/inspect.py
+++ b/figmaclaw/commands/inspect.py
@@ -18,6 +18,7 @@ from pathlib import Path
 
 import click
 
+from figmaclaw.commands._shared import load_state
 from figmaclaw.figma_frontmatter import (
     CURRENT_ENRICHMENT_SCHEMA_VERSION,
     CURRENT_PULL_SCHEMA_VERSION,
@@ -26,6 +27,7 @@ from figmaclaw.figma_frontmatter import (
 from figmaclaw.figma_md_parse import section_line_ranges
 from figmaclaw.figma_parse import parse_frontmatter
 from figmaclaw.figma_schema import is_placeholder_row
+from figmaclaw.schema_status import enrichment_schema_status, is_pull_schema_stale
 
 SECTION_THRESHOLD = 80
 
@@ -166,20 +168,17 @@ def inspect_cmd(
 
     # Schema staleness: pull-pass frontmatter fields
     try:
-        from figmaclaw.figma_sync_state import FigmaSyncState as _FSS
-
-        _state = _FSS(repo_dir)
-        _state.load()
-        _file_entry = _state.manifest.files.get(meta.file_key)
-        file_pull_schema_version = _file_entry.pull_schema_version if _file_entry else 0
+        file_entry = load_state(repo_dir).manifest.files.get(meta.file_key)
+        file_pull_schema_version = file_entry.pull_schema_version if file_entry else 0
     except Exception:
         file_pull_schema_version = 0
-    pull_schema_stale = file_pull_schema_version < CURRENT_PULL_SCHEMA_VERSION
+    pull_schema_stale = is_pull_schema_stale(file_pull_schema_version)
 
     # Schema staleness: enrichment prompt/format
-    esv = meta.enriched_schema_version  # 0 if pre-versioning or never enriched
-    enrichment_must_update = esv < MIN_REQUIRED_ENRICHMENT_SCHEMA_VERSION
-    enrichment_should_update = esv < CURRENT_ENRICHMENT_SCHEMA_VERSION
+    enrichment = enrichment_schema_status(meta.enriched_schema_version)
+    esv = enrichment.version  # 0 if pre-versioning or never enriched
+    enrichment_must_update = enrichment.must_update
+    enrichment_should_update = enrichment.should_update
 
     needs_enrichment = (
         has_placeholders

--- a/figmaclaw/commands/list_files.py
+++ b/figmaclaw/commands/list_files.py
@@ -3,14 +3,13 @@
 from __future__ import annotations
 
 import asyncio
-import os
 from datetime import datetime
 from pathlib import Path
 
 import click
 
+from figmaclaw.commands._shared import load_state, require_figma_api_key
 from figmaclaw.figma_client import FigmaClient
-from figmaclaw.figma_sync_state import FigmaSyncState
 from figmaclaw.figma_utils import parse_since, parse_team_id_from_url
 
 
@@ -35,9 +34,7 @@ def list_cmd(
 ) -> None:
     """List Figma files for a team, optionally filtered by last-modified date."""
     repo_dir = Path(ctx.obj["repo_dir"])
-    api_key = os.environ.get("FIGMA_API_KEY", "")
-    if not api_key:
-        raise click.UsageError("FIGMA_API_KEY environment variable is not set.")
+    api_key = require_figma_api_key()
 
     team_id = parse_team_id_from_url(team_id_or_url)
     since_dt: datetime | None = None
@@ -60,8 +57,7 @@ async def _run(
 ) -> None:
     from figmaclaw.pull_logic import pull_file
 
-    state = FigmaSyncState(repo_dir)
-    state.load()
+    state = load_state(repo_dir)
     tracked = set(state.manifest.tracked_files)
 
     async with FigmaClient(api_key) as client:

--- a/figmaclaw/commands/pull.py
+++ b/figmaclaw/commands/pull.py
@@ -4,11 +4,11 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
-import os
 from pathlib import Path
 
 import click
 
+from figmaclaw.commands._shared import load_state, require_figma_api_key, require_tracked_files
 from figmaclaw.figma_api_models import FileSummary, ProjectSummary
 from figmaclaw.figma_client import FigmaClient
 from figmaclaw.figma_sync_state import FigmaSyncState
@@ -77,9 +77,7 @@ def pull_cmd(
 ) -> None:
     """Pull all tracked Figma files and write changed pages to disk."""
     repo_dir = Path(ctx.obj["repo_dir"])
-    api_key = os.environ.get("FIGMA_API_KEY", "")
-    if not api_key:
-        raise click.UsageError("FIGMA_API_KEY environment variable is not set.")
+    api_key = require_figma_api_key()
 
     asyncio.run(
         _run(
@@ -183,8 +181,7 @@ async def _run(
     since: str,
     prune: bool = True,
 ) -> None:
-    state = FigmaSyncState(repo_dir)
-    state.load()
+    state = load_state(repo_dir)
 
     commit_count = 0
 
@@ -214,8 +211,7 @@ async def _run(
             listing_last_modified = await _listing_prefilter(client, team_id, state, since)
             state.save()  # persist any newly tracked files before pulling
 
-        if not state.manifest.tracked_files:
-            click.echo("No tracked files. Run 'figmaclaw track <file-key>' first.")
+        if not require_tracked_files(state):
             return
 
         keys = [file_key] if file_key else list(state.manifest.tracked_files)

--- a/figmaclaw/commands/pull.py
+++ b/figmaclaw/commands/pull.py
@@ -16,6 +16,7 @@ from figmaclaw.figma_utils import parse_since
 from figmaclaw.git_utils import git_commit, git_push
 from figmaclaw.prune_utils import prune_file_artifacts_from_manifest
 from figmaclaw.pull_logic import PullResult, pull_file
+from figmaclaw.status_markers import COMMIT_MSG_PREFIX, HAS_MORE_TRUE
 
 
 @click.command("pull")
@@ -321,7 +322,7 @@ async def _run(
         if total_schema_upgraded and not total_written:
             # Schema-only run: use a different verb so it's recognizable in git log
             parts.append(f"{total_schema_upgraded} page(s) schema-upgraded")
-        click.echo(f"COMMIT_MSG:sync: figmaclaw pull — {', '.join(parts)} updated")
+        click.echo(f"{COMMIT_MSG_PREFIX}sync: figmaclaw pull — {', '.join(parts)} updated")
 
     if has_more_global:
-        click.echo("HAS_MORE:true")
+        click.echo(HAS_MORE_TRUE)

--- a/figmaclaw/commands/screenshots.py
+++ b/figmaclaw/commands/screenshots.py
@@ -26,6 +26,7 @@ from figmaclaw.figma_md_parse import parse_sections
 from figmaclaw.figma_parse import parse_frontmatter
 from figmaclaw.figma_paths import screenshot_cache_path
 from figmaclaw.image_export import DEFAULT_IMAGE_BATCH_SIZE, get_image_urls_batched
+from figmaclaw.staleness import stale_frame_ids_from_manifest
 
 _MAX_CONCURRENT_DOWNLOADS = 10
 _DOWNLOAD_LOCK_FILENAME = ".figma-downloads.lock"
@@ -118,21 +119,13 @@ async def _run(
         # Compare manifest frame_hashes (current) vs frontmatter
         # enriched_frame_hashes (at last enrichment).
         state = load_state(repo_dir)
-        stale_ids: set[str] = set()
-        manifest_file = state.manifest.files.get(file_key)
-        if manifest_file:
-            page_entry = manifest_file.pages.get(fm.page_node_id)
-            if page_entry:
-                current_hashes = page_entry.frame_hashes
-                enriched_hashes = fm.enriched_frame_hashes or {}
-                for nid, h in current_hashes.items():
-                    if nid not in enriched_hashes or enriched_hashes[nid] != h:
-                        stale_ids.add(nid)
-                # Also include frames with no hash at all (new frames)
-                for nid in all_body_ids:
-                    if nid not in enriched_hashes:
-                        stale_ids.add(nid)
-        else:
+        stale_ids = stale_frame_ids_from_manifest(
+            state,
+            file_key=file_key,
+            page_node_id=fm.page_node_id,
+            enriched_frame_hashes=fm.enriched_frame_hashes,
+        )
+        if stale_ids is None:
             # No manifest entry — all frames are stale
             stale_ids = set(all_body_ids)
         node_ids = [nid for nid in all_body_ids if nid in stale_ids]

--- a/figmaclaw/commands/screenshots.py
+++ b/figmaclaw/commands/screenshots.py
@@ -98,15 +98,16 @@ async def _run(
         )
 
     file_key = fm.file_key
+    sections = parse_sections(md_text)
 
     # Node IDs come from the body (parse_sections) — covers pages where fm.frames
     # is empty because no descriptions have been written yet.
-    all_body_ids = [f.node_id for s in parse_sections(md_text) for f in s.frames]
+    all_body_ids = [f.node_id for s in sections for f in s.frames]
 
     # Section filter: restrict to frames in one section
     if section_node_id:
         section_frames: set[str] = set()
-        for s in parse_sections(md_text):
+        for s in sections:
             if s.node_id == section_node_id:
                 section_frames = {f.node_id for f in s.frames}
                 break

--- a/figmaclaw/commands/screenshots.py
+++ b/figmaclaw/commands/screenshots.py
@@ -15,18 +15,18 @@ from __future__ import annotations
 import asyncio
 import fcntl
 import json
-import os
 from pathlib import Path
 from typing import Any
 
 import click
 
+from figmaclaw.commands._shared import load_state, require_figma_api_key
 from figmaclaw.figma_client import FigmaClient
 from figmaclaw.figma_md_parse import parse_sections
 from figmaclaw.figma_parse import parse_frontmatter
 from figmaclaw.figma_paths import screenshot_cache_path
+from figmaclaw.image_export import DEFAULT_IMAGE_BATCH_SIZE, get_image_urls_batched
 
-_FIGMA_IMAGE_BATCH = 50
 _MAX_CONCURRENT_DOWNLOADS = 10
 _DOWNLOAD_LOCK_FILENAME = ".figma-downloads.lock"
 
@@ -71,9 +71,7 @@ def screenshots_cmd(
     MCP plugins are unavailable.
     """
     repo_dir = Path(ctx.obj["repo_dir"])
-    api_key = os.environ.get("FIGMA_API_KEY", "")
-    if not api_key:
-        raise click.UsageError("FIGMA_API_KEY environment variable is not set.")
+    api_key = require_figma_api_key()
 
     result = asyncio.run(
         _run(api_key, repo_dir, md_path, pending_only, stale_only, section_node_id)
@@ -118,10 +116,7 @@ async def _run(
         # Stale = frames whose content hash changed since last enrichment.
         # Compare manifest frame_hashes (current) vs frontmatter
         # enriched_frame_hashes (at last enrichment).
-        from figmaclaw.figma_sync_state import FigmaSyncState
-
-        state = FigmaSyncState(repo_dir)
-        state.load()
+        state = load_state(repo_dir)
         stale_ids: set[str] = set()
         manifest_file = state.manifest.files.get(file_key)
         if manifest_file:
@@ -176,15 +171,13 @@ async def _run(
     lock_fd = await asyncio.to_thread(_acquire)
     try:
         async with FigmaClient(api_key) as client:
-            all_urls: dict[str, str | None] = {}
-            for i in range(0, len(node_ids), _FIGMA_IMAGE_BATCH):
-                batch = node_ids[i : i + _FIGMA_IMAGE_BATCH]
-                try:
-                    urls = await client.get_image_urls(file_key, batch)
-                except Exception:
-                    # API error for this batch — mark all as failed
-                    urls = {nid: None for nid in batch}
-                all_urls.update(urls)
+            all_urls = await get_image_urls_batched(
+                client,
+                file_key,
+                node_ids,
+                batch_size=DEFAULT_IMAGE_BATCH_SIZE,
+                fill_none_on_batch_error=True,
+            )
 
             semaphore = asyncio.Semaphore(_MAX_CONCURRENT_DOWNLOADS)
             tasks = [

--- a/figmaclaw/commands/sync.py
+++ b/figmaclaw/commands/sync.py
@@ -30,17 +30,17 @@ from __future__ import annotations
 
 import asyncio
 import datetime
-import os
 from pathlib import Path
 
 import click
 
+from figmaclaw.commands._shared import load_state, require_figma_api_key
 from figmaclaw.figma_client import FigmaClient
 from figmaclaw.figma_hash import compute_frame_hashes, compute_page_hash
 from figmaclaw.figma_models import from_page_node
 from figmaclaw.figma_parse import parse_flows, parse_frontmatter, split_frontmatter
 from figmaclaw.figma_render import scaffold_page
-from figmaclaw.figma_sync_state import FigmaSyncState, PageEntry
+from figmaclaw.figma_sync_state import PageEntry
 from figmaclaw.git_utils import git_commit
 from figmaclaw.pull_logic import _merge_existing, update_page_frontmatter, write_new_page
 
@@ -74,9 +74,7 @@ def sync_cmd(
     To also generate descriptions, use:  figmaclaw inspect + figma-enrich-page skill
     """
     repo_dir = Path(ctx.obj["repo_dir"])
-    api_key = os.environ.get("FIGMA_API_KEY", "")
-    if not api_key:
-        raise click.UsageError("FIGMA_API_KEY environment variable is not set.")
+    api_key = require_figma_api_key()
 
     asyncio.run(_run(api_key, repo_dir, md_path, auto_commit, show_scaffold, show_body))
 
@@ -106,8 +104,7 @@ async def _run(
     click.echo(f"sync: {md_rel}")
     click.echo(f"  file_key={file_key}  page_node_id={page_node_id}")
 
-    state = FigmaSyncState(repo_dir)
-    state.load()
+    state = load_state(repo_dir)
 
     async with FigmaClient(api_key) as client:
         try:

--- a/figmaclaw/commands/sync.py
+++ b/figmaclaw/commands/sync.py
@@ -198,7 +198,11 @@ async def _run(
     state.set_page_entry(file_key, page_node_id, entry)
     if state.manifest.files.get(file_key):
         state.set_file_meta(
-            file_key, version=api_version, last_modified=api_last_modified, last_checked_at=now
+            file_key,
+            version=api_version,
+            last_modified=api_last_modified,
+            last_checked_at=now,
+            file_name=file_name,
         )
     state.save()
     click.echo(f"  manifest updated (hash={new_hash})")

--- a/figmaclaw/commands/track.py
+++ b/figmaclaw/commands/track.py
@@ -3,13 +3,12 @@
 from __future__ import annotations
 
 import asyncio
-import os
 from pathlib import Path
 
 import click
 
+from figmaclaw.commands._shared import load_state, require_figma_api_key
 from figmaclaw.figma_client import FigmaClient
-from figmaclaw.figma_sync_state import FigmaSyncState
 from figmaclaw.pull_logic import pull_file
 
 
@@ -20,16 +19,13 @@ from figmaclaw.pull_logic import pull_file
 def track_cmd(ctx: click.Context, file_key: str, no_pull: bool) -> None:
     """Register a Figma file for syncing and run an initial pull."""
     repo_dir = Path(ctx.obj["repo_dir"])
-    api_key = os.environ.get("FIGMA_API_KEY", "")
-    if not api_key:
-        raise click.UsageError("FIGMA_API_KEY environment variable is not set.")
+    api_key = require_figma_api_key()
 
     asyncio.run(_run(api_key, repo_dir, file_key, no_pull))
 
 
 async def _run(api_key: str, repo_dir: Path, file_key: str, no_pull: bool) -> None:
-    state = FigmaSyncState(repo_dir)
-    state.load()
+    state = load_state(repo_dir)
 
     async with FigmaClient(api_key) as client:
         # Validate the file exists and get its name

--- a/figmaclaw/commands/webhooks.py
+++ b/figmaclaw/commands/webhooks.py
@@ -45,6 +45,7 @@ from typing import Any, Protocol
 
 import click
 
+from figmaclaw.commands._shared import require_figma_api_key
 from figmaclaw.figma_client import FigmaClient
 from figmaclaw.figma_models import ValidationReport, Webhook
 from figmaclaw.figma_sync_state import FigmaSyncState
@@ -82,10 +83,7 @@ def _load_tracked_files(repo_dir: Path) -> list[str]:
 
 
 def _require_api_key() -> str:
-    api_key = os.environ.get("FIGMA_API_KEY", "")
-    if not api_key:
-        raise click.UsageError("FIGMA_API_KEY environment variable is not set.")
-    return api_key
+    return require_figma_api_key()
 
 
 def _require_passcode() -> str:

--- a/figmaclaw/commands/webhooks.py
+++ b/figmaclaw/commands/webhooks.py
@@ -45,7 +45,11 @@ from typing import Any, Protocol
 
 import click
 
-from figmaclaw.commands._shared import load_state, require_figma_api_key
+from figmaclaw.commands._shared import (
+    FIGMA_WEBHOOK_SECRET_ENV,
+    load_state,
+    require_figma_api_key,
+)
 from figmaclaw.figma_client import FigmaClient
 from figmaclaw.figma_models import ValidationReport, Webhook
 
@@ -85,9 +89,11 @@ def _require_api_key() -> str:
 
 
 def _require_passcode() -> str:
-    passcode = os.environ.get("FIGMA_WEBHOOK_SECRET", "")
+    passcode = os.environ.get(FIGMA_WEBHOOK_SECRET_ENV, "")
     if not passcode:
-        click.echo("Warning: FIGMA_WEBHOOK_SECRET not set — passcode will be empty", err=True)
+        click.echo(
+            f"Warning: {FIGMA_WEBHOOK_SECRET_ENV} not set — passcode will be empty", err=True
+        )
     return passcode
 
 

--- a/figmaclaw/commands/webhooks.py
+++ b/figmaclaw/commands/webhooks.py
@@ -40,6 +40,7 @@ import asyncio
 import os
 import sys
 from collections import defaultdict
+from collections.abc import Awaitable, Callable
 from pathlib import Path
 from typing import Any, Protocol
 
@@ -337,21 +338,30 @@ def _run(coro: Any) -> Any:
     return asyncio.run(coro)
 
 
+def _resolve_context(ctx: click.Context) -> tuple[str, list[str]]:
+    """Return (api_key, tracked_file_keys) for webhook commands."""
+    repo_dir = Path(ctx.obj["repo_dir"])
+    return _require_api_key(), _load_tracked_files(repo_dir)
+
+
+def _run_with_client(api_key: str, op: Callable[[FigmaClient], Awaitable[Any]]) -> Any:
+    """Execute one async operation with a managed FigmaClient."""
+
+    async def _main() -> Any:
+        async with FigmaClient(api_key) as client:
+            return await op(client)
+
+    return _run(_main())
+
+
 @webhooks_group.command("sync")
 @click.option("--endpoint", required=True, help="Webhook delivery endpoint URL.")
 @click.option("--dry-run", is_flag=True, help="Preview changes without mutating Figma.")
 @click.pass_context
 def sync_cmd(ctx: click.Context, endpoint: str, dry_run: bool) -> None:
     """Enforce exactly-one webhook per tracked file (idempotent)."""
-    repo_dir = Path(ctx.obj["repo_dir"])
-    api_key = _require_api_key()
-    file_keys = _load_tracked_files(repo_dir)
-
-    async def _main() -> None:
-        async with FigmaClient(api_key) as client:
-            await sync(client, endpoint, file_keys, dry_run=dry_run)
-
-    _run(_main())
+    api_key, file_keys = _resolve_context(ctx)
+    _run_with_client(api_key, lambda client: sync(client, endpoint, file_keys, dry_run=dry_run))
 
 
 @webhooks_group.command("register")
@@ -360,15 +370,11 @@ def sync_cmd(ctx: click.Context, endpoint: str, dry_run: bool) -> None:
 @click.pass_context
 def register_cmd(ctx: click.Context, endpoint: str, dry_run: bool) -> None:
     """Add missing webhooks only (conservative, never deletes)."""
-    repo_dir = Path(ctx.obj["repo_dir"])
-    api_key = _require_api_key()
-    file_keys = _load_tracked_files(repo_dir)
-
-    async def _main() -> None:
-        async with FigmaClient(api_key) as client:
-            await register(client, endpoint, file_keys, dry_run=dry_run)
-
-    _run(_main())
+    api_key, file_keys = _resolve_context(ctx)
+    _run_with_client(
+        api_key,
+        lambda client: register(client, endpoint, file_keys, dry_run=dry_run),
+    )
 
 
 @webhooks_group.command("validate")
@@ -376,15 +382,8 @@ def register_cmd(ctx: click.Context, endpoint: str, dry_run: bool) -> None:
 @click.pass_context
 def validate_cmd(ctx: click.Context, endpoint: str) -> None:
     """Check invariant; exits non-zero if issues are found."""
-    repo_dir = Path(ctx.obj["repo_dir"])
-    api_key = _require_api_key()
-    file_keys = _load_tracked_files(repo_dir)
-
-    async def _main() -> ValidationReport:
-        async with FigmaClient(api_key) as client:
-            return await validate(client, endpoint, file_keys)
-
-    report = _run(_main())
+    api_key, file_keys = _resolve_context(ctx)
+    report = _run_with_client(api_key, lambda client: validate(client, endpoint, file_keys))
     if not report.ok:
         sys.exit(1)
 
@@ -393,15 +392,8 @@ def validate_cmd(ctx: click.Context, endpoint: str) -> None:
 @click.pass_context
 def list_cmd(ctx: click.Context) -> None:
     """List all registered webhooks for tracked files."""
-    repo_dir = Path(ctx.obj["repo_dir"])
-    api_key = _require_api_key()
-    file_keys = _load_tracked_files(repo_dir)
-
-    async def _main() -> None:
-        async with FigmaClient(api_key) as client:
-            await list_all(client, file_keys)
-
-    _run(_main())
+    api_key, file_keys = _resolve_context(ctx)
+    _run_with_client(api_key, lambda client: list_all(client, file_keys))
 
 
 @webhooks_group.command("delete-all")
@@ -409,12 +401,7 @@ def list_cmd(ctx: click.Context) -> None:
 @click.pass_context
 def delete_all_cmd(ctx: click.Context, endpoint: str | None) -> None:
     """Delete all file-level webhooks (optionally filtered to an endpoint)."""
-    repo_dir = Path(ctx.obj["repo_dir"])
-    api_key = _require_api_key()
-    file_keys = _load_tracked_files(repo_dir)
-
-    async def _main() -> None:
-        async with FigmaClient(api_key) as client:
-            await delete_all(client, file_keys, endpoint_filter=endpoint)
-
-    _run(_main())
+    api_key, file_keys = _resolve_context(ctx)
+    _run_with_client(
+        api_key, lambda client: delete_all(client, file_keys, endpoint_filter=endpoint)
+    )

--- a/figmaclaw/commands/webhooks.py
+++ b/figmaclaw/commands/webhooks.py
@@ -45,10 +45,9 @@ from typing import Any, Protocol
 
 import click
 
-from figmaclaw.commands._shared import require_figma_api_key
+from figmaclaw.commands._shared import load_state, require_figma_api_key
 from figmaclaw.figma_client import FigmaClient
 from figmaclaw.figma_models import ValidationReport, Webhook
-from figmaclaw.figma_sync_state import FigmaSyncState
 
 
 class WebhookClient(Protocol):
@@ -73,8 +72,7 @@ class WebhookClient(Protocol):
 
 
 def _load_tracked_files(repo_dir: Path) -> list[str]:
-    state = FigmaSyncState(repo_dir)
-    state.load()
+    state = load_state(repo_dir)
     if not state.manifest.tracked_files:
         raise click.ClickException(
             f"No tracked files found in {repo_dir}/.figma-sync/manifest.json"

--- a/figmaclaw/figma_paths.py
+++ b/figmaclaw/figma_paths.py
@@ -74,3 +74,8 @@ def census_path(file_slug: str) -> str:
 def token_sidecar_path(screen_md: Path) -> Path:
     """Return the .tokens.json sidecar path for a screen markdown file path."""
     return screen_md.with_suffix(".tokens.json")
+
+
+def token_sidecar_rel_to_md_rel(sidecar_rel: str) -> str:
+    """Convert a repo-relative .tokens.json path to its .md counterpart."""
+    return sidecar_rel.replace(".tokens.json", ".md")

--- a/figmaclaw/figma_paths.py
+++ b/figmaclaw/figma_paths.py
@@ -69,3 +69,8 @@ def census_path(file_slug: str) -> str:
     Example: figma/design-system/_census.md
     """
     return f"figma/{file_slug}/_census.md"
+
+
+def token_sidecar_path(screen_md: Path) -> Path:
+    """Return the .tokens.json sidecar path for a screen markdown file path."""
+    return screen_md.with_suffix(".tokens.json")

--- a/figmaclaw/figma_sync_state.py
+++ b/figmaclaw/figma_sync_state.py
@@ -139,11 +139,19 @@ class FigmaSyncState:
         )
 
     def set_file_meta(
-        self, file_key: str, version: str, last_modified: str, last_checked_at: str
+        self,
+        file_key: str,
+        version: str,
+        last_modified: str,
+        last_checked_at: str,
+        *,
+        file_name: str | None = None,
     ) -> None:
         """Update file-level metadata after a successful check."""
         if file_key in self.manifest.files:
             entry = self.manifest.files[file_key]
+            if file_name:
+                entry.file_name = file_name
             entry.version = version
             entry.last_modified = last_modified
             entry.last_checked_at = last_checked_at

--- a/figmaclaw/image_export.py
+++ b/figmaclaw/image_export.py
@@ -1,0 +1,38 @@
+"""Shared helpers for Figma image export URL retrieval."""
+
+from __future__ import annotations
+
+from figmaclaw.figma_client import FigmaClient
+
+DEFAULT_IMAGE_BATCH_SIZE = 50
+
+
+async def get_image_urls_batched(
+    client: FigmaClient,
+    file_key: str,
+    node_ids: list[str],
+    *,
+    batch_size: int = DEFAULT_IMAGE_BATCH_SIZE,
+    scale: float | None = None,
+    format: str | None = None,
+    fill_none_on_batch_error: bool = False,
+) -> dict[str, str | None]:
+    """Fetch image export URLs in fixed-size batches and merge results."""
+    all_urls: dict[str, str | None] = {}
+    for i in range(0, len(node_ids), batch_size):
+        batch = node_ids[i : i + batch_size]
+        try:
+            if scale is not None and format is not None:
+                urls = await client.get_image_urls(file_key, batch, scale=scale, format=format)
+            elif scale is not None:
+                urls = await client.get_image_urls(file_key, batch, scale=scale)
+            elif format is not None:
+                urls = await client.get_image_urls(file_key, batch, format=format)
+            else:
+                urls = await client.get_image_urls(file_key, batch)
+        except Exception:
+            if not fill_none_on_batch_error:
+                raise
+            urls = {nid: None for nid in batch}
+        all_urls.update(urls)
+    return all_urls

--- a/figmaclaw/in_context.py
+++ b/figmaclaw/in_context.py
@@ -30,6 +30,7 @@ from pathlib import Path
 
 from figmaclaw.figma_client import FigmaClient
 from figmaclaw.figma_frontmatter import SectionNode
+from figmaclaw.image_export import get_image_urls_batched
 
 # Max data string length that safely fits inside a use_figma code call alongside helpers.
 # Measured overhead per call: helpers (~9.8KB) + _find_page_js (~165 chars)
@@ -87,6 +88,25 @@ class ContextBuildError(RuntimeError):
         self.category = category
 
 
+async def _get_single_export_url(
+    client: FigmaClient,
+    file_key: str,
+    node_id: str,
+    *,
+    format: str,
+    scale: float | None = None,
+) -> str | None:
+    """Fetch one export URL for one node using shared batching logic."""
+    urls = await get_image_urls_batched(
+        client,
+        file_key,
+        [node_id],
+        format=format,
+        scale=scale,
+    )
+    return urls.get(node_id)
+
+
 async def fetch_section_data(
     client: FigmaClient,
     file_key: str,
@@ -98,8 +118,7 @@ async def fetch_section_data(
     at decreasing scales). Uses the first format+scale whose base64 fits within
     SVG_SIZE_LIMIT. Raises ValueError if nothing fits.
     """
-    svg_urls = await client.get_image_urls(file_key, [section.node_id], format="svg")
-    svg_url = svg_urls.get(section.node_id)
+    svg_url = await _get_single_export_url(client, file_key, section.node_id, format="svg")
     if svg_url:
         svg_bytes = await client.download_url(svg_url)
         try:
@@ -115,8 +134,13 @@ async def fetch_section_data(
     # SVG too large — try raster formats at decreasing scales
     saw_raster_url = False
     for fmt, scale in _RASTER_FALLBACK_STEPS:
-        urls = await client.get_image_urls(file_key, [section.node_id], format=fmt, scale=scale)
-        url = urls.get(section.node_id)
+        url = await _get_single_export_url(
+            client,
+            file_key,
+            section.node_id,
+            format=fmt,
+            scale=scale,
+        )
         if not url:
             continue
         saw_raster_url = True

--- a/figmaclaw/prune_utils.py
+++ b/figmaclaw/prune_utils.py
@@ -22,9 +22,11 @@ def is_generated_md_relpath(rel_path: str) -> bool:
     """True when rel_path looks like a generated page/component markdown path."""
     path = Path(rel_path)
     parts = path.parts
-    if len(parts) < 4:
+    if len(parts) < 3 or parts[0] != "figma":
         return False
-    if parts[0] != "figma":
+    if len(parts) == 3:
+        return path.name == "_census.md"
+    if len(parts) < 4:
         return False
     if parts[-2] not in {"pages", "components"}:
         return False

--- a/figmaclaw/prune_utils.py
+++ b/figmaclaw/prune_utils.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import re
 from pathlib import Path
 
+from figmaclaw.figma_paths import token_sidecar_path
 from figmaclaw.figma_sync_state import FigmaSyncState, PageEntry
 
 _NODE_SUFFIX_RE = re.compile(r".*-\d+-\d+\.md$")
@@ -43,7 +44,7 @@ def remove_generated_relpath(repo_root: Path, rel_path: str) -> int:
         path.unlink()
         removed += 1
     if path.suffix == ".md":
-        sidecar = path.with_suffix(".tokens.json")
+        sidecar = token_sidecar_path(path)
         if sidecar.exists():
             sidecar.unlink()
             removed += 1

--- a/figmaclaw/prune_utils.py
+++ b/figmaclaw/prune_utils.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import re
 from pathlib import Path
 
-from figmaclaw.figma_paths import token_sidecar_path
+from figmaclaw.figma_paths import token_sidecar_path, token_sidecar_rel_to_md_rel
 from figmaclaw.figma_sync_state import FigmaSyncState, PageEntry
 
 _NODE_SUFFIX_RE = re.compile(r".*-\d+-\d+\.md$")
@@ -91,7 +91,7 @@ def find_generated_orphans(
             if is_generated_md_relpath(rel) and rel not in expected_paths:
                 orphans.add(rel)
         for tok in directory.glob("*.tokens.json"):
-            md_rel = str(tok.relative_to(repo_root)).replace(".tokens.json", ".md")
+            md_rel = token_sidecar_rel_to_md_rel(str(tok.relative_to(repo_root)))
             if is_generated_md_relpath(md_rel) and md_rel not in expected_paths:
                 orphans.add(str(tok.relative_to(repo_root)))
     return sorted(orphans)

--- a/figmaclaw/pull_logic.py
+++ b/figmaclaw/pull_logic.py
@@ -55,7 +55,14 @@ from figmaclaw.figma_frontmatter import (
 from figmaclaw.figma_hash import compute_frame_hashes, compute_page_hash
 from figmaclaw.figma_models import FigmaPage, FigmaSection, from_page_node
 from figmaclaw.figma_parse import parse_flows, parse_frontmatter
-from figmaclaw.figma_paths import census_path, component_path, file_slug_for_key, page_path, slugify
+from figmaclaw.figma_paths import (
+    census_path,
+    component_path,
+    file_slug_for_key,
+    page_path,
+    slugify,
+    token_sidecar_path,
+)
 from figmaclaw.figma_render import (
     build_component_frontmatter,
     build_page_frontmatter,
@@ -363,7 +370,7 @@ def _write_token_sidecar(
     size by ~100x on complex pages while preserving all data needed by
     suggest-tokens.
     """
-    sidecar_path = screen_md.with_suffix(".tokens.json")
+    sidecar_path = token_sidecar_path(screen_md)
     now = datetime.datetime.now(datetime.UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
 
     frames_data: dict = {}
@@ -409,7 +416,7 @@ def _screen_artifacts_need_reconcile(md_abs: Path) -> bool:
     """Return True when screen markdown/sidecar artifacts are missing or stale."""
     if not md_abs.exists():
         return True
-    return _sidecar_needs_backfill(md_abs.with_suffix(".tokens.json"))
+    return _sidecar_needs_backfill(token_sidecar_path(md_abs))
 
 
 def _node_suffix_from_relpath(rel_path: str) -> str | None:
@@ -445,8 +452,8 @@ def _migrate_generated_path(
         old_path.unlink()
 
     if move_sidecar and old_path.suffix == ".md":
-        old_sidecar = old_path.with_suffix(".tokens.json")
-        new_sidecar = new_path.with_suffix(".tokens.json")
+        old_sidecar = token_sidecar_path(old_path)
+        new_sidecar = token_sidecar_path(new_path)
         if old_sidecar.exists() and not new_sidecar.exists():
             new_sidecar.parent.mkdir(parents=True, exist_ok=True)
             old_sidecar.rename(new_sidecar)

--- a/figmaclaw/pull_logic.py
+++ b/figmaclaw/pull_logic.py
@@ -113,6 +113,25 @@ def _candidate_dirs_from_rel(repo_root: Path, rel: str) -> set[Path]:
     return dirs
 
 
+def _build_prune_candidate_dirs(
+    repo_root: Path,
+    file_slug: str,
+    *,
+    expected_paths: set[str],
+    previous_entry_paths: set[str],
+) -> set[Path]:
+    """Build the candidate directory set used by generated-orphan pruning."""
+    candidate_dirs = {
+        repo_root / f"figma/{file_slug}",
+        repo_root / f"figma/{file_slug}/pages",
+        repo_root / f"figma/{file_slug}/components",
+    }
+    candidate_dirs.update(_all_figma_file_dirs(repo_root))
+    for rel in expected_paths | previous_entry_paths:
+        candidate_dirs.update(_candidate_dirs_from_rel(repo_root, rel))
+    return candidate_dirs
+
+
 def _file_slug_for_state(state: FigmaSyncState, file_key: str, file_name: str) -> str:
     """Return a collision-safe file slug for the current manifest state."""
     from figmaclaw.figma_paths import file_slug_for_key
@@ -651,14 +670,15 @@ async def pull_file(
         # Even on file-level skip, optionally prune generated orphans under file slug.
         if prune:
             expected_paths = _all_manifest_generated_paths(state)
-            candidate_dirs = {
-                repo_root / f"figma/{file_slug}",
-                repo_root / f"figma/{file_slug}/pages",
-                repo_root / f"figma/{file_slug}/components",
+            previous_entry_paths = {
+                rel for page in stored.pages.values() for rel in entry_paths(page)
             }
-            candidate_dirs.update(_all_figma_file_dirs(repo_root))
-            for rel in {rel for page in stored.pages.values() for rel in entry_paths(page)}:
-                candidate_dirs.update(_candidate_dirs_from_rel(repo_root, rel))
+            candidate_dirs = _build_prune_candidate_dirs(
+                repo_root,
+                file_slug,
+                expected_paths=expected_paths,
+                previous_entry_paths=previous_entry_paths,
+            )
             for orphan_rel in find_generated_orphans(
                 repo_root, candidate_dirs=candidate_dirs, expected_paths=expected_paths
             ):
@@ -1115,17 +1135,15 @@ async def pull_file(
 
         # 3) Existing on-disk generated artifacts not referenced by manifest (legacy orphans).
         expected_paths = _all_manifest_generated_paths(state)
-        candidate_dirs = {
-            repo_root / f"figma/{file_slug}",
-            repo_root / f"figma/{file_slug}/pages",
-            repo_root / f"figma/{file_slug}/components",
+        previous_entry_paths = {
+            rel for previous_entry in previous_pages.values() for rel in entry_paths(previous_entry)
         }
-        candidate_dirs.update(_all_figma_file_dirs(repo_root))
-        for rel in expected_paths:
-            candidate_dirs.update(_candidate_dirs_from_rel(repo_root, rel))
-        for previous_entry in previous_pages.values():
-            for rel in entry_paths(previous_entry):
-                candidate_dirs.update(_candidate_dirs_from_rel(repo_root, rel))
+        candidate_dirs = _build_prune_candidate_dirs(
+            repo_root,
+            file_slug,
+            expected_paths=expected_paths,
+            previous_entry_paths=previous_entry_paths,
+        )
         for orphan_rel in find_generated_orphans(
             repo_root, candidate_dirs=candidate_dirs, expected_paths=expected_paths
         ):

--- a/figmaclaw/pull_logic.py
+++ b/figmaclaw/pull_logic.py
@@ -55,7 +55,7 @@ from figmaclaw.figma_frontmatter import (
 from figmaclaw.figma_hash import compute_frame_hashes, compute_page_hash
 from figmaclaw.figma_models import FigmaPage, FigmaSection, from_page_node
 from figmaclaw.figma_parse import parse_flows, parse_frontmatter
-from figmaclaw.figma_paths import component_path, page_path, slugify
+from figmaclaw.figma_paths import census_path, component_path, file_slug_for_key, page_path, slugify
 from figmaclaw.figma_render import (
     build_component_frontmatter,
     build_page_frontmatter,
@@ -78,12 +78,39 @@ TOKEN_SIDECAR_SCHEMA_VERSION = 2
 
 def _all_manifest_generated_paths(state: FigmaSyncState) -> set[str]:
     """Return all generated paths currently referenced by the manifest."""
-    return {
+    page_and_component_paths = {
         rel
         for file_entry in state.manifest.files.values()
         for page_entry in file_entry.pages.values()
         for rel in entry_paths(page_entry)
     }
+    census_paths = {
+        census_path(file_slug_for_key(file_entry.file_name, file_key))
+        for file_key, file_entry in state.manifest.files.items()
+    }
+    return page_and_component_paths | census_paths
+
+
+def _all_figma_file_dirs(repo_root: Path) -> set[Path]:
+    """Return all figma/{file-slug} directories currently on disk."""
+    figma_root = repo_root / "figma"
+    if not figma_root.exists() or not figma_root.is_dir():
+        return set()
+    return {p for p in figma_root.iterdir() if p.is_dir()}
+
+
+def _candidate_dirs_from_rel(repo_root: Path, rel: str) -> set[Path]:
+    """Return prune candidate dirs for one generated rel path.
+
+    Includes the direct parent and the file-root directory (figma/{file-slug})
+    so root artifacts like _census.md are discovered during rename/migration.
+    """
+    abs_path = repo_root / rel
+    dirs = {abs_path.parent}
+    rel_parts = Path(rel).parts
+    if len(rel_parts) >= 4 and rel_parts[0] == "figma" and rel_parts[2] in {"pages", "components"}:
+        dirs.add(repo_root / rel_parts[0] / rel_parts[1])
+    return dirs
 
 
 def _file_slug_for_state(state: FigmaSyncState, file_key: str, file_name: str) -> str:
@@ -625,11 +652,13 @@ async def pull_file(
         if prune:
             expected_paths = _all_manifest_generated_paths(state)
             candidate_dirs = {
+                repo_root / f"figma/{file_slug}",
                 repo_root / f"figma/{file_slug}/pages",
                 repo_root / f"figma/{file_slug}/components",
             }
+            candidate_dirs.update(_all_figma_file_dirs(repo_root))
             for rel in {rel for page in stored.pages.values() for rel in entry_paths(page)}:
-                candidate_dirs.add((repo_root / rel).parent)
+                candidate_dirs.update(_candidate_dirs_from_rel(repo_root, rel))
             for orphan_rel in find_generated_orphans(
                 repo_root, candidate_dirs=candidate_dirs, expected_paths=expected_paths
             ):
@@ -652,6 +681,7 @@ async def pull_file(
         version=api_version,
         last_modified=api_last_modified,
         last_checked_at=now,
+        file_name=file_name,
     )
 
     # Fetch component sets once per changed file. Used to populate component_set_keys
@@ -1086,14 +1116,16 @@ async def pull_file(
         # 3) Existing on-disk generated artifacts not referenced by manifest (legacy orphans).
         expected_paths = _all_manifest_generated_paths(state)
         candidate_dirs = {
+            repo_root / f"figma/{file_slug}",
             repo_root / f"figma/{file_slug}/pages",
             repo_root / f"figma/{file_slug}/components",
         }
+        candidate_dirs.update(_all_figma_file_dirs(repo_root))
         for rel in expected_paths:
-            candidate_dirs.add((repo_root / rel).parent)
+            candidate_dirs.update(_candidate_dirs_from_rel(repo_root, rel))
         for previous_entry in previous_pages.values():
             for rel in entry_paths(previous_entry):
-                candidate_dirs.add((repo_root / rel).parent)
+                candidate_dirs.update(_candidate_dirs_from_rel(repo_root, rel))
         for orphan_rel in find_generated_orphans(
             repo_root, candidate_dirs=candidate_dirs, expected_paths=expected_paths
         ):

--- a/figmaclaw/pull_logic.py
+++ b/figmaclaw/pull_logic.py
@@ -76,6 +76,7 @@ from figmaclaw.prune_utils import (
     find_generated_orphans,
     remove_generated_relpath,
 )
+from figmaclaw.schema_status import is_pull_schema_stale
 from figmaclaw.token_catalog import load_catalog, merge_bindings, save_catalog
 from figmaclaw.token_scan import PageTokenScan, scan_page
 
@@ -651,7 +652,7 @@ async def pull_file(
     file_name = meta.name
 
     stored = state.manifest.files.get(file_key)
-    schema_stale = (stored.pull_schema_version if stored else 0) < CURRENT_PULL_SCHEMA_VERSION
+    schema_stale = is_pull_schema_stale(stored.pull_schema_version if stored else 0)
     file_slug = _file_slug_for_state(state, file_key, file_name)
 
     local_reconcile_needed = False

--- a/figmaclaw/pull_logic.py
+++ b/figmaclaw/pull_logic.py
@@ -132,6 +132,12 @@ def _build_prune_candidate_dirs(
     return candidate_dirs
 
 
+def _remove_generated_paths(repo_root: Path, rel_paths: set[str]) -> None:
+    """Delete generated artifact rel paths in stable order."""
+    for rel in sorted(rel_paths):
+        remove_generated_relpath(repo_root, rel)
+
+
 def _file_slug_for_state(state: FigmaSyncState, file_key: str, file_name: str) -> str:
     """Return a collision-safe file slug for the current manifest state."""
     from figmaclaw.figma_paths import file_slug_for_key
@@ -679,10 +685,12 @@ async def pull_file(
                 expected_paths=expected_paths,
                 previous_entry_paths=previous_entry_paths,
             )
-            for orphan_rel in find_generated_orphans(
-                repo_root, candidate_dirs=candidate_dirs, expected_paths=expected_paths
-            ):
-                remove_generated_relpath(repo_root, orphan_rel)
+            orphan_rels = set(
+                find_generated_orphans(
+                    repo_root, candidate_dirs=candidate_dirs, expected_paths=expected_paths
+                )
+            )
+            _remove_generated_paths(repo_root, orphan_rels)
         _progress(f"{file_name}: unchanged (version {api_version}), skipping all pages")
         result.skipped_file = True
         return result
@@ -1117,8 +1125,7 @@ async def pull_file(
         for previous_page_id, previous_entry in previous_pages.items():
             if previous_page_id in current_page_ids:
                 continue
-            for stale_rel in sorted(entry_paths(previous_entry)):
-                remove_generated_relpath(repo_root, stale_rel)
+            _remove_generated_paths(repo_root, entry_paths(previous_entry))
             if previous_page_id in file_entry.pages:
                 file_entry.pages.pop(previous_page_id)
                 manifest_changed = True
@@ -1130,8 +1137,7 @@ async def pull_file(
             if previous_entry is None or current_entry is None:
                 continue
             stale_paths = entry_paths(previous_entry) - entry_paths(current_entry)
-            for stale_rel in sorted(stale_paths):
-                remove_generated_relpath(repo_root, stale_rel)
+            _remove_generated_paths(repo_root, stale_paths)
 
         # 3) Existing on-disk generated artifacts not referenced by manifest (legacy orphans).
         expected_paths = _all_manifest_generated_paths(state)
@@ -1144,10 +1150,12 @@ async def pull_file(
             expected_paths=expected_paths,
             previous_entry_paths=previous_entry_paths,
         )
-        for orphan_rel in find_generated_orphans(
-            repo_root, candidate_dirs=candidate_dirs, expected_paths=expected_paths
-        ):
-            remove_generated_relpath(repo_root, orphan_rel)
+        orphan_rels = set(
+            find_generated_orphans(
+                repo_root, candidate_dirs=candidate_dirs, expected_paths=expected_paths
+            )
+        )
+        _remove_generated_paths(repo_root, orphan_rels)
 
     if manifest_changed:
         state.save()

--- a/figmaclaw/schema_status.py
+++ b/figmaclaw/schema_status.py
@@ -1,0 +1,33 @@
+"""Shared schema/version status helpers for pull and enrichment flows."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel
+
+from figmaclaw.figma_frontmatter import (
+    CURRENT_ENRICHMENT_SCHEMA_VERSION,
+    CURRENT_PULL_SCHEMA_VERSION,
+    MIN_REQUIRED_ENRICHMENT_SCHEMA_VERSION,
+)
+
+
+class EnrichmentSchemaStatus(BaseModel):
+    """Computed enrichment schema status flags for one page."""
+
+    version: int
+    must_update: bool
+    should_update: bool
+
+
+def is_pull_schema_stale(pull_schema_version: int) -> bool:
+    """Return True when file pull schema version is behind current."""
+    return pull_schema_version < CURRENT_PULL_SCHEMA_VERSION
+
+
+def enrichment_schema_status(enriched_schema_version: int) -> EnrichmentSchemaStatus:
+    """Return enrichment schema update flags for one page."""
+    return EnrichmentSchemaStatus(
+        version=enriched_schema_version,
+        must_update=enriched_schema_version < MIN_REQUIRED_ENRICHMENT_SCHEMA_VERSION,
+        should_update=enriched_schema_version < CURRENT_ENRICHMENT_SCHEMA_VERSION,
+    )

--- a/figmaclaw/staleness.py
+++ b/figmaclaw/staleness.py
@@ -1,0 +1,38 @@
+"""Shared helpers for stale frame detection across commands."""
+
+from __future__ import annotations
+
+from figmaclaw.figma_sync_state import FigmaSyncState
+
+
+def stale_frame_ids(
+    current_hashes: dict[str, str],
+    enriched_frame_hashes: dict[str, str] | None,
+) -> set[str]:
+    """Return frame IDs whose manifest hash differs from enriched hash."""
+    enriched = enriched_frame_hashes or {}
+    stale: set[str] = set()
+    for nid, h in current_hashes.items():
+        if nid not in enriched or enriched[nid] != h:
+            stale.add(nid)
+    for nid in enriched:
+        if nid not in current_hashes:
+            stale.add(nid)
+    return stale
+
+
+def stale_frame_ids_from_manifest(
+    state: FigmaSyncState,
+    *,
+    file_key: str,
+    page_node_id: str,
+    enriched_frame_hashes: dict[str, str] | None,
+) -> set[str] | None:
+    """Return stale frame ids for one page, or None when manifest context is missing."""
+    file_entry = state.manifest.files.get(file_key)
+    if file_entry is None:
+        return None
+    page_entry = file_entry.pages.get(page_node_id)
+    if page_entry is None:
+        return None
+    return stale_frame_ids(page_entry.frame_hashes, enriched_frame_hashes)

--- a/figmaclaw/status_markers.py
+++ b/figmaclaw/status_markers.py
@@ -1,0 +1,4 @@
+"""Shared status marker constants emitted by CLI commands/workflows."""
+
+COMMIT_MSG_PREFIX = "COMMIT_MSG:"
+HAS_MORE_TRUE = "HAS_MORE:true"

--- a/tests/test_census.py
+++ b/tests/test_census.py
@@ -18,6 +18,7 @@ import pytest
 
 import figmaclaw.commands.census as census_module
 from figmaclaw.commands.census import _compute_hash, _existing_hash, _render, _run
+from figmaclaw.figma_paths import file_slug_for_key
 from figmaclaw.figma_sync_state import FigmaSyncState
 
 
@@ -139,7 +140,7 @@ class TestCensusSkipBehavior:
         cs = [_make_component_set("Button", "aabb1122")]
         await self._run_census(tmp_path, cs)
 
-        out = tmp_path / "figma" / "web-app" / "_census.md"
+        out = tmp_path / "figma" / file_slug_for_key("Web App", "key1") / "_census.md"
         assert out.exists()
         mtime_first = out.stat().st_mtime_ns
 
@@ -156,7 +157,7 @@ class TestCensusSkipBehavior:
         cs_before = [_make_component_set("Button", "aabb1122")]
         await self._run_census(tmp_path, cs_before)
 
-        out = tmp_path / "figma" / "web-app" / "_census.md"
+        out = tmp_path / "figma" / file_slug_for_key("Web App", "key1") / "_census.md"
         content_before = out.read_text()
 
         cs_after = [
@@ -166,3 +167,27 @@ class TestCensusSkipBehavior:
         await self._run_census(tmp_path, cs_after)
 
         assert out.read_text() != content_before
+
+    @pytest.mark.asyncio
+    async def test_census_uses_latest_file_name_slug_from_manifest(self, tmp_path: Path):
+        """INVARIANT: census path follows latest manifest file_name for this file key."""
+        state = FigmaSyncState(tmp_path)
+        state.load()
+        state.add_tracked_file("key1", "Old Name")
+        state.manifest.files["key1"].file_name = "New Name"
+        state.save()
+
+        cs = [_make_component_set("Button", "aabb1122")]
+        mock_client = AsyncMock()
+        mock_client.get_component_sets = AsyncMock(return_value=cs)
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+        mock_client_class = MagicMock(return_value=mock_client)
+
+        with patch.object(census_module, "FigmaClient", mock_client_class):
+            await _run("fake-api-key", tmp_path, None, auto_commit=False, force=False)
+
+        assert not (
+            tmp_path / "figma" / file_slug_for_key("Old Name", "key1") / "_census.md"
+        ).exists()
+        assert (tmp_path / "figma" / file_slug_for_key("New Name", "key1") / "_census.md").exists()

--- a/tests/test_pull_logic.py
+++ b/tests/test_pull_logic.py
@@ -2264,6 +2264,10 @@ async def test_pull_file_file_rename_moves_path_and_prunes_old(tmp_path: Path):
     )
     old_abs = tmp_path / old_rel
     assert old_abs.exists()
+    old_census_rel = f"figma/{slugify(old_file_name)}-abc123/_census.md"
+    old_census_abs = tmp_path / old_census_rel
+    old_census_abs.parent.mkdir(parents=True, exist_ok=True)
+    old_census_abs.write_text("legacy census", encoding="utf-8")
 
     mock_client.get_file_meta = AsyncMock(
         return_value=_custom_file_meta(
@@ -2278,6 +2282,8 @@ async def test_pull_file_file_rename_moves_path_and_prunes_old(tmp_path: Path):
     new_abs = tmp_path / new_rel
     assert new_abs.exists()
     assert not old_abs.exists()
+    assert not old_census_abs.exists()
+    assert state.manifest.files["abc123"].file_name == new_file_name
 
 
 @pytest.mark.asyncio
@@ -2349,11 +2355,16 @@ async def test_pull_file_unchanged_run_prunes_existing_generated_orphans(tmp_pat
     current_md.parent.mkdir(parents=True, exist_ok=True)
     current_md.write_text("current")
     current_md.with_suffix(".tokens.json").write_text('{"schema_version":2}')
+    current_census = tmp_path / "figma/web-app-abc123/_census.md"
+    current_census.write_text("current-census")
 
     orphan_md = tmp_path / "figma/web-app-abc123/pages/legacy-100-99.md"
     orphan_md.write_text("orphan")
     orphan_tok = orphan_md.with_suffix(".tokens.json")
     orphan_tok.write_text("{}")
+    orphan_census = tmp_path / "figma/legacy-web-app-abc123/_census.md"
+    orphan_census.parent.mkdir(parents=True, exist_ok=True)
+    orphan_census.write_text("orphan-census")
 
     mock_client = MagicMock(spec=FigmaClient)
     mock_client.get_file_meta = AsyncMock(return_value=fake_file_meta("v2", "2026-03-31T12:00:00Z"))
@@ -2362,8 +2373,10 @@ async def test_pull_file_unchanged_run_prunes_existing_generated_orphans(tmp_pat
 
     assert result.skipped_file is True
     assert current_md.exists()
+    assert current_census.exists()
     assert not orphan_md.exists()
     assert not orphan_tok.exists()
+    assert not orphan_census.exists()
 
 
 @pytest.mark.asyncio
@@ -2408,6 +2421,8 @@ async def test_pull_file_unchanged_skip_does_not_prune_other_file_paths_in_candi
     beta.write_text("beta")
     alpha.with_suffix(".tokens.json").write_text('{"schema_version":2}')
     beta.with_suffix(".tokens.json").write_text('{"schema_version":2}')
+    beta_census = tmp_path / "figma/design-system-fileB2222222222222222222222/_census.md"
+    beta_census.write_text("beta-census")
 
     mock_client = MagicMock(spec=FigmaClient)
     mock_client.get_file_meta = AsyncMock(return_value=fake_file_meta("v2", "2026-03-31T12:00:00Z"))
@@ -2416,6 +2431,7 @@ async def test_pull_file_unchanged_skip_does_not_prune_other_file_paths_in_candi
     assert result.skipped_file is True
     assert alpha.exists()
     assert beta.exists()
+    assert beta_census.exists()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Problem
Legacy `_census.md` files could be orphaned after file renames/migrations.

## Fix
- Treat `_census.md` as generated artifact for prune logic.
- Include file-root directories in prune scan and discover all `figma/*` roots on disk to clean legacy leftovers.
- Include current census paths in expected generated paths so valid census files are preserved.
- Use key-stable slug pathing in `census` (`file_slug_for_key`) to match `pull`.
- Update `set_file_meta(..., file_name=...)` so manifest file names stay fresh on rename.

## Tests
Added/updated TDD coverage:
- `test_pull_file_file_rename_moves_path_and_prunes_old`
- `test_pull_file_unchanged_run_prunes_existing_generated_orphans`
- `test_pull_file_unchanged_skip_does_not_prune_other_file_paths_in_candidate_dir`
- `test_census_uses_latest_file_name_slug_from_manifest`
- updated census idempotency path tests

Focused suite run:
- `uv run pytest -q tests/test_pull_logic.py tests/test_census.py tests/test_figma_paths_and_state.py`
- Result: `124 passed`
