### PR TITLE
feat(sync): add checkpoint observability logs and CI artifacts

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -85,6 +85,8 @@ jobs:
         env:
           FIGMA_API_KEY: ${{ secrets.FIGMA_API_KEY }}
           INPUT_FORCE: ${{ inputs.force }}
+          FIGMA_TEAM_ID: ${{ inputs.figma_team_id }}
+          SINCE: ${{ inputs.since }}
           FIGMACLAW_SYNC_OBS_DIR: ${{ runner.temp }}/figmaclaw-sync-observability
         run: |
           bash .figmaclaw-workflow/scripts/checkpoint_pull_loop.sh

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -85,5 +85,26 @@ jobs:
         env:
           FIGMA_API_KEY: ${{ secrets.FIGMA_API_KEY }}
           INPUT_FORCE: ${{ inputs.force }}
+          FIGMACLAW_SYNC_OBS_DIR: ${{ runner.temp }}/figmaclaw-sync-observability
         run: |
           bash .figmaclaw-workflow/scripts/checkpoint_pull_loop.sh
+
+      - name: Print sync observability summary
+        if: always()
+        run: |
+          OBS_DIR="${{ runner.temp }}/figmaclaw-sync-observability"
+          if [ -f "${OBS_DIR}/checkpoint_summary.txt" ]; then
+            echo "----- checkpoint_summary.txt -----"
+            cat "${OBS_DIR}/checkpoint_summary.txt"
+          else
+            echo "No checkpoint_summary.txt produced."
+          fi
+
+      - name: Upload sync observability artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: figmaclaw-sync-observability-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/figmaclaw-sync-observability/
+          if-no-files-found: warn
+          retention-days: 14

--- a/docs/sync-observability.md
+++ b/docs/sync-observability.md
@@ -2,6 +2,7 @@
 
 This document defines the structured telemetry emitted by
 `scripts/checkpoint_pull_loop.sh` in reusable sync workflow runs.
+It also documents per-file pull telemetry emitted by `figmaclaw pull`.
 
 ## Goals
 
@@ -16,6 +17,16 @@ Every loop phase prints a single-line log prefix:
 `SYNC_OBS event=<event> batch=<n> elapsed_s=<sec> max_pages=<n> pull_status=<code> committed=<bool|na> has_more=<bool> idle_has_more=<n> reason="<text>"`
 
 This is intended for real-time log tailing while a run is active.
+
+`figmaclaw pull` now emits per-run and per-file lines with prefix:
+
+`SYNC_OBS_PULL event=<event> ...`
+
+Key events:
+
+- `run_start` / `run_end`
+- `listing_prefilter` (when `--team-id` is used)
+- `file_end` (one line per considered file with outcome + duration)
 
 ## Artifact files
 
@@ -61,3 +72,14 @@ Notes:
 
 GitHub artifact upload occurs after step completion (`if: always()`), so artifacts
 are post-run. During execution, use `SYNC_OBS` lines in live logs.
+
+## Correlating loop + pull telemetry
+
+- `SYNC_OBS` gives checkpoint-batch level timing and git checkpoint stages.
+- `SYNC_OBS_PULL` gives per-file timing/outcomes inside each `figmaclaw pull` call.
+
+Together they isolate whether slowness is primarily:
+
+- in pull internals (API/render/write),
+- or in checkpoint git stages (pull/add/diff/commit/push),
+- or in repeated timeout/backoff patterns.

--- a/docs/sync-observability.md
+++ b/docs/sync-observability.md
@@ -1,0 +1,63 @@
+# Sync Observability (Checkpoint Pull Loop)
+
+This document defines the structured telemetry emitted by
+`scripts/checkpoint_pull_loop.sh` in reusable sync workflow runs.
+
+## Goals
+
+- Explain where sync time is spent (pull vs git checkpoint stages).
+- Make progress visible during long runs.
+- Preserve machine-readable artifacts for post-run profiling.
+
+## Live log format
+
+Every loop phase prints a single-line log prefix:
+
+`SYNC_OBS event=<event> batch=<n> elapsed_s=<sec> max_pages=<n> pull_status=<code> committed=<bool|na> has_more=<bool> idle_has_more=<n> reason="<text>"`
+
+This is intended for real-time log tailing while a run is active.
+
+## Artifact files
+
+Reusable workflow `sync.yml` uploads an artifact named:
+
+`figmaclaw-sync-observability-<run_id>-<run_attempt>`
+
+Containing:
+
+- `checkpoint_events.csv` (per-event timeline)
+- `checkpoint_summary.txt` (rollup counters and final reason)
+
+## `checkpoint_events.csv` schema
+
+Header:
+
+`ts_utc,elapsed_s,batch,event,input_force,max_pages,pull_status,pull_duration_s,git_pull_s,git_add_s,git_diff_s,git_commit_s,git_push_s,committed,has_more,idle_has_more,reason`
+
+Notes:
+
+- `elapsed_s`: seconds from loop start.
+- `pull_duration_s`: duration of `figmaclaw pull` batch call.
+- `git_*_s`: stage durations for checkpoint operations.
+- `event` values include:
+  - `loop_start`, `batch_start`, `batch_end`
+  - `batch_timeout_backoff`, `batch_timeout_stop`
+  - `loop_break`, `loop_end`
+
+## `checkpoint_summary.txt` keys
+
+- `total_elapsed_s`
+- `batches_started`
+- `total_commits`
+- `total_timeouts`
+- `total_backoffs`
+- `final_reason`
+- `max_batches`
+- `max_pages_per_batch`
+- `batch_timeout_seconds`
+- `input_force`
+
+## Current limitation
+
+GitHub artifact upload occurs after step completion (`if: always()`), so artifacts
+are post-run. During execution, use `SYNC_OBS` lines in live logs.

--- a/figmaclaw/commands/pull.py
+++ b/figmaclaw/commands/pull.py
@@ -6,6 +6,7 @@ import asyncio
 import contextlib
 import time
 from pathlib import Path
+from typing import Any
 
 import click
 
@@ -117,6 +118,70 @@ def _emit_pull_obs(event: str, **fields: object) -> None:
     click.echo("SYNC_OBS_PULL " + " ".join(parts))
 
 
+class _PullObs:
+    """Structured pull observability emitter + counters."""
+
+    def __init__(
+        self,
+        *,
+        force: bool,
+        max_pages: int | None,
+        team_id: str | None,
+        since: str,
+        prune: bool,
+    ) -> None:
+        self.run_start = time.monotonic()
+        self.files_seen = 0
+        self.files_attempted_pull = 0
+        self.files_skipped_prefilter = 0
+        self.files_errors = 0
+        self.files_no_access = 0
+        self.files_updated = 0
+        self.files_skipped = 0
+        self.emit(
+            "run_start",
+            force=force,
+            max_pages=max_pages if max_pages is not None else "none",
+            team_id=team_id if team_id is not None else "none",
+            since=since,
+            prune=prune,
+        )
+
+    def emit(self, event: str, **fields: Any) -> None:
+        _emit_pull_obs(event, **fields)
+
+    def duration(self) -> float:
+        return round(time.monotonic() - self.run_start, 3)
+
+    def set_files_seen(self, n: int) -> None:
+        self.files_seen = n
+
+    def file_end(self, file_key: str, outcome: str, file_start: float, **fields: Any) -> None:
+        self.emit(
+            "file_end",
+            file_key=file_key,
+            outcome=outcome,
+            duration_s=round(time.monotonic() - file_start, 3),
+            **fields,
+        )
+
+    def run_end(self, *, has_more_global: bool, reason: str | None = None) -> None:
+        payload: dict[str, Any] = {
+            "duration_s": self.duration(),
+            "files_seen": self.files_seen,
+            "files_attempted_pull": self.files_attempted_pull,
+            "files_skipped_prefilter": self.files_skipped_prefilter,
+            "files_errors": self.files_errors,
+            "files_no_access": self.files_no_access,
+            "files_updated": self.files_updated,
+            "files_skipped": self.files_skipped,
+            "has_more_global": has_more_global,
+        }
+        if reason is not None:
+            payload["reason"] = reason
+        self.emit("run_end", **payload)
+
+
 async def _listing_prefilter(
     client: FigmaClient,
     team_id: str,
@@ -194,23 +259,13 @@ async def _run(
     since: str,
     prune: bool = True,
 ) -> None:
-    run_start = time.monotonic()
     state = load_state(repo_dir)
 
     commit_count = 0
-    files_seen = 0
-    files_attempted_pull = 0
-    files_skipped_prefilter = 0
-    files_errors = 0
-    files_no_access = 0
-    files_updated = 0
-    files_skipped = 0
-
-    _emit_pull_obs(
-        "run_start",
+    obs = _PullObs(
         force=force,
-        max_pages=max_pages if max_pages is not None else "none",
-        team_id=team_id if team_id is not None else "none",
+        max_pages=max_pages,
+        team_id=team_id,
         since=since,
         prune=prune,
     )
@@ -253,49 +308,30 @@ async def _run(
             )
 
         if not require_tracked_files(state):
-            _emit_pull_obs(
-                "run_end",
-                duration_s=round(time.monotonic() - run_start, 3),
-                reason="no_tracked_files",
-            )
+            obs.run_end(has_more_global=False, reason="no_tracked_files")
             return
 
         keys = [file_key] if file_key else list(state.manifest.tracked_files)
-        files_seen = len(keys)
+        obs.set_files_seen(len(keys))
 
         for key in keys:
             file_start = time.monotonic()
             if key not in state.manifest.tracked_files:
                 click.echo(f"File key {key!r} is not tracked. Run 'figmaclaw track {key}' first.")
-                files_skipped += 1
-                _emit_pull_obs(
-                    "file_end",
-                    file_key=key,
-                    outcome="not_tracked",
-                    duration_s=round(time.monotonic() - file_start, 3),
-                )
+                obs.files_skipped += 1
+                obs.file_end(key, "not_tracked", file_start)
                 continue
 
             skip_reason = state.manifest.skipped_files.get(key)
             if skip_reason:
                 click.echo(f"{key}: skipped — {skip_reason}")
-                files_skipped += 1
-                _emit_pull_obs(
-                    "file_end",
-                    file_key=key,
-                    outcome="manifest_skipped",
-                    duration_s=round(time.monotonic() - file_start, 3),
-                )
+                obs.files_skipped += 1
+                obs.file_end(key, "manifest_skipped", file_start)
                 continue
 
             if max_pages is not None and pages_budget is not None and pages_budget <= 0:
                 has_more_global = True
-                _emit_pull_obs(
-                    "file_end",
-                    file_key=key,
-                    outcome="budget_exhausted",
-                    duration_s=round(time.monotonic() - file_start, 3),
-                )
+                obs.file_end(key, "budget_exhausted", file_start)
                 break
 
             # Listing pre-filter: skip get_file_meta entirely when the listing tells us
@@ -309,17 +345,12 @@ async def _run(
                 stored_entry = state.manifest.files.get(key)
                 stored_lm = stored_entry.last_modified if stored_entry else ""
                 if listing_lm is None or stored_lm == listing_lm:
-                    files_skipped_prefilter += 1
-                    _emit_pull_obs(
-                        "file_end",
-                        file_key=key,
-                        outcome="listing_prefilter_skip",
-                        duration_s=round(time.monotonic() - file_start, 3),
-                    )
+                    obs.files_skipped_prefilter += 1
+                    obs.file_end(key, "listing_prefilter_skip", file_start)
                     continue
 
             try:
-                files_attempted_pull += 1
+                obs.files_attempted_pull += 1
                 result = await pull_file(
                     client,
                     key,
@@ -332,13 +363,8 @@ async def _run(
                 )
             except Exception as exc:
                 click.echo(f"{key}: error — {exc} (skipping)")
-                files_errors += 1
-                _emit_pull_obs(
-                    "file_end",
-                    file_key=key,
-                    outcome="error",
-                    duration_s=round(time.monotonic() - file_start, 3),
-                )
+                obs.files_errors += 1
+                obs.file_end(key, "error", file_start)
                 continue
             all_results.append(result)
 
@@ -350,7 +376,7 @@ async def _run(
                 has_more_global = True
 
             if result.no_access:
-                files_no_access += 1
+                obs.files_no_access += 1
                 # Permanently inaccessible (restricted/deleted) — move out of tracked_files.
                 reason = "no access — get_file_meta returns 400/404"
                 pruned = prune_file_artifacts_from_manifest(
@@ -365,15 +391,9 @@ async def _run(
                     f"{key}: skipped — {reason} — removed from tracked_files "
                     f"(pruned {pruned} path(s))"
                 )
-                _emit_pull_obs(
-                    "file_end",
-                    file_key=key,
-                    outcome="no_access_pruned",
-                    duration_s=round(time.monotonic() - file_start, 3),
-                    pruned_paths=pruned,
-                )
+                obs.file_end(key, "no_access_pruned", file_start, pruned_paths=pruned)
             elif result.skipped_file:
-                files_skipped += 1
+                obs.files_skipped += 1
                 # If pull failed (e.g. 400 on get_file_meta) and we know the listing
                 # last_modified, stamp it into the manifest so future runs pre-filter
                 # this file without making a wasted API call.
@@ -383,14 +403,9 @@ async def _run(
                     if listing_lm and stored_entry and not stored_entry.last_modified:
                         stored_entry.last_modified = listing_lm
                 click.echo(f"{key}: unchanged (skipped)")
-                _emit_pull_obs(
-                    "file_end",
-                    file_key=key,
-                    outcome="pull_skipped",
-                    duration_s=round(time.monotonic() - file_start, 3),
-                )
+                obs.file_end(key, "pull_skipped", file_start)
             else:
-                files_updated += 1
+                obs.files_updated += 1
                 errored = f", {result.pages_errored} error(s)" if result.pages_errored else ""
                 upgraded = (
                     f", {result.pages_schema_upgraded} schema-upgraded"
@@ -404,11 +419,10 @@ async def _run(
                     click.echo(f"  → {path}")
                 for path in result.component_paths:
                     click.echo(f"  ❖ {path}")
-                _emit_pull_obs(
-                    "file_end",
-                    file_key=key,
-                    outcome="updated",
-                    duration_s=round(time.monotonic() - file_start, 3),
+                obs.file_end(
+                    key,
+                    "updated",
+                    file_start,
                     pages_written=result.pages_written,
                     components_written=result.component_sections_written,
                     pages_skipped=result.pages_skipped,
@@ -437,15 +451,4 @@ async def _run(
     if has_more_global:
         click.echo(HAS_MORE_TRUE)
 
-    _emit_pull_obs(
-        "run_end",
-        duration_s=round(time.monotonic() - run_start, 3),
-        files_seen=files_seen,
-        files_attempted_pull=files_attempted_pull,
-        files_skipped_prefilter=files_skipped_prefilter,
-        files_errors=files_errors,
-        files_no_access=files_no_access,
-        files_updated=files_updated,
-        files_skipped=files_skipped,
-        has_more_global=has_more_global,
-    )
+    obs.run_end(has_more_global=has_more_global)

--- a/figmaclaw/commands/pull.py
+++ b/figmaclaw/commands/pull.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import time
 from pathlib import Path
 
 import click
@@ -105,6 +106,17 @@ def _git_push(repo_dir: Path) -> None:
     git_push(repo_dir)
 
 
+def _obs_s(value: object) -> str:
+    return str(value).replace("\n", " ").replace("\r", " ").replace(" ", "_")
+
+
+def _emit_pull_obs(event: str, **fields: object) -> None:
+    parts = [f"event={_obs_s(event)}"]
+    for key, value in fields.items():
+        parts.append(f"{key}={_obs_s(value)}")
+    click.echo("SYNC_OBS_PULL " + " ".join(parts))
+
+
 async def _listing_prefilter(
     client: FigmaClient,
     team_id: str,
@@ -182,9 +194,26 @@ async def _run(
     since: str,
     prune: bool = True,
 ) -> None:
+    run_start = time.monotonic()
     state = load_state(repo_dir)
 
     commit_count = 0
+    files_seen = 0
+    files_attempted_pull = 0
+    files_skipped_prefilter = 0
+    files_errors = 0
+    files_no_access = 0
+    files_updated = 0
+    files_skipped = 0
+
+    _emit_pull_obs(
+        "run_start",
+        force=force,
+        max_pages=max_pages if max_pages is not None else "none",
+        team_id=team_id if team_id is not None else "none",
+        since=since,
+        prune=prune,
+    )
 
     def on_page_written(page_label: str, paths: list[str]) -> None:
         nonlocal commit_count
@@ -209,26 +238,64 @@ async def _run(
         # returned no files" — both are handled correctly by the is not None check below.
         listing_last_modified: dict[str, str] | None = None
         if team_id and not file_key:
+            listing_t0 = time.monotonic()
+            tracked_before = len(state.manifest.tracked_files)
             listing_last_modified = await _listing_prefilter(client, team_id, state, since)
             state.save()  # persist any newly tracked files before pulling
+            listing_duration_s = round(time.monotonic() - listing_t0, 3)
+            tracked_after = len(state.manifest.tracked_files)
+            _emit_pull_obs(
+                "listing_prefilter",
+                duration_s=listing_duration_s,
+                listed_files=len(listing_last_modified),
+                tracked_before=tracked_before,
+                tracked_after=tracked_after,
+            )
 
         if not require_tracked_files(state):
+            _emit_pull_obs(
+                "run_end",
+                duration_s=round(time.monotonic() - run_start, 3),
+                reason="no_tracked_files",
+            )
             return
 
         keys = [file_key] if file_key else list(state.manifest.tracked_files)
+        files_seen = len(keys)
 
         for key in keys:
+            file_start = time.monotonic()
             if key not in state.manifest.tracked_files:
                 click.echo(f"File key {key!r} is not tracked. Run 'figmaclaw track {key}' first.")
+                files_skipped += 1
+                _emit_pull_obs(
+                    "file_end",
+                    file_key=key,
+                    outcome="not_tracked",
+                    duration_s=round(time.monotonic() - file_start, 3),
+                )
                 continue
 
             skip_reason = state.manifest.skipped_files.get(key)
             if skip_reason:
                 click.echo(f"{key}: skipped — {skip_reason}")
+                files_skipped += 1
+                _emit_pull_obs(
+                    "file_end",
+                    file_key=key,
+                    outcome="manifest_skipped",
+                    duration_s=round(time.monotonic() - file_start, 3),
+                )
                 continue
 
             if max_pages is not None and pages_budget is not None and pages_budget <= 0:
                 has_more_global = True
+                _emit_pull_obs(
+                    "file_end",
+                    file_key=key,
+                    outcome="budget_exhausted",
+                    duration_s=round(time.monotonic() - file_start, 3),
+                )
                 break
 
             # Listing pre-filter: skip get_file_meta entirely when the listing tells us
@@ -242,9 +309,17 @@ async def _run(
                 stored_entry = state.manifest.files.get(key)
                 stored_lm = stored_entry.last_modified if stored_entry else ""
                 if listing_lm is None or stored_lm == listing_lm:
+                    files_skipped_prefilter += 1
+                    _emit_pull_obs(
+                        "file_end",
+                        file_key=key,
+                        outcome="listing_prefilter_skip",
+                        duration_s=round(time.monotonic() - file_start, 3),
+                    )
                     continue
 
             try:
+                files_attempted_pull += 1
                 result = await pull_file(
                     client,
                     key,
@@ -257,6 +332,13 @@ async def _run(
                 )
             except Exception as exc:
                 click.echo(f"{key}: error — {exc} (skipping)")
+                files_errors += 1
+                _emit_pull_obs(
+                    "file_end",
+                    file_key=key,
+                    outcome="error",
+                    duration_s=round(time.monotonic() - file_start, 3),
+                )
                 continue
             all_results.append(result)
 
@@ -268,6 +350,7 @@ async def _run(
                 has_more_global = True
 
             if result.no_access:
+                files_no_access += 1
                 # Permanently inaccessible (restricted/deleted) — move out of tracked_files.
                 reason = "no access — get_file_meta returns 400/404"
                 pruned = prune_file_artifacts_from_manifest(
@@ -282,7 +365,15 @@ async def _run(
                     f"{key}: skipped — {reason} — removed from tracked_files "
                     f"(pruned {pruned} path(s))"
                 )
+                _emit_pull_obs(
+                    "file_end",
+                    file_key=key,
+                    outcome="no_access_pruned",
+                    duration_s=round(time.monotonic() - file_start, 3),
+                    pruned_paths=pruned,
+                )
             elif result.skipped_file:
+                files_skipped += 1
                 # If pull failed (e.g. 400 on get_file_meta) and we know the listing
                 # last_modified, stamp it into the manifest so future runs pre-filter
                 # this file without making a wasted API call.
@@ -292,7 +383,14 @@ async def _run(
                     if listing_lm and stored_entry and not stored_entry.last_modified:
                         stored_entry.last_modified = listing_lm
                 click.echo(f"{key}: unchanged (skipped)")
+                _emit_pull_obs(
+                    "file_end",
+                    file_key=key,
+                    outcome="pull_skipped",
+                    duration_s=round(time.monotonic() - file_start, 3),
+                )
             else:
+                files_updated += 1
                 errored = f", {result.pages_errored} error(s)" if result.pages_errored else ""
                 upgraded = (
                     f", {result.pages_schema_upgraded} schema-upgraded"
@@ -306,6 +404,18 @@ async def _run(
                     click.echo(f"  → {path}")
                 for path in result.component_paths:
                     click.echo(f"  ❖ {path}")
+                _emit_pull_obs(
+                    "file_end",
+                    file_key=key,
+                    outcome="updated",
+                    duration_s=round(time.monotonic() - file_start, 3),
+                    pages_written=result.pages_written,
+                    components_written=result.component_sections_written,
+                    pages_skipped=result.pages_skipped,
+                    pages_errors=result.pages_errored,
+                    schema_upgraded=result.pages_schema_upgraded,
+                    has_more=result.has_more,
+                )
 
     state.save()
 
@@ -326,3 +436,16 @@ async def _run(
 
     if has_more_global:
         click.echo(HAS_MORE_TRUE)
+
+    _emit_pull_obs(
+        "run_end",
+        duration_s=round(time.monotonic() - run_start, 3),
+        files_seen=files_seen,
+        files_attempted_pull=files_attempted_pull,
+        files_skipped_prefilter=files_skipped_prefilter,
+        files_errors=files_errors,
+        files_no_access=files_no_access,
+        files_updated=files_updated,
+        files_skipped=files_skipped,
+        has_more_global=has_more_global,
+    )

--- a/scripts/checkpoint_pull_loop.sh
+++ b/scripts/checkpoint_pull_loop.sh
@@ -10,6 +10,8 @@ MAX_IDLE_HAS_MORE_BATCHES="${MAX_IDLE_HAS_MORE_BATCHES:-3}"
 BATCH_TIMEOUT_SECONDS="${BATCH_TIMEOUT_SECONDS:-900}"
 MAX_PAGES_PER_BATCH="${MAX_PAGES_PER_BATCH:-5}"
 FIGMACLAW_OUT_PATH="${FIGMACLAW_OUT_PATH:-/tmp/figmaclaw-out.txt}"
+FIGMA_TEAM_ID="${FIGMA_TEAM_ID:-}"
+SINCE="${SINCE:-3m}"
 FIGMACLAW_SYNC_OBS_DIR="${FIGMACLAW_SYNC_OBS_DIR:-}"
 
 declare -a PULL_ARGS
@@ -72,6 +74,9 @@ set_pull_args() {
     PULL_ARGS=(--force)
   else
     PULL_ARGS=(--max-pages "$CURRENT_MAX_PAGES_PER_BATCH")
+  fi
+  if [ -n "$FIGMA_TEAM_ID" ]; then
+    PULL_ARGS+=(--team-id "$FIGMA_TEAM_ID" --since "$SINCE")
   fi
 }
 

--- a/scripts/checkpoint_pull_loop.sh
+++ b/scripts/checkpoint_pull_loop.sh
@@ -10,9 +10,62 @@ MAX_IDLE_HAS_MORE_BATCHES="${MAX_IDLE_HAS_MORE_BATCHES:-3}"
 BATCH_TIMEOUT_SECONDS="${BATCH_TIMEOUT_SECONDS:-900}"
 MAX_PAGES_PER_BATCH="${MAX_PAGES_PER_BATCH:-5}"
 FIGMACLAW_OUT_PATH="${FIGMACLAW_OUT_PATH:-/tmp/figmaclaw-out.txt}"
+FIGMACLAW_SYNC_OBS_DIR="${FIGMACLAW_SYNC_OBS_DIR:-}"
 
 declare -a PULL_ARGS
 CURRENT_MAX_PAGES_PER_BATCH="$MAX_PAGES_PER_BATCH"
+SCRIPT_START_EPOCH="$(date +%s)"
+OBS_EVENTS_FILE=""
+OBS_SUMMARY_FILE=""
+BATCHES_STARTED=0
+TOTAL_TIMEOUTS=0
+TOTAL_BACKOFFS=0
+TOTAL_COMMITS=0
+FINAL_REASON="unknown"
+
+PULL_STATUS=0
+PULL_DURATION_S=0
+GIT_PULL_S=0
+GIT_ADD_S=0
+GIT_DIFF_S=0
+GIT_COMMIT_S=0
+GIT_PUSH_S=0
+HAS_MORE="false"
+
+sanitize_obs_field() {
+  echo "$1" | tr '\n\r,' '   '
+}
+
+emit_obs() {
+  local event="$1"
+  local reason="${2:-}"
+  local ts_utc elapsed_s safe_reason
+  ts_utc="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+  elapsed_s="$(( $(date +%s) - SCRIPT_START_EPOCH ))"
+  safe_reason="$(sanitize_obs_field "$reason")"
+
+  echo "SYNC_OBS event=${event} batch=${BATCH:-0} elapsed_s=${elapsed_s} max_pages=${CURRENT_MAX_PAGES_PER_BATCH} pull_status=${PULL_STATUS} committed=${committed:-na} has_more=${HAS_MORE} idle_has_more=${idle_has_more:-0} reason=\"${safe_reason}\""
+
+  if [ -z "$OBS_EVENTS_FILE" ]; then
+    return
+  fi
+
+  cat >> "$OBS_EVENTS_FILE" <<EOF
+${ts_utc},${elapsed_s},${BATCH:-0},${event},${INPUT_FORCE},${CURRENT_MAX_PAGES_PER_BATCH},${PULL_STATUS},${PULL_DURATION_S},${GIT_PULL_S},${GIT_ADD_S},${GIT_DIFF_S},${GIT_COMMIT_S},${GIT_PUSH_S},${committed:-na},${HAS_MORE},${idle_has_more:-0},${safe_reason}
+EOF
+}
+
+init_observability() {
+  if [ -z "$FIGMACLAW_SYNC_OBS_DIR" ]; then
+    return
+  fi
+  mkdir -p "$FIGMACLAW_SYNC_OBS_DIR"
+  OBS_EVENTS_FILE="${FIGMACLAW_SYNC_OBS_DIR}/checkpoint_events.csv"
+  OBS_SUMMARY_FILE="${FIGMACLAW_SYNC_OBS_DIR}/checkpoint_summary.txt"
+  cat > "$OBS_EVENTS_FILE" <<EOF
+ts_utc,elapsed_s,batch,event,input_force,max_pages,pull_status,pull_duration_s,git_pull_s,git_add_s,git_diff_s,git_commit_s,git_push_s,committed,has_more,idle_has_more,reason
+EOF
+}
 
 set_pull_args() {
   if [ "$INPUT_FORCE" = "true" ]; then
@@ -23,53 +76,99 @@ set_pull_args() {
 }
 
 run_pull_batch() {
+  local t0 t1
+  t0="$(date +%s)"
   set +e
   timeout "$BATCH_TIMEOUT_SECONDS" figmaclaw pull "${PULL_ARGS[@]}" | tee "$FIGMACLAW_OUT_PATH"
   PULL_STATUS=${PIPESTATUS[0]}
   set -e
+  t1="$(date +%s)"
+  PULL_DURATION_S="$((t1 - t0))"
 }
 
 commit_if_changed() {
+  local t0 t1
+  GIT_PULL_S=0
+  GIT_ADD_S=0
+  GIT_DIFF_S=0
+  GIT_COMMIT_S=0
+  GIT_PUSH_S=0
+
+  t0="$(date +%s)"
   git pull --no-rebase --ff-only origin main
+  t1="$(date +%s)"
+  GIT_PULL_S="$((t1 - t0))"
+
+  t0="$(date +%s)"
   git add figma/ .figma-sync/
+  t1="$(date +%s)"
+  GIT_ADD_S="$((t1 - t0))"
+
+  t0="$(date +%s)"
   if git diff --cached --quiet; then
+    t1="$(date +%s)"
+    GIT_DIFF_S="$((t1 - t0))"
     echo "false"
     return
   fi
+  t1="$(date +%s)"
+  GIT_DIFF_S="$((t1 - t0))"
 
   COMMIT_MSG="$(grep '^COMMIT_MSG:' "$FIGMACLAW_OUT_PATH" | head -1 | sed 's/^COMMIT_MSG://' | tr -d '\n\r')"
   COMMIT_MSG="${COMMIT_MSG:-sync: figmaclaw — checkpoint batch $BATCH}"
+
+  t0="$(date +%s)"
   git commit -m "${COMMIT_MSG}"
+  t1="$(date +%s)"
+  GIT_COMMIT_S="$((t1 - t0))"
+
+  t0="$(date +%s)"
   git push
+  t1="$(date +%s)"
+  GIT_PUSH_S="$((t1 - t0))"
   echo "true"
 }
 
+init_observability
+emit_obs "loop_start" "checkpoint loop started"
+
 idle_has_more=0
-PULL_STATUS=0
 BATCH=0
+committed="na"
 while true; do
   BATCH=$((BATCH + 1))
   if [ "$BATCH" -gt "$MAX_BATCHES" ]; then
     echo "Reached MAX_BATCHES=$MAX_BATCHES; stopping checkpoint loop early."
+    FINAL_REASON="max_batches"
+    emit_obs "loop_break" "Reached MAX_BATCHES"
     break
   fi
 
+  BATCHES_STARTED=$((BATCHES_STARTED + 1))
+  HAS_MORE="false"
+  committed="na"
   echo "--- batch $BATCH ---"
+  emit_obs "batch_start" "starting batch"
 
   set_pull_args
   run_pull_batch
   pull_status="$PULL_STATUS"
 
   if [ "$pull_status" -eq 124 ]; then
+    TOTAL_TIMEOUTS=$((TOTAL_TIMEOUTS + 1))
     if [ "$INPUT_FORCE" != "true" ] && [ "$CURRENT_MAX_PAGES_PER_BATCH" -gt 1 ]; then
       CURRENT_MAX_PAGES_PER_BATCH=$((CURRENT_MAX_PAGES_PER_BATCH / 2))
       if [ "$CURRENT_MAX_PAGES_PER_BATCH" -lt 1 ]; then
         CURRENT_MAX_PAGES_PER_BATCH=1
       fi
+      TOTAL_BACKOFFS=$((TOTAL_BACKOFFS + 1))
       echo "figmaclaw pull timed out after ${BATCH_TIMEOUT_SECONDS}s; retrying with --max-pages ${CURRENT_MAX_PAGES_PER_BATCH}."
+      emit_obs "batch_timeout_backoff" "timeout with retry"
       continue
     fi
     echo "figmaclaw pull timed out after ${BATCH_TIMEOUT_SECONDS}s; stopping checkpoint loop early."
+    FINAL_REASON="timeout_stop"
+    emit_obs "batch_timeout_stop" "timeout without retry"
     break
   fi
 
@@ -77,21 +176,55 @@ while true; do
   CURRENT_MAX_PAGES_PER_BATCH="$MAX_PAGES_PER_BATCH"
 
   committed="$(commit_if_changed)"
+  if [ "$committed" = "true" ]; then
+    TOTAL_COMMITS=$((TOTAL_COMMITS + 1))
+  fi
 
   if grep -q '^HAS_MORE:true' "$FIGMACLAW_OUT_PATH"; then
+    HAS_MORE="true"
     if [ "$committed" = false ]; then
       idle_has_more=$((idle_has_more + 1))
       echo "HAS_MORE:true with no commit (idle_has_more=$idle_has_more/$MAX_IDLE_HAS_MORE_BATCHES)"
       if [ "$idle_has_more" -ge "$MAX_IDLE_HAS_MORE_BATCHES" ]; then
         echo "Stopping loop after repeated HAS_MORE:true without progress."
+        FINAL_REASON="idle_has_more_limit"
+        emit_obs "batch_end" "idle has_more limit reached"
         break
       fi
     else
       idle_has_more=0
     fi
   else
+    FINAL_REASON="has_more_false"
+    emit_obs "batch_end" "HAS_MORE false"
     break
   fi
 
-  [ "$INPUT_FORCE" = "true" ] && break
+  emit_obs "batch_end" "HAS_MORE true, continuing"
+
+  if [ "$INPUT_FORCE" = "true" ]; then
+    FINAL_REASON="force_single_batch"
+    emit_obs "loop_break" "force mode single batch"
+    break
+  fi
 done
+
+emit_obs "loop_end" "$FINAL_REASON"
+
+if [ -n "$OBS_SUMMARY_FILE" ]; then
+  total_elapsed_s="$(( $(date +%s) - SCRIPT_START_EPOCH ))"
+  cat > "$OBS_SUMMARY_FILE" <<EOF
+total_elapsed_s=${total_elapsed_s}
+batches_started=${BATCHES_STARTED}
+total_commits=${TOTAL_COMMITS}
+total_timeouts=${TOTAL_TIMEOUTS}
+total_backoffs=${TOTAL_BACKOFFS}
+final_reason=${FINAL_REASON}
+max_batches=${MAX_BATCHES}
+max_pages_per_batch=${MAX_PAGES_PER_BATCH}
+batch_timeout_seconds=${BATCH_TIMEOUT_SECONDS}
+input_force=${INPUT_FORCE}
+EOF
+  echo "SYNC_OBS summary_file=${OBS_SUMMARY_FILE}"
+  echo "SYNC_OBS events_file=${OBS_EVENTS_FILE}"
+fi

--- a/tests/test_checkpoint_pull_loop.py
+++ b/tests/test_checkpoint_pull_loop.py
@@ -205,6 +205,20 @@ def test_force_uses_force_flag_only(tmp_path: Path) -> None:
     assert args == "pull --force"
 
 
+def test_non_force_includes_team_prefilter_args_when_present(tmp_path: Path) -> None:
+    _run_loop(
+        tmp_path,
+        scenario="single_done",
+        git_dirty="1",
+        timeout_mode="pass",
+        MAX_PAGES_PER_BATCH="7",
+        FIGMA_TEAM_ID="12345",
+        SINCE="7d",
+    )
+    args = (tmp_path / "pull-args.txt").read_text().strip()
+    assert args == "pull --max-pages 7 --team-id 12345 --since 7d"
+
+
 def test_timeout_retries_with_smaller_batch_then_succeeds(tmp_path: Path) -> None:
     out = _run_loop(
         tmp_path,

--- a/tests/test_checkpoint_pull_loop.py
+++ b/tests/test_checkpoint_pull_loop.py
@@ -229,3 +229,31 @@ def test_timeout_does_not_retry_in_force_mode(tmp_path: Path) -> None:
     count = int((tmp_path / "count.txt").read_text())
     assert count == 1
     assert "stopping checkpoint loop early." in out
+
+
+def test_emits_sync_observability_logs_and_files(tmp_path: Path) -> None:
+    obs_dir = tmp_path / "obs"
+    out = _run_loop(
+        tmp_path,
+        scenario="single_done",
+        git_dirty="1",
+        timeout_mode="pass",
+        FIGMACLAW_SYNC_OBS_DIR=str(obs_dir),
+    )
+
+    events = obs_dir / "checkpoint_events.csv"
+    summary = obs_dir / "checkpoint_summary.txt"
+    assert events.exists()
+    assert summary.exists()
+
+    events_text = events.read_text()
+    assert "event" in events_text.splitlines()[0]
+    assert "batch_start" in events_text
+    assert "loop_end" in events_text
+
+    summary_text = summary.read_text()
+    assert "batches_started=" in summary_text
+    assert "total_commits=1" in summary_text
+
+    assert "SYNC_OBS event=batch_start" in out
+    assert "SYNC_OBS summary_file=" in out

--- a/tests/test_pull_logic.py
+++ b/tests/test_pull_logic.py
@@ -1118,6 +1118,43 @@ async def test_pull_cmd_forwards_prune_flag_to_pull_file(tmp_path: Path):
     assert mock_pull.await_args.kwargs["prune"] is False
 
 
+@pytest.mark.asyncio
+async def test_pull_cmd_emits_observability_lines(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+):
+    """INVARIANT: pull command emits structured SYNC_OBS_PULL lines for profiling."""
+    from figmaclaw.commands.pull import _run
+
+    state = _make_state_with_file(tmp_path, "fileA", "")
+    state.save()
+
+    mock_client = MagicMock(spec=FigmaClient)
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+    mock_client.get_file_meta = AsyncMock(
+        return_value={
+            "version": "v2",
+            "lastModified": "2026-03-01T00:00:00Z",
+            "name": "App",
+            "document": {"children": []},
+        }
+    )
+
+    with (
+        patch("figmaclaw.commands.pull.FigmaClient", return_value=mock_client),
+        patch(
+            "figmaclaw.commands.pull.pull_file",
+            AsyncMock(return_value=PullResult(file_key="fileA", skipped_file=True)),
+        ),
+    ):
+        await _run("key", tmp_path, None, False, None, False, 10, None, "all")
+
+    out = capsys.readouterr().out
+    assert "SYNC_OBS_PULL event=run_start" in out
+    assert "SYNC_OBS_PULL event=file_end file_key=fileA outcome=pull_skipped" in out
+    assert "SYNC_OBS_PULL event=run_end" in out
+
+
 # --- _compute_raw_frames ---
 
 


### PR DESCRIPTION
## Why
Current sync debugging is too opaque while runs are active. We can see step-level status, but not where checkpoint-loop time is spent (pull call vs git checkpoint stages, timeout/backoff paths, commit cadence).

## What this adds
1. Structured checkpoint telemetry in `scripts/checkpoint_pull_loop.sh`
- Emits normalized `SYNC_OBS ...` lines in live logs for every significant event.
- Writes `checkpoint_events.csv` with per-event timings and state.
- Writes `checkpoint_summary.txt` with rollup counters and final exit reason.

2. Reusable sync workflow artifact upload (`.github/workflows/sync.yml`)
- Sets `FIGMACLAW_SYNC_OBS_DIR` in the pull step.
- Prints summary file in logs (`if: always()`).
- Uploads `figmaclaw-sync-observability-<run>-<attempt>` artifact (`if: always()`).

3. Tests + format docs
- `tests/test_checkpoint_pull_loop.py`: verifies observability files and `SYNC_OBS` lines are emitted.
- `docs/sync-observability.md`: defines live line contract, CSV schema, and summary keys.

## Format (contract)
`checkpoint_events.csv` columns:
`ts_utc,elapsed_s,batch,event,input_force,max_pages,pull_status,pull_duration_s,git_pull_s,git_add_s,git_diff_s,git_commit_s,git_push_s,committed,has_more,idle_has_more,reason`

## Validation
- `uv run pytest -q tests/test_checkpoint_pull_loop.py` -> 9 passed
- `uv run pytest -q tests/test_workflow_template_invariants.py` -> 4 passed
