### PR TITLE
fix: skip _census.md in claude-run enrichment selection

### DIFF
--- a/figmaclaw/commands/claude_run.py
+++ b/figmaclaw/commands/claude_run.py
@@ -125,6 +125,10 @@ def enrichment_info(md_path: Path) -> tuple[bool, int]:
     * Else has ``enriched_hash`` in fm?      → already enriched → skip.
     * Counts body table rows for a frame-size estimate.
     """
+    # Census files are inventories, not page docs; never send them to enrichment.
+    if md_path.name == "_census.md":
+        return False, 0
+
     try:
         text = md_path.read_text()
     except OSError:
@@ -174,8 +178,8 @@ def collect_files(
       gets the full CI timeout.
     """
     if target.is_file():
-        return [target]
-    if changed_only:
+        files = [target]
+    elif changed_only:
         files = _changed_files(target, glob_pattern)
     else:
         files = sorted(target.glob(glob_pattern))

--- a/tests/smoke/test_claude_run_smoke.py
+++ b/tests/smoke/test_claude_run_smoke.py
@@ -62,3 +62,46 @@ def test_claude_run_needs_enrichment_backfills_placeholder_pages(tmp_path: Path)
     out = result.output
     assert str(md_placeholder) in out
     assert str(md_clean) not in out
+
+
+@pytest.mark.smoke
+def test_claude_run_needs_enrichment_excludes_census_files(tmp_path: Path) -> None:
+    """Smoke: _census.md must never be queued as an enrichable page."""
+    figma_file_dir = tmp_path / "figma" / "design-system-abc123"
+    pages = figma_file_dir / "pages"
+    md_pending = pages / "pending-page.md"
+    _write_page(md_pending, enriched=False, placeholder=True)
+
+    census_md = figma_file_dir / "_census.md"
+    census_md.parent.mkdir(parents=True, exist_ok=True)
+    census_md.write_text(
+        "\n".join(
+            [
+                "---",
+                "file_key: abc123",
+                "---",
+                "",
+                "| Component set | Key | Page | Updated |",
+                "|---|---|---|---|",
+                "| `Button` | `k1` | Components | 2026-04-15 |",
+            ]
+        )
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        [
+            "--repo-dir",
+            str(tmp_path),
+            "claude-run",
+            str(tmp_path / "figma"),
+            "--needs-enrichment",
+            "--dry-run",
+        ],
+    )
+
+    assert result.exit_code == 0
+    out = result.output
+    assert str(md_pending) in out
+    assert str(census_md) not in out

--- a/tests/test_claude_run.py
+++ b/tests/test_claude_run.py
@@ -214,6 +214,24 @@ class TestEnrichmentInfo:
         assert needs is True
         assert count == 1
 
+    def test_census_file_is_never_enrichable(self, tmp_path: Path) -> None:
+        """_census.md is an inventory artifact and must never enter enrichment."""
+        md = tmp_path / "_census.md"
+        md.write_text(
+            textwrap.dedent("""\
+            ---
+            file_key: abc123
+            ---
+
+            | Component set | Key | Page | Updated |
+            |---|---|---|---|
+            | `Button` | `k1` | Components | 2026-04-15 |
+        """)
+        )
+        needs, count = enrichment_info(md)
+        assert needs is False
+        assert count == 0
+
 
 # ---------------------------------------------------------------------------
 # collect_files — file discovery and filtering
@@ -321,6 +339,27 @@ class TestCollectFiles:
             tmp_path / "figma", "**/*.md", changed_only=False, needs_enrichment=True
         )
         assert [r.name for r in result] == ["small.md", "medium.md", "big.md"]
+
+    def test_needs_enrichment_skips_census_files(self, tmp_path: Path) -> None:
+        """Census markdown files must never be selected for enrichment."""
+        figma_dir = tmp_path / "figma" / "design-system-abc123"
+        pages = figma_dir / "pages"
+        self._make_page(pages / "pending.md", enriched=False, frames=3)
+        (figma_dir / "_census.md").write_text(
+            textwrap.dedent("""\
+            ---
+            file_key: abc123
+            ---
+
+            | Component set | Key | Page | Updated |
+            |---|---|---|---|
+            | `Button` | `k1` | Components | 2026-04-15 |
+        """)
+        )
+        result = collect_files(
+            tmp_path / "figma", "**/*.md", changed_only=False, needs_enrichment=True
+        )
+        assert [r.name for r in result] == ["pending.md"]
 
     def test_empty_directory(self, tmp_path: Path) -> None:
         """Empty directory → empty list, no crash."""


### PR DESCRIPTION
## Problem
`claude-run --needs-enrichment` was selecting `figma/**/_census.md` files, which are inventory artifacts (not page docs). This created noisy `figmaclaw inspect .../_census.md` tracebacks and wasted enrichment time.

## Fix
- Treat `_census.md` as non-enrichable in `enrichment_info()`.
- Keep single-file targets on the same filtering path to avoid bypass inconsistencies.
- Add tests proving census files are never selected.

## Validation
- `uv run pytest -q tests/test_claude_run.py`
- `45 passed`
