### PR TITLE
fix(sync): harden checkpoint retries + job-level concurrency isolation

### DIFF
--- a/figmaclaw/workflows/figmaclaw-sync.yaml
+++ b/figmaclaw/workflows/figmaclaw-sync.yaml
@@ -21,15 +21,17 @@ on:
         required: false
         default: '3m'
 
-# Must be in caller: concurrency groups are repo-scoped.
-# Sync is isolated from webhook debounce to avoid cross-workflow cancellation.
-# cancel-in-progress: false — never drop a scheduled sync run.
-concurrency:
-  group: figma-git-sync-pull
-  cancel-in-progress: false
+# NOTE:
+# Keep concurrency at the job level (not workflow level) so long-running
+# enrichment from run N does not block pull/census from run N+1.
 
 jobs:
   sync:
+    # Must be in caller: concurrency groups are repo-scoped.
+    # cancel-in-progress: false — never drop a scheduled sync pull.
+    concurrency:
+      group: figma-git-sync-pull
+      cancel-in-progress: false
     uses: aviadr1/figmaclaw/.github/workflows/sync.yml@main
     with:
       force: ${{ github.event.inputs.force || 'false' }}
@@ -43,6 +45,10 @@ jobs:
   census:
     needs: sync
     if: success()
+    # Only the latest census run matters; cancel stale in-flight runs.
+    concurrency:
+      group: figma-git-census
+      cancel-in-progress: true
     uses: aviadr1/figmaclaw/.github/workflows/census.yml@main
     secrets:
       FIGMA_API_KEY: ${{ secrets.FIGMA_API_KEY }}
@@ -52,6 +58,10 @@ jobs:
   enrich:
     needs: sync
     if: success()
+    # Debounce enrichment backlog across scheduled runs.
+    concurrency:
+      group: figma-git-enrich
+      cancel-in-progress: true
     uses: aviadr1/figmaclaw/.github/workflows/claude-run.yml@main
     with:
       target: figma/
@@ -72,6 +82,10 @@ jobs:
   enrich-large:
     needs: sync
     if: success()
+    # Debounce large-page enrichment backlog across scheduled runs.
+    concurrency:
+      group: figma-git-enrich-large
+      cancel-in-progress: true
     uses: aviadr1/figmaclaw/.github/workflows/claude-run.yml@main
     with:
       target: figma/

--- a/scripts/checkpoint_pull_loop.sh
+++ b/scripts/checkpoint_pull_loop.sh
@@ -12,11 +12,15 @@ MAX_PAGES_PER_BATCH="${MAX_PAGES_PER_BATCH:-5}"
 FIGMACLAW_OUT_PATH="${FIGMACLAW_OUT_PATH:-/tmp/figmaclaw-out.txt}"
 
 declare -a PULL_ARGS
-if [ "$INPUT_FORCE" = "true" ]; then
-  PULL_ARGS=(--force)
-else
-  PULL_ARGS=(--max-pages "$MAX_PAGES_PER_BATCH")
-fi
+CURRENT_MAX_PAGES_PER_BATCH="$MAX_PAGES_PER_BATCH"
+
+set_pull_args() {
+  if [ "$INPUT_FORCE" = "true" ]; then
+    PULL_ARGS=(--force)
+  else
+    PULL_ARGS=(--max-pages "$CURRENT_MAX_PAGES_PER_BATCH")
+  fi
+}
 
 run_pull_batch() {
   set +e
@@ -52,13 +56,25 @@ while true; do
 
   echo "--- batch $BATCH ---"
 
+  set_pull_args
   run_pull_batch
   pull_status="$PULL_STATUS"
 
   if [ "$pull_status" -eq 124 ]; then
+    if [ "$INPUT_FORCE" != "true" ] && [ "$CURRENT_MAX_PAGES_PER_BATCH" -gt 1 ]; then
+      CURRENT_MAX_PAGES_PER_BATCH=$((CURRENT_MAX_PAGES_PER_BATCH / 2))
+      if [ "$CURRENT_MAX_PAGES_PER_BATCH" -lt 1 ]; then
+        CURRENT_MAX_PAGES_PER_BATCH=1
+      fi
+      echo "figmaclaw pull timed out after ${BATCH_TIMEOUT_SECONDS}s; retrying with --max-pages ${CURRENT_MAX_PAGES_PER_BATCH}."
+      continue
+    fi
     echo "figmaclaw pull timed out after ${BATCH_TIMEOUT_SECONDS}s; stopping checkpoint loop early."
     break
   fi
+
+  # After a successful backoff retry, restore the default batch size for throughput.
+  CURRENT_MAX_PAGES_PER_BATCH="$MAX_PAGES_PER_BATCH"
 
   committed="$(commit_if_changed)"
 

--- a/tests/test_checkpoint_pull_loop.py
+++ b/tests/test_checkpoint_pull_loop.py
@@ -62,8 +62,20 @@ exit 0
 set -euo pipefail
 _duration="${1:?}"
 shift
+TIMEOUT_COUNT_FILE="${TIMEOUT_COUNT_FILE:-}"
+timeout_count=0
+if [ -n "$TIMEOUT_COUNT_FILE" ] && [ -f "$TIMEOUT_COUNT_FILE" ]; then timeout_count="$(cat "$TIMEOUT_COUNT_FILE")"; fi
 if [ "${TIMEOUT_MODE:-pass}" = "always" ]; then
   exit 124
+fi
+if [ "${TIMEOUT_MODE:-pass}" = "first_only" ]; then
+  timeout_count=$((timeout_count+1))
+  if [ -n "$TIMEOUT_COUNT_FILE" ]; then echo "$timeout_count" > "$TIMEOUT_COUNT_FILE"; fi
+  "$@"
+  if [ "$timeout_count" -eq 1 ]; then
+    exit 124
+  fi
+  exit $?
 fi
 "$@"
 """,
@@ -81,6 +93,7 @@ def _run_loop(
     trace = tmp_path / "git-trace.txt"
     count = tmp_path / "count.txt"
     args = tmp_path / "pull-args.txt"
+    timeout_count = tmp_path / "timeout-count.txt"
 
     bin_dir = _setup_fake_bin(
         tmp_path, scenario=scenario, git_dirty=git_dirty, timeout_mode=timeout_mode
@@ -94,6 +107,7 @@ def _run_loop(
             "TRACE_FILE": str(trace),
             "FIGMACLAW_OUT_PATH": str(out_path),
             "ARGS_FILE": str(args),
+            "TIMEOUT_COUNT_FILE": str(timeout_count),
             "SCENARIO": scenario,
             "GIT_DIRTY": git_dirty,
             "TIMEOUT_MODE": timeout_mode,
@@ -189,3 +203,29 @@ def test_force_uses_force_flag_only(tmp_path: Path) -> None:
     )
     args = (tmp_path / "pull-args.txt").read_text().strip()
     assert args == "pull --force"
+
+
+def test_timeout_retries_with_smaller_batch_then_succeeds(tmp_path: Path) -> None:
+    out = _run_loop(
+        tmp_path,
+        scenario="single_done",
+        git_dirty="1",
+        timeout_mode="first_only",
+        MAX_PAGES_PER_BATCH="8",
+    )
+    args = (tmp_path / "pull-args.txt").read_text().strip().splitlines()
+    assert args == ["pull --max-pages 8", "pull --max-pages 4"]
+    assert "retrying with --max-pages 4" in out
+
+
+def test_timeout_does_not_retry_in_force_mode(tmp_path: Path) -> None:
+    out = _run_loop(
+        tmp_path,
+        scenario="single_done",
+        git_dirty="1",
+        timeout_mode="first_only",
+        INPUT_FORCE="true",
+    )
+    count = int((tmp_path / "count.txt").read_text())
+    assert count == 1
+    assert "stopping checkpoint loop early." in out

--- a/tests/test_workflow_template_invariants.py
+++ b/tests/test_workflow_template_invariants.py
@@ -16,11 +16,13 @@ def test_webhook_template_debounces_with_isolated_group() -> None:
 
 
 def test_sync_template_isolated_from_webhook_cancellation() -> None:
-    """INVARIANT: scheduled sync group cannot be canceled by webhook debounce."""
+    """INVARIANT: sync job is serialized and insulated from webhook debounce."""
     text = bundled_template_text("figmaclaw-sync.yaml")
 
-    assert "cancel-in-progress: false" in text
+    assert "sync:\n" in text
     assert "group: figma-git-sync-pull" in text
+    assert "cancel-in-progress: false" in text
+    assert "group: figma-git-webhook" not in text
 
 
 def test_manage_webhooks_template_is_installed() -> None:
@@ -31,16 +33,17 @@ def test_manage_webhooks_template_is_installed() -> None:
 
 
 def test_concurrency_groups_are_isolated_by_workflow_role() -> None:
-    """INVARIANT: webhook debounce cannot cancel scheduled sync runs."""
+    """INVARIANT: concurrency groups are explicit and non-overlapping by role."""
 
-    def _group(text: str) -> str:
-        m = re.search(r"^\s*group:\s*([^\n]+)\s*$", text, flags=re.MULTILINE)
-        assert m is not None
-        return m.group(1).strip()
+    sync_text = bundled_template_text("figmaclaw-sync.yaml")
+    webhook_text = bundled_template_text("figmaclaw-webhook.yaml")
 
-    sync_group = _group(bundled_template_text("figmaclaw-sync.yaml"))
-    webhook_group = _group(bundled_template_text("figmaclaw-webhook.yaml"))
+    sync_groups = set(re.findall(r"^\s*group:\s*([^\n]+)\s*$", sync_text, flags=re.MULTILINE))
+    webhook_groups = set(re.findall(r"^\s*group:\s*([^\n]+)\s*$", webhook_text, flags=re.MULTILINE))
 
-    assert sync_group == "figma-git-sync-pull"
-    assert webhook_group == "figma-git-webhook"
-    assert sync_group != webhook_group
+    assert "figma-git-sync-pull" in sync_groups
+    assert "figma-git-census" in sync_groups
+    assert "figma-git-enrich" in sync_groups
+    assert "figma-git-enrich-large" in sync_groups
+    assert webhook_groups == {"figma-git-webhook"}
+    assert sync_groups.isdisjoint(webhook_groups)


### PR DESCRIPTION
## Problem
Recent sync hardening fixed starvation/stuck loops but introduced two recurring inefficiency/regression patterns:
1. `checkpoint_pull_loop.sh` exited on first batch timeout, which can repeatedly drop progress when timeout happens mid-batch.
2. Caller `figmaclaw-sync` template serialized the entire workflow with top-level concurrency, so long enrichment stages blocked next hourly sync runs and built queue lag.

## Root-cause synthesis
- Guardrails were added incrementally across #91/#93/#94/#95/#97, but timeout handling and concurrency scope were tuned independently.
- Timeout protection was correct in intent (avoid infinite runs) but too binary (stop immediately).
- Workflow-level serialization was correct for avoiding push races, but too coarse for mixed workloads (sync vs enrich).

## Fix
- Add adaptive timeout backoff in checkpoint loop:
  - on timeout in non-force mode, halve `--max-pages` and retry (down to 1).
  - preserve early-stop behavior for force mode and persistent timeout at page budget 1.
  - reset back to default page budget after successful batch.
- Move concurrency from workflow-level to job-level in `figmaclaw-sync` template:
  - `sync`: serialized, `cancel-in-progress: false`
  - `census`: debounced, `cancel-in-progress: true`
  - `enrich`: debounced, `cancel-in-progress: true`
  - `enrich-large`: debounced, `cancel-in-progress: true`

## Tests
- `tests/test_checkpoint_pull_loop.py`
  - add first-timeout retry/backoff regression test
  - add force-mode timeout no-retry test
- `tests/test_workflow_template_invariants.py`
  - update invariants for explicit non-overlapping job-level concurrency groups

## Validation
- `uv run pytest -q tests/test_checkpoint_pull_loop.py`
- `uv run pytest -q tests/test_workflow_template_invariants.py`
- `uv run pytest -q -m "not smoke_api and not smoke_webhook and not smoke_mcp"`
- `uv run pytest -q -m "not smoke_api and not smoke_webhook and not smoke_mcp" --cov=figmaclaw --cov-report=term-missing`
