### PR TITLE
fix(sync): add heartbeat and clean observability output

### DIFF
--- a/docs/sync-observability.md
+++ b/docs/sync-observability.md
@@ -26,7 +26,14 @@ Key events:
 
 - `run_start` / `run_end`
 - `listing_prefilter` (when `--team-id` is used)
+- `file_heartbeat` (every N seconds while a single file pull is still running; default 30s)
 - `file_end` (one line per considered file with outcome + duration)
+
+`file_end` outcomes include:
+
+- `updated`: file processing produced page/component/schema writes
+- `processed_no_writes`: file was processed but no page/component/schema writes occurred
+- `pull_skipped`, `listing_prefilter_skip`, `manifest_skipped`, `no_access_pruned`, `error`
 
 ## Artifact files
 

--- a/figmaclaw/commands/pull.py
+++ b/figmaclaw/commands/pull.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import os
 import time
 from pathlib import Path
 from typing import Any
@@ -182,6 +183,33 @@ class _PullObs:
         self.emit("run_end", **payload)
 
 
+def _pull_heartbeat_seconds() -> int:
+    raw = os.getenv("FIGMACLAW_PULL_HEARTBEAT_SECONDS", "30").strip()
+    with contextlib.suppress(ValueError):
+        val = int(raw)
+        return max(val, 0)
+    return 30
+
+
+async def _file_heartbeat_loop(
+    obs: _PullObs, *, file_key: str, file_start: float, stop_event: asyncio.Event, interval_s: int
+) -> None:
+    if interval_s <= 0:
+        return
+    while not stop_event.is_set():
+        try:
+            await asyncio.wait_for(stop_event.wait(), timeout=interval_s)
+            return
+        except TimeoutError:
+            obs.emit(
+                "file_heartbeat",
+                file_key=file_key,
+                elapsed_s=round(time.monotonic() - file_start, 3),
+                interval_s=interval_s,
+                note="still_processing",
+            )
+
+
 async def _listing_prefilter(
     client: FigmaClient,
     team_id: str,
@@ -269,6 +297,7 @@ async def _run(
         since=since,
         prune=prune,
     )
+    heartbeat_interval_s = _pull_heartbeat_seconds()
 
     def on_page_written(page_label: str, paths: list[str]) -> None:
         nonlocal commit_count
@@ -351,16 +380,30 @@ async def _run(
 
             try:
                 obs.files_attempted_pull += 1
-                result = await pull_file(
-                    client,
-                    key,
-                    state,
-                    repo_dir,
-                    force=force,
-                    max_pages=pages_budget,
-                    prune=prune,
-                    on_page_written=on_page_written,
+                stop_heartbeat = asyncio.Event()
+                heartbeat_task = asyncio.create_task(
+                    _file_heartbeat_loop(
+                        obs,
+                        file_key=key,
+                        file_start=file_start,
+                        stop_event=stop_heartbeat,
+                        interval_s=heartbeat_interval_s,
+                    )
                 )
+                try:
+                    result = await pull_file(
+                        client,
+                        key,
+                        state,
+                        repo_dir,
+                        force=force,
+                        max_pages=pages_budget,
+                        prune=prune,
+                        on_page_written=on_page_written,
+                    )
+                finally:
+                    stop_heartbeat.set()
+                    await asyncio.gather(heartbeat_task, return_exceptions=True)
             except Exception as exc:
                 click.echo(f"{key}: error — {exc} (skipping)")
                 obs.files_errors += 1
@@ -405,7 +448,17 @@ async def _run(
                 click.echo(f"{key}: unchanged (skipped)")
                 obs.file_end(key, "pull_skipped", file_start)
             else:
-                obs.files_updated += 1
+                wrote_any = bool(
+                    result.pages_written
+                    or result.component_sections_written
+                    or result.pages_schema_upgraded
+                )
+                if wrote_any:
+                    obs.files_updated += 1
+                    outcome = "updated"
+                else:
+                    # Pull processed file-level metadata but wrote no page/component output.
+                    outcome = "processed_no_writes"
                 errored = f", {result.pages_errored} error(s)" if result.pages_errored else ""
                 upgraded = (
                     f", {result.pages_schema_upgraded} schema-upgraded"
@@ -421,7 +474,7 @@ async def _run(
                     click.echo(f"  ❖ {path}")
                 obs.file_end(
                     key,
-                    "updated",
+                    outcome,
                     file_start,
                     pages_written=result.pages_written,
                     components_written=result.component_sections_written,

--- a/scripts/checkpoint_pull_loop.sh
+++ b/scripts/checkpoint_pull_loop.sh
@@ -100,17 +100,17 @@ commit_if_changed() {
   GIT_PUSH_S=0
 
   t0="$(date +%s)"
-  git pull --no-rebase --ff-only origin main
+  git pull --no-rebase --ff-only origin main >&2
   t1="$(date +%s)"
   GIT_PULL_S="$((t1 - t0))"
 
   t0="$(date +%s)"
-  git add figma/ .figma-sync/
+  git add figma/ .figma-sync/ >&2
   t1="$(date +%s)"
   GIT_ADD_S="$((t1 - t0))"
 
   t0="$(date +%s)"
-  if git diff --cached --quiet; then
+  if git diff --cached --quiet >&2; then
     t1="$(date +%s)"
     GIT_DIFF_S="$((t1 - t0))"
     echo "false"
@@ -123,12 +123,12 @@ commit_if_changed() {
   COMMIT_MSG="${COMMIT_MSG:-sync: figmaclaw — checkpoint batch $BATCH}"
 
   t0="$(date +%s)"
-  git commit -m "${COMMIT_MSG}"
+  git commit -m "${COMMIT_MSG}" >&2
   t1="$(date +%s)"
   GIT_COMMIT_S="$((t1 - t0))"
 
   t0="$(date +%s)"
-  git push
+  git push >&2
   t1="$(date +%s)"
   GIT_PUSH_S="$((t1 - t0))"
   echo "true"

--- a/tests/test_pull_logic.py
+++ b/tests/test_pull_logic.py
@@ -22,6 +22,7 @@ Current: see test_schema_upgrade_does_not_cause_infinite_loop_with_max_pages (v2
 
 from __future__ import annotations
 
+import asyncio
 import json
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -1153,6 +1154,87 @@ async def test_pull_cmd_emits_observability_lines(
     assert "SYNC_OBS_PULL event=run_start" in out
     assert "SYNC_OBS_PULL event=file_end file_key=fileA outcome=pull_skipped" in out
     assert "SYNC_OBS_PULL event=run_end" in out
+
+
+@pytest.mark.asyncio
+async def test_pull_cmd_observability_uses_processed_no_writes_outcome(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """INVARIANT: non-skipped pulls with zero writes are labeled processed_no_writes."""
+    from figmaclaw.commands.pull import _run
+
+    state = _make_state_with_file(tmp_path, "fileA", "")
+    state.save()
+
+    mock_client = MagicMock(spec=FigmaClient)
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+    mock_client.get_file_meta = AsyncMock(
+        return_value={
+            "version": "v2",
+            "lastModified": "2026-03-01T00:00:00Z",
+            "name": "App",
+            "document": {"children": []},
+        }
+    )
+
+    with (
+        patch("figmaclaw.commands.pull.FigmaClient", return_value=mock_client),
+        patch(
+            "figmaclaw.commands.pull.pull_file",
+            AsyncMock(
+                return_value=PullResult(
+                    file_key="fileA",
+                    skipped_file=False,
+                    pages_written=0,
+                    component_sections_written=0,
+                    pages_schema_upgraded=0,
+                    pages_skipped=3,
+                )
+            ),
+        ),
+    ):
+        await _run("key", tmp_path, None, False, None, False, 10, None, "all")
+
+    out = capsys.readouterr().out
+    assert "SYNC_OBS_PULL event=file_end file_key=fileA outcome=processed_no_writes" in out
+
+
+@pytest.mark.asyncio
+async def test_pull_cmd_emits_file_heartbeat_for_long_pull(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """INVARIANT: long pull_file calls emit periodic file_heartbeat observability."""
+    from figmaclaw.commands.pull import _run
+
+    state = _make_state_with_file(tmp_path, "fileA", "")
+    state.save()
+    monkeypatch.setenv("FIGMACLAW_PULL_HEARTBEAT_SECONDS", "1")
+
+    mock_client = MagicMock(spec=FigmaClient)
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+    mock_client.get_file_meta = AsyncMock(
+        return_value={
+            "version": "v2",
+            "lastModified": "2026-03-01T00:00:00Z",
+            "name": "App",
+            "document": {"children": []},
+        }
+    )
+
+    async def _slow_pull_file(*_args, **_kwargs) -> PullResult:
+        await asyncio.sleep(1.2)
+        return PullResult(file_key="fileA", skipped_file=True)
+
+    with (
+        patch("figmaclaw.commands.pull.FigmaClient", return_value=mock_client),
+        patch("figmaclaw.commands.pull.pull_file", side_effect=_slow_pull_file),
+    ):
+        await _run("key", tmp_path, None, False, None, False, 10, None, "all")
+
+    out = capsys.readouterr().out
+    assert "SYNC_OBS_PULL event=file_heartbeat file_key=fileA" in out
 
 
 # --- _compute_raw_frames ---


### PR DESCRIPTION
## Why
Recent observability improved root-cause visibility, but two issues remained:
1. Long single-file pulls could appear silent for minutes.
2. `SYNC_OBS_PULL` used `outcome=updated` even when no writes happened, which was cryptic.
3. `SYNC_OBS committed=...` could be polluted by git command stdout captured in command substitution.

## What changed
1. 30s heartbeat for long file processing in `figmaclaw pull`
- Added `SYNC_OBS_PULL event=file_heartbeat ... note=still_processing` every 30s while a file is being pulled.
- Interval configurable via `FIGMACLAW_PULL_HEARTBEAT_SECONDS` (default `30`).

2. Clearer file outcome semantics
- `file_end outcome=updated` only when writes occurred (pages/components/schema-upgrade).
- Added `file_end outcome=processed_no_writes` when file processing ran but produced no writes.

3. Fixed checkpoint committed-field pollution
- In `scripts/checkpoint_pull_loop.sh`, git command stdout/stderr for commit-stage commands is redirected to stderr so `committed="$(commit_if_changed)"` remains clean `true|false`.

4. Docs update
- `docs/sync-observability.md` now documents heartbeat event and outcome semantics.

## Tests
- Added pull observability tests:
  - `processed_no_writes` outcome assertion
  - heartbeat emission assertion for long pull
- Existing checkpoint loop tests still pass.

## Validation
- `pytest -q tests/test_pull_logic.py -k "observability_lines or processed_no_writes or file_heartbeat"` -> 3 passed
- `pytest -q tests/test_checkpoint_pull_loop.py` -> 10 passed
