### PR TITLE
fix: harden claude-run filtering, screenshot cache, and checkpoint observability

### DIFF
--- a/figmaclaw/commands/claude_run.py
+++ b/figmaclaw/commands/claude_run.py
@@ -183,6 +183,16 @@ def collect_files(
         files = _changed_files(target, glob_pattern)
     else:
         files = sorted(target.glob(glob_pattern))
+
+    # Census markdown is an inventory artifact, never a page-enrichment target.
+    census_count = sum(1 for f in files if f.name == "_census.md")
+    if census_count:
+        files = [f for f in files if f.name != "_census.md"]
+        click.echo(
+            f"[claude-run] skipping {census_count} census file(s) (_census.md, non-enrichable)",
+            err=True,
+        )
+
     if needs_enrichment:
         before = len(files)
         enrichable: list[tuple[Path, int]] = []

--- a/figmaclaw/commands/claude_run.py
+++ b/figmaclaw/commands/claude_run.py
@@ -49,6 +49,7 @@ from figmaclaw.verdict import (
 SECTION_THRESHOLD = 80  # pages/sections above this use incremental mode
 ENRICHMENT_LOG = ".figma-sync/enrichment-log.csv"
 STREAM_JSON_LOG = ".figma-sync/claude-stream.jsonl"  # raw stream-json, appended per batch
+NON_ENRICHABLE_MARKDOWN_BASENAMES = frozenset({"_census.md"})
 
 
 def _log_enrichment(
@@ -114,6 +115,17 @@ def _changed_files(base: Path, glob_pattern: str) -> list[Path]:
     return sorted(result)
 
 
+def _is_non_enrichable_markdown(path: Path) -> bool:
+    """Return True when a markdown artifact should never be enriched."""
+    return path.name in NON_ENRICHABLE_MARKDOWN_BASENAMES
+
+
+def _exclude_non_enrichable_markdown(files: list[Path]) -> tuple[list[Path], int]:
+    """Drop known non-enrichable markdown artifacts from discovered files."""
+    filtered = [f for f in files if not _is_non_enrichable_markdown(f)]
+    return filtered, len(files) - len(filtered)
+
+
 def enrichment_info(md_path: Path) -> tuple[bool, int]:
     """Fast check: does *md_path* need enrichment?
 
@@ -125,8 +137,8 @@ def enrichment_info(md_path: Path) -> tuple[bool, int]:
     * Else has ``enriched_hash`` in fm?      → already enriched → skip.
     * Counts body table rows for a frame-size estimate.
     """
-    # Census files are inventories, not page docs; never send them to enrichment.
-    if md_path.name == "_census.md":
+    # Inventory artifacts are never page-enrichment targets.
+    if _is_non_enrichable_markdown(md_path):
         return False, 0
 
     try:
@@ -184,12 +196,10 @@ def collect_files(
     else:
         files = sorted(target.glob(glob_pattern))
 
-    # Census markdown is an inventory artifact, never a page-enrichment target.
-    census_count = sum(1 for f in files if f.name == "_census.md")
-    if census_count:
-        files = [f for f in files if f.name != "_census.md"]
+    files, skipped_non_enrichable = _exclude_non_enrichable_markdown(files)
+    if skipped_non_enrichable:
         click.echo(
-            f"[claude-run] skipping {census_count} census file(s) (_census.md, non-enrichable)",
+            (f"[claude-run] skipping {skipped_non_enrichable} non-enrichable markdown artifact(s)"),
             err=True,
         )
 

--- a/figmaclaw/commands/screenshots.py
+++ b/figmaclaw/commands/screenshots.py
@@ -150,24 +150,40 @@ async def _run(
     if not node_ids:
         return {"file_key": file_key, "screenshots": []}
 
+    requested_node_ids = list(node_ids)
+
     # In non-stale modes, reuse existing local cache files to avoid repeated
     # downloads during local retries. In --stale mode we always refresh.
     cached_screenshots: list[dict[str, str]] = []
     if not stale_only:
         uncached_ids: list[str] = []
+        invalid_cache_count = 0
         for node_id in node_ids:
             cached_path = screenshot_cache_path(repo_dir, file_key, node_id)
-            if cached_path.exists():
+            if cached_path.is_file() and cached_path.stat().st_size > 0:
                 try:
                     rel = str(cached_path.relative_to(repo_dir))
                 except ValueError:
                     rel = str(cached_path)
                 cached_screenshots.append({"node_id": node_id, "path": rel})
             else:
+                if cached_path.exists():
+                    invalid_cache_count += 1
                 uncached_ids.append(node_id)
+        click.echo(
+            (
+                f"[screenshots] cache hits={len(cached_screenshots)} "
+                f"misses={len(uncached_ids)} invalid={invalid_cache_count}"
+            ),
+            err=True,
+        )
         node_ids = uncached_ids
 
     if not node_ids:
+        click.echo(
+            f"[screenshots] cache satisfied all {len(requested_node_ids)} frame(s); no fetch needed",
+            err=True,
+        )
         return {"file_key": file_key, "screenshots": cached_screenshots, "failed": []}
 
     lock_path = repo_dir / ".figma-cache" / _DOWNLOAD_LOCK_FILENAME
@@ -204,7 +220,9 @@ async def _run(
         await asyncio.to_thread(_release, lock_fd)
 
     downloaded = [r for r in results if isinstance(r, dict)]
-    screenshots = cached_screenshots + downloaded
+    screenshot_by_id = {s["node_id"]: s for s in cached_screenshots}
+    screenshot_by_id.update({s["node_id"]: s for s in downloaded})
+    screenshots = [screenshot_by_id[nid] for nid in requested_node_ids if nid in screenshot_by_id]
     # Frames where Figma returned null URL (hidden/deleted/unrenderable)
     null_url = {nid for nid, url in all_urls.items() if url is None}
     # Frames where download failed (URL existed but PNG download errored)

--- a/figmaclaw/commands/screenshots.py
+++ b/figmaclaw/commands/screenshots.py
@@ -30,6 +30,16 @@ from figmaclaw.staleness import stale_frame_ids_from_manifest
 
 _MAX_CONCURRENT_DOWNLOADS = 10
 _DOWNLOAD_LOCK_FILENAME = ".figma-downloads.lock"
+_ALLOWED_SCREENSHOT_EXTS = {".png", ".jpg", ".jpeg", ".svg"}
+
+
+def _is_valid_cached_screenshot(path: Path) -> bool:
+    """Return True when a cached screenshot path is a supported non-empty file."""
+    return (
+        path.is_file()
+        and path.suffix.lower() in _ALLOWED_SCREENSHOT_EXTS
+        and path.stat().st_size > 0
+    )
 
 
 @click.command("screenshots")
@@ -160,7 +170,7 @@ async def _run(
         invalid_cache_count = 0
         for node_id in node_ids:
             cached_path = screenshot_cache_path(repo_dir, file_key, node_id)
-            if cached_path.is_file() and cached_path.stat().st_size > 0:
+            if _is_valid_cached_screenshot(cached_path):
                 try:
                     rel = str(cached_path.relative_to(repo_dir))
                 except ValueError:

--- a/figmaclaw/commands/screenshots.py
+++ b/figmaclaw/commands/screenshots.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 import asyncio
 import fcntl
 import json
+import os
 from pathlib import Path
 from typing import Any
 
@@ -33,13 +34,42 @@ _DOWNLOAD_LOCK_FILENAME = ".figma-downloads.lock"
 _ALLOWED_SCREENSHOT_EXTS = {".png", ".jpg", ".jpeg", ".svg"}
 
 
+def _looks_like_supported_image_bytes(head: bytes, suffix: str) -> bool:
+    """Validate basic file signature for supported screenshot formats."""
+    ext = suffix.lower()
+    if ext == ".png":
+        return head.startswith(b"\x89PNG\r\n\x1a\n")
+    if ext in {".jpg", ".jpeg"}:
+        return head.startswith(b"\xff\xd8\xff")
+    if ext == ".svg":
+        text = head.decode("utf-8", errors="ignore").lstrip().lower()
+        return text.startswith("<svg") or "<svg" in text
+    return False
+
+
 def _is_valid_cached_screenshot(path: Path) -> bool:
     """Return True when a cached screenshot path is a supported non-empty file."""
-    return (
-        path.is_file()
-        and path.suffix.lower() in _ALLOWED_SCREENSHOT_EXTS
-        and path.stat().st_size > 0
-    )
+    ext = path.suffix.lower()
+    if ext not in _ALLOWED_SCREENSHOT_EXTS:
+        return False
+    if not path.is_file():
+        return False
+    try:
+        if path.stat().st_size <= 0:
+            return False
+        with path.open("rb") as f:
+            head = f.read(4096)
+    except OSError:
+        return False
+    return _looks_like_supported_image_bytes(head, ext)
+
+
+def _path_for_manifest(repo_dir: Path, path: Path) -> str:
+    """Render path as repo-relative when possible, absolute otherwise."""
+    try:
+        return str(path.relative_to(repo_dir))
+    except ValueError:
+        return str(path)
 
 
 @click.command("screenshots")
@@ -162,40 +192,6 @@ async def _run(
 
     requested_node_ids = list(node_ids)
 
-    # In non-stale modes, reuse existing local cache files to avoid repeated
-    # downloads during local retries. In --stale mode we always refresh.
-    cached_screenshots: list[dict[str, str]] = []
-    if not stale_only:
-        uncached_ids: list[str] = []
-        invalid_cache_count = 0
-        for node_id in node_ids:
-            cached_path = screenshot_cache_path(repo_dir, file_key, node_id)
-            if _is_valid_cached_screenshot(cached_path):
-                try:
-                    rel = str(cached_path.relative_to(repo_dir))
-                except ValueError:
-                    rel = str(cached_path)
-                cached_screenshots.append({"node_id": node_id, "path": rel})
-            else:
-                if cached_path.exists():
-                    invalid_cache_count += 1
-                uncached_ids.append(node_id)
-        click.echo(
-            (
-                f"[screenshots] cache hits={len(cached_screenshots)} "
-                f"misses={len(uncached_ids)} invalid={invalid_cache_count}"
-            ),
-            err=True,
-        )
-        node_ids = uncached_ids
-
-    if not node_ids:
-        click.echo(
-            f"[screenshots] cache satisfied all {len(requested_node_ids)} frame(s); no fetch needed",
-            err=True,
-        )
-        return {"file_key": file_key, "screenshots": cached_screenshots, "failed": []}
-
     lock_path = repo_dir / ".figma-cache" / _DOWNLOAD_LOCK_FILENAME
 
     def _acquire() -> Any:
@@ -210,6 +206,42 @@ async def _run(
 
     lock_fd = await asyncio.to_thread(_acquire)
     try:
+        # In non-stale modes, reuse existing local cache files to avoid repeated
+        # downloads during local retries. In --stale mode we always refresh.
+        cached_screenshots: list[dict[str, str]] = []
+        if not stale_only:
+            uncached_ids: list[str] = []
+            invalid_cache_count = 0
+            for node_id in node_ids:
+                cached_path = screenshot_cache_path(repo_dir, file_key, node_id)
+                if _is_valid_cached_screenshot(cached_path):
+                    cached_screenshots.append(
+                        {"node_id": node_id, "path": _path_for_manifest(repo_dir, cached_path)}
+                    )
+                else:
+                    if cached_path.exists():
+                        invalid_cache_count += 1
+                    uncached_ids.append(node_id)
+            click.echo(
+                (
+                    f"[screenshots] file_key={file_key} stale_only={stale_only} "
+                    f"cache hits={len(cached_screenshots)} "
+                    f"misses={len(uncached_ids)} invalid={invalid_cache_count}"
+                ),
+                err=True,
+            )
+            node_ids = uncached_ids
+
+        if not node_ids:
+            click.echo(
+                (
+                    f"[screenshots] file_key={file_key} stale_only={stale_only} "
+                    f"cache satisfied all {len(requested_node_ids)} frame(s); no fetch needed"
+                ),
+                err=True,
+            )
+            return {"file_key": file_key, "screenshots": cached_screenshots, "failed": []}
+
         async with FigmaClient(api_key) as client:
             all_urls = await get_image_urls_batched(
                 client,
@@ -260,11 +292,12 @@ async def _download_one(
 
     out_path = screenshot_cache_path(repo_dir, file_key, node_id)
     out_path.parent.mkdir(parents=True, exist_ok=True)
-    out_path.write_bytes(data)
-
+    tmp_path = out_path.with_suffix(f"{out_path.suffix}.tmp.{os.getpid()}")
     try:
-        rel = str(out_path.relative_to(repo_dir))
-    except ValueError:
-        rel = str(out_path)
+        tmp_path.write_bytes(data)
+        os.replace(tmp_path, out_path)
+    finally:
+        if tmp_path.exists():
+            tmp_path.unlink(missing_ok=True)
 
-    return {"node_id": node_id, "path": rel}
+    return {"node_id": node_id, "path": _path_for_manifest(repo_dir, out_path)}

--- a/figmaclaw/commands/screenshots.py
+++ b/figmaclaw/commands/screenshots.py
@@ -150,6 +150,26 @@ async def _run(
     if not node_ids:
         return {"file_key": file_key, "screenshots": []}
 
+    # In non-stale modes, reuse existing local cache files to avoid repeated
+    # downloads during local retries. In --stale mode we always refresh.
+    cached_screenshots: list[dict[str, str]] = []
+    if not stale_only:
+        uncached_ids: list[str] = []
+        for node_id in node_ids:
+            cached_path = screenshot_cache_path(repo_dir, file_key, node_id)
+            if cached_path.exists():
+                try:
+                    rel = str(cached_path.relative_to(repo_dir))
+                except ValueError:
+                    rel = str(cached_path)
+                cached_screenshots.append({"node_id": node_id, "path": rel})
+            else:
+                uncached_ids.append(node_id)
+        node_ids = uncached_ids
+
+    if not node_ids:
+        return {"file_key": file_key, "screenshots": cached_screenshots, "failed": []}
+
     lock_path = repo_dir / ".figma-cache" / _DOWNLOAD_LOCK_FILENAME
 
     def _acquire() -> Any:
@@ -183,7 +203,8 @@ async def _run(
     finally:
         await asyncio.to_thread(_release, lock_fd)
 
-    screenshots = [r for r in results if isinstance(r, dict)]
+    downloaded = [r for r in results if isinstance(r, dict)]
+    screenshots = cached_screenshots + downloaded
     # Frames where Figma returned null URL (hidden/deleted/unrenderable)
     null_url = {nid for nid, url in all_urls.items() if url is None}
     # Frames where download failed (URL existed but PNG download errored)

--- a/scripts/checkpoint_pull_loop.sh
+++ b/scripts/checkpoint_pull_loop.sh
@@ -174,6 +174,7 @@ while true; do
     echo "figmaclaw pull timed out after ${BATCH_TIMEOUT_SECONDS}s; stopping checkpoint loop early."
     FINAL_REASON="timeout_stop"
     emit_obs "batch_timeout_stop" "timeout without retry"
+    emit_obs "batch_end" "timeout stop"
     break
   fi
 

--- a/tests/smoke/test_claude_run_smoke.py
+++ b/tests/smoke/test_claude_run_smoke.py
@@ -105,3 +105,45 @@ def test_claude_run_needs_enrichment_excludes_census_files(tmp_path: Path) -> No
     out = result.output
     assert str(md_pending) in out
     assert str(census_md) not in out
+
+
+@pytest.mark.smoke
+def test_claude_run_dry_run_also_excludes_census_files(tmp_path: Path) -> None:
+    """Smoke: _census.md is excluded even without --needs-enrichment."""
+    figma_file_dir = tmp_path / "figma" / "design-system-abc123"
+    pages = figma_file_dir / "pages"
+    md_page = pages / "pending-page.md"
+    _write_page(md_page, enriched=False, placeholder=True)
+
+    census_md = figma_file_dir / "_census.md"
+    census_md.parent.mkdir(parents=True, exist_ok=True)
+    census_md.write_text(
+        "\n".join(
+            [
+                "---",
+                "file_key: abc123",
+                "---",
+                "",
+                "| Component set | Key | Page | Updated |",
+                "|---|---|---|---|",
+                "| `Button` | `k1` | Components | 2026-04-15 |",
+            ]
+        )
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        [
+            "--repo-dir",
+            str(tmp_path),
+            "claude-run",
+            str(tmp_path / "figma"),
+            "--dry-run",
+        ],
+    )
+
+    assert result.exit_code == 0
+    out = result.output
+    assert str(md_page) in out
+    assert str(census_md) not in out

--- a/tests/test_checkpoint_pull_loop.py
+++ b/tests/test_checkpoint_pull_loop.py
@@ -271,3 +271,19 @@ def test_emits_sync_observability_logs_and_files(tmp_path: Path) -> None:
 
     assert "SYNC_OBS event=batch_start" in out
     assert "SYNC_OBS summary_file=" in out
+
+
+def test_timeout_stop_emits_batch_end_event(tmp_path: Path) -> None:
+    obs_dir = tmp_path / "obs"
+    _run_loop(
+        tmp_path,
+        scenario="single_done",
+        git_dirty="1",
+        timeout_mode="always",
+        FIGMACLAW_SYNC_OBS_DIR=str(obs_dir),
+    )
+
+    events_text = (obs_dir / "checkpoint_events.csv").read_text()
+    assert "batch_start" in events_text
+    assert "batch_timeout_stop" in events_text
+    assert "batch_end" in events_text

--- a/tests/test_claude_run.py
+++ b/tests/test_claude_run.py
@@ -262,6 +262,13 @@ class TestCollectFiles:
         result = collect_files(md, "**/*.md", changed_only=False)
         assert result == [md]
 
+    def test_single_file_target_census_is_skipped(self, tmp_path: Path) -> None:
+        """Single-file census targets are ignored as non-enrichable artifacts."""
+        census = tmp_path / "_census.md"
+        census.write_text("---\nfile_key: abc123\n---\n")
+        result = collect_files(census, "**/*.md", changed_only=False)
+        assert result == []
+
     def test_directory_glob(self, tmp_path: Path) -> None:
         """Directory target → glob matches."""
         pages = tmp_path / "figma" / "pages"
@@ -270,6 +277,16 @@ class TestCollectFiles:
         (tmp_path / "figma" / "other.txt").write_text("not a match")
         result = collect_files(tmp_path / "figma", "**/*.md", changed_only=False)
         assert len(result) == 2
+
+    def test_directory_glob_skips_census_even_without_needs_enrichment(
+        self, tmp_path: Path
+    ) -> None:
+        """Census files are excluded during discovery even without needs_enrichment."""
+        root = tmp_path / "figma" / "web-app-abc123"
+        self._make_page(root / "pages" / "a.md")
+        (root / "_census.md").write_text("---\nfile_key: abc123\n---\n")
+        result = collect_files(tmp_path / "figma", "**/*.md", changed_only=False)
+        assert [p.name for p in result] == ["a.md"]
 
     def test_needs_enrichment_filters_enriched(self, tmp_path: Path) -> None:
         """needs_enrichment=True filters out files with enriched_hash."""

--- a/tests/test_screenshots.py
+++ b/tests/test_screenshots.py
@@ -253,8 +253,8 @@ async def test_screenshots_non_stale_reuses_existing_cache(tmp_path: Path) -> No
     # Existing cached frame is skipped from fetch list.
     mock_client.get_image_urls.assert_called_once_with("abc123", ["11:2"])
     mock_client.download_url.assert_called_once_with("http://example.com/2.png")
-    node_ids = {s["node_id"] for s in result["screenshots"]}
-    assert node_ids == {"11:1", "11:2"}
+    node_ids = [s["node_id"] for s in result["screenshots"]]
+    assert node_ids == ["11:1", "11:2"]
     assert result["failed"] == []
 
 
@@ -282,8 +282,63 @@ async def test_screenshots_non_stale_all_cached_skips_figma_fetch(tmp_path: Path
 
     mock_client.get_image_urls.assert_not_called()
     mock_client.download_url.assert_not_called()
-    node_ids = {s["node_id"] for s in result["screenshots"]}
-    assert node_ids == {"11:1", "11:2"}
+    node_ids = [s["node_id"] for s in result["screenshots"]]
+    assert node_ids == ["11:1", "11:2"]
+    assert result["failed"] == []
+
+
+@pytest.mark.asyncio
+async def test_screenshots_non_stale_invalid_cache_is_refetched(tmp_path: Path) -> None:
+    """INVARIANT: invalid cache artifacts (e.g., empty file) are treated as misses."""
+    md_path = _write_md(tmp_path, _make_page(["11:1"]))
+    invalid_cache = screenshot_cache_path(tmp_path, "abc123", "11:1")
+    invalid_cache.parent.mkdir(parents=True, exist_ok=True)
+    invalid_cache.write_bytes(b"")
+
+    mock_client = MagicMock(spec=FigmaClient)
+    mock_client.get_image_urls = AsyncMock(return_value={"11:1": "http://example.com/1.png"})
+    mock_client.download_url = AsyncMock(return_value=b"\x89PNG\r\nfresh")
+
+    with patch.object(screenshots_module, "FigmaClient") as MockClientClass:
+        MockClientClass.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+        MockClientClass.return_value.__aexit__ = AsyncMock(return_value=False)
+
+        result = await screenshots_module._run(
+            "fake-key", tmp_path, md_path, pending_only=False, stale_only=False
+        )
+
+    mock_client.get_image_urls.assert_called_once_with("abc123", ["11:1"])
+    mock_client.download_url.assert_called_once_with("http://example.com/1.png")
+    assert [s["node_id"] for s in result["screenshots"]] == ["11:1"]
+    assert result["failed"] == []
+
+
+@pytest.mark.asyncio
+async def test_screenshots_non_stale_preserves_requested_node_order(tmp_path: Path) -> None:
+    """INVARIANT: screenshot manifest preserves source node order with mixed cache hits/misses."""
+    md_path = _write_md(tmp_path, _make_page(["11:1", "11:2", "11:3"]))
+    cached = screenshot_cache_path(tmp_path, "abc123", "11:2")
+    cached.parent.mkdir(parents=True, exist_ok=True)
+    cached.write_bytes(b"\x89PNG\r\ncached")
+
+    mock_client = MagicMock(spec=FigmaClient)
+    mock_client.get_image_urls = AsyncMock(
+        return_value={
+            "11:1": "http://example.com/1.png",
+            "11:3": "http://example.com/3.png",
+        }
+    )
+    mock_client.download_url = AsyncMock(return_value=b"\x89PNG\r\nfresh")
+
+    with patch.object(screenshots_module, "FigmaClient") as MockClientClass:
+        MockClientClass.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+        MockClientClass.return_value.__aexit__ = AsyncMock(return_value=False)
+
+        result = await screenshots_module._run(
+            "fake-key", tmp_path, md_path, pending_only=False, stale_only=False
+        )
+
+    assert [s["node_id"] for s in result["screenshots"]] == ["11:1", "11:2", "11:3"]
     assert result["failed"] == []
 
 
@@ -332,6 +387,33 @@ async def test_screenshots_stale_mode_downloads_even_if_cached(tmp_path: Path) -
     assert mock_client.download_url.call_count == 2
     node_ids = {s["node_id"] for s in result["screenshots"]}
     assert node_ids == {"11:1", "11:2"}
+
+
+@pytest.mark.asyncio
+async def test_screenshots_logs_cache_summary_for_fast_path(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """INVARIANT: non-stale all-cached path emits cache hit/miss observability logs."""
+    md_path = _write_md(tmp_path, _make_page(["11:1", "11:2"]))
+    for node_id in ("11:1", "11:2"):
+        cached = screenshot_cache_path(tmp_path, "abc123", node_id)
+        cached.parent.mkdir(parents=True, exist_ok=True)
+        cached.write_bytes(b"\x89PNG\r\ncached")
+
+    mock_client = MagicMock(spec=FigmaClient)
+    mock_client.get_image_urls = AsyncMock(return_value={})
+    mock_client.download_url = AsyncMock(return_value=b"\x89PNG\r\nfresh")
+
+    with patch.object(screenshots_module, "FigmaClient") as MockClientClass:
+        MockClientClass.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+        MockClientClass.return_value.__aexit__ = AsyncMock(return_value=False)
+        await screenshots_module._run(
+            "fake-key", tmp_path, md_path, pending_only=False, stale_only=False
+        )
+
+    captured = capsys.readouterr()
+    assert "cache hits=2 misses=0 invalid=0" in captured.err
+    assert "cache satisfied all 2 frame(s); no fetch needed" in captured.err
 
 
 def test_screenshots_semaphore_limit_constant() -> None:

--- a/tests/test_screenshots.py
+++ b/tests/test_screenshots.py
@@ -22,6 +22,8 @@ from figmaclaw.figma_paths import screenshot_cache_path
 from figmaclaw.figma_render import scaffold_page
 from figmaclaw.figma_sync_state import FileEntry, PageEntry
 
+_VALID_PNG_HEADER = b"\x89PNG\r\n\x1a\n"
+
 
 def _make_page(node_ids: list[str] | None = None, described: bool = False) -> FigmaPage:
     ids = node_ids or ["11:1", "11:2", "11:3"]
@@ -62,6 +64,11 @@ def _write_md(tmp_path: Path, page: FigmaPage) -> Path:
     return p
 
 
+def _write_valid_png(path: Path, payload: bytes = b"cached") -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(_VALID_PNG_HEADER + payload)
+
+
 @pytest.mark.asyncio
 async def test_screenshots_returns_manifest_with_file_key(tmp_path: Path) -> None:
     """INVARIANT: screenshots result always contains file_key."""
@@ -75,7 +82,7 @@ async def test_screenshots_returns_manifest_with_file_key(tmp_path: Path) -> Non
             "11:3": "http://example.com/3.png",
         }
     )
-    mock_client.download_url = AsyncMock(return_value=b"\x89PNG\r\n")
+    mock_client.download_url = AsyncMock(return_value=_VALID_PNG_HEADER + b"ok")
 
     with patch.object(screenshots_module, "FigmaClient") as MockClientClass:
         MockClientClass.return_value.__aenter__ = AsyncMock(return_value=mock_client)
@@ -101,7 +108,7 @@ async def test_screenshots_successful_downloads_in_manifest(tmp_path: Path) -> N
             "11:2": "http://example.com/2.png",
         }
     )
-    mock_client.download_url = AsyncMock(return_value=b"\x89PNG\r\n")
+    mock_client.download_url = AsyncMock(return_value=_VALID_PNG_HEADER + b"ok")
 
     with patch.object(screenshots_module, "FigmaClient") as MockClientClass:
         MockClientClass.return_value.__aenter__ = AsyncMock(return_value=mock_client)
@@ -214,7 +221,7 @@ async def test_screenshots_pending_only_skips_described_frames(tmp_path: Path) -
 
     mock_client = MagicMock(spec=FigmaClient)
     mock_client.get_image_urls = AsyncMock(return_value={"11:2": "http://example.com/2.png"})
-    mock_client.download_url = AsyncMock(return_value=b"\x89PNG\r\n")
+    mock_client.download_url = AsyncMock(return_value=_VALID_PNG_HEADER + b"ok")
 
     with patch.object(screenshots_module, "FigmaClient") as MockClientClass:
         MockClientClass.return_value.__aenter__ = AsyncMock(return_value=mock_client)
@@ -235,12 +242,11 @@ async def test_screenshots_non_stale_reuses_existing_cache(tmp_path: Path) -> No
     """INVARIANT: non-stale runs skip re-downloading already cached screenshots."""
     md_path = _write_md(tmp_path, _make_page(["11:1", "11:2"]))
     cached = screenshot_cache_path(tmp_path, "abc123", "11:1")
-    cached.parent.mkdir(parents=True, exist_ok=True)
-    cached.write_bytes(b"\x89PNG\r\ncached")
+    _write_valid_png(cached)
 
     mock_client = MagicMock(spec=FigmaClient)
     mock_client.get_image_urls = AsyncMock(return_value={"11:2": "http://example.com/2.png"})
-    mock_client.download_url = AsyncMock(return_value=b"\x89PNG\r\nfresh")
+    mock_client.download_url = AsyncMock(return_value=_VALID_PNG_HEADER + b"fresh")
 
     with patch.object(screenshots_module, "FigmaClient") as MockClientClass:
         MockClientClass.return_value.__aenter__ = AsyncMock(return_value=mock_client)
@@ -264,13 +270,12 @@ async def test_screenshots_non_stale_all_cached_skips_figma_fetch(tmp_path: Path
     md_path = _write_md(tmp_path, _make_page(["11:1", "11:2"]))
     cached_1 = screenshot_cache_path(tmp_path, "abc123", "11:1")
     cached_2 = screenshot_cache_path(tmp_path, "abc123", "11:2")
-    cached_1.parent.mkdir(parents=True, exist_ok=True)
-    cached_1.write_bytes(b"\x89PNG\r\ncached-1")
-    cached_2.write_bytes(b"\x89PNG\r\ncached-2")
+    _write_valid_png(cached_1, b"cached-1")
+    _write_valid_png(cached_2, b"cached-2")
 
     mock_client = MagicMock(spec=FigmaClient)
     mock_client.get_image_urls = AsyncMock(return_value={})
-    mock_client.download_url = AsyncMock(return_value=b"\x89PNG\r\nfresh")
+    mock_client.download_url = AsyncMock(return_value=_VALID_PNG_HEADER + b"fresh")
 
     with patch.object(screenshots_module, "FigmaClient") as MockClientClass:
         MockClientClass.return_value.__aenter__ = AsyncMock(return_value=mock_client)
@@ -297,7 +302,33 @@ async def test_screenshots_non_stale_invalid_cache_is_refetched(tmp_path: Path) 
 
     mock_client = MagicMock(spec=FigmaClient)
     mock_client.get_image_urls = AsyncMock(return_value={"11:1": "http://example.com/1.png"})
-    mock_client.download_url = AsyncMock(return_value=b"\x89PNG\r\nfresh")
+    mock_client.download_url = AsyncMock(return_value=_VALID_PNG_HEADER + b"fresh")
+
+    with patch.object(screenshots_module, "FigmaClient") as MockClientClass:
+        MockClientClass.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+        MockClientClass.return_value.__aexit__ = AsyncMock(return_value=False)
+
+        result = await screenshots_module._run(
+            "fake-key", tmp_path, md_path, pending_only=False, stale_only=False
+        )
+
+    mock_client.get_image_urls.assert_called_once_with("abc123", ["11:1"])
+    mock_client.download_url.assert_called_once_with("http://example.com/1.png")
+    assert [s["node_id"] for s in result["screenshots"]] == ["11:1"]
+    assert result["failed"] == []
+
+
+@pytest.mark.asyncio
+async def test_screenshots_non_stale_corrupt_png_is_refetched(tmp_path: Path) -> None:
+    """INVARIANT: non-image content with .png extension is treated as invalid cache."""
+    md_path = _write_md(tmp_path, _make_page(["11:1"]))
+    corrupt = screenshot_cache_path(tmp_path, "abc123", "11:1")
+    corrupt.parent.mkdir(parents=True, exist_ok=True)
+    corrupt.write_bytes(b"<html>error</html>")
+
+    mock_client = MagicMock(spec=FigmaClient)
+    mock_client.get_image_urls = AsyncMock(return_value={"11:1": "http://example.com/1.png"})
+    mock_client.download_url = AsyncMock(return_value=_VALID_PNG_HEADER + b"fresh")
 
     with patch.object(screenshots_module, "FigmaClient") as MockClientClass:
         MockClientClass.return_value.__aenter__ = AsyncMock(return_value=mock_client)
@@ -328,7 +359,7 @@ async def test_screenshots_non_stale_unsupported_extension_is_refetched(tmp_path
 
     mock_client = MagicMock(spec=FigmaClient)
     mock_client.get_image_urls = AsyncMock(return_value={"11:1": "http://example.com/1.png"})
-    mock_client.download_url = AsyncMock(return_value=b"\x89PNG\r\nfresh")
+    mock_client.download_url = AsyncMock(return_value=_VALID_PNG_HEADER + b"fresh")
 
     with (
         patch.object(screenshots_module, "screenshot_cache_path", side_effect=_cache_path),
@@ -351,8 +382,7 @@ async def test_screenshots_non_stale_preserves_requested_node_order(tmp_path: Pa
     """INVARIANT: screenshot manifest preserves source node order with mixed cache hits/misses."""
     md_path = _write_md(tmp_path, _make_page(["11:1", "11:2", "11:3"]))
     cached = screenshot_cache_path(tmp_path, "abc123", "11:2")
-    cached.parent.mkdir(parents=True, exist_ok=True)
-    cached.write_bytes(b"\x89PNG\r\ncached")
+    _write_valid_png(cached)
 
     mock_client = MagicMock(spec=FigmaClient)
     mock_client.get_image_urls = AsyncMock(
@@ -361,7 +391,7 @@ async def test_screenshots_non_stale_preserves_requested_node_order(tmp_path: Pa
             "11:3": "http://example.com/3.png",
         }
     )
-    mock_client.download_url = AsyncMock(return_value=b"\x89PNG\r\nfresh")
+    mock_client.download_url = AsyncMock(return_value=_VALID_PNG_HEADER + b"fresh")
 
     with patch.object(screenshots_module, "FigmaClient") as MockClientClass:
         MockClientClass.return_value.__aenter__ = AsyncMock(return_value=mock_client)
@@ -380,8 +410,7 @@ async def test_screenshots_stale_mode_downloads_even_if_cached(tmp_path: Path) -
     """INVARIANT: --stale always refreshes selected stale frames, ignoring cache presence."""
     md_path = _write_md(tmp_path, _make_page(["11:1", "11:2"]))
     cached = screenshot_cache_path(tmp_path, "abc123", "11:1")
-    cached.parent.mkdir(parents=True, exist_ok=True)
-    cached.write_bytes(b"\x89PNG\r\nold")
+    _write_valid_png(cached, b"old")
 
     state = screenshots_module.load_state(tmp_path)
     state.manifest.files["abc123"] = FileEntry(
@@ -405,7 +434,7 @@ async def test_screenshots_stale_mode_downloads_even_if_cached(tmp_path: Path) -
     mock_client.get_image_urls = AsyncMock(
         return_value={"11:1": "http://example.com/1.png", "11:2": "http://example.com/2.png"}
     )
-    mock_client.download_url = AsyncMock(return_value=b"\x89PNG\r\nfresh")
+    mock_client.download_url = AsyncMock(return_value=_VALID_PNG_HEADER + b"fresh")
 
     with patch.object(screenshots_module, "FigmaClient") as MockClientClass:
         MockClientClass.return_value.__aenter__ = AsyncMock(return_value=mock_client)
@@ -430,12 +459,11 @@ async def test_screenshots_logs_cache_summary_for_fast_path(
     md_path = _write_md(tmp_path, _make_page(["11:1", "11:2"]))
     for node_id in ("11:1", "11:2"):
         cached = screenshot_cache_path(tmp_path, "abc123", node_id)
-        cached.parent.mkdir(parents=True, exist_ok=True)
-        cached.write_bytes(b"\x89PNG\r\ncached")
+        _write_valid_png(cached)
 
     mock_client = MagicMock(spec=FigmaClient)
     mock_client.get_image_urls = AsyncMock(return_value={})
-    mock_client.download_url = AsyncMock(return_value=b"\x89PNG\r\nfresh")
+    mock_client.download_url = AsyncMock(return_value=_VALID_PNG_HEADER + b"fresh")
 
     with patch.object(screenshots_module, "FigmaClient") as MockClientClass:
         MockClientClass.return_value.__aenter__ = AsyncMock(return_value=mock_client)

--- a/tests/test_screenshots.py
+++ b/tests/test_screenshots.py
@@ -314,6 +314,39 @@ async def test_screenshots_non_stale_invalid_cache_is_refetched(tmp_path: Path) 
 
 
 @pytest.mark.asyncio
+async def test_screenshots_non_stale_unsupported_extension_is_refetched(tmp_path: Path) -> None:
+    """INVARIANT: cache files with unsupported extension are treated as invalid."""
+    md_path = _write_md(tmp_path, _make_page(["11:1"]))
+    unsupported = tmp_path / ".figma-cache" / "screenshots" / "abc123" / "11-1.webp"
+    unsupported.parent.mkdir(parents=True, exist_ok=True)
+    unsupported.write_bytes(b"RIFF....WEBP")
+
+    def _cache_path(_: Path, __: str, node_id: str) -> Path:
+        if node_id == "11:1":
+            return unsupported
+        raise AssertionError(f"unexpected node id {node_id}")
+
+    mock_client = MagicMock(spec=FigmaClient)
+    mock_client.get_image_urls = AsyncMock(return_value={"11:1": "http://example.com/1.png"})
+    mock_client.download_url = AsyncMock(return_value=b"\x89PNG\r\nfresh")
+
+    with (
+        patch.object(screenshots_module, "screenshot_cache_path", side_effect=_cache_path),
+        patch.object(screenshots_module, "FigmaClient") as MockClientClass,
+    ):
+        MockClientClass.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+        MockClientClass.return_value.__aexit__ = AsyncMock(return_value=False)
+        result = await screenshots_module._run(
+            "fake-key", tmp_path, md_path, pending_only=False, stale_only=False
+        )
+
+    mock_client.get_image_urls.assert_called_once_with("abc123", ["11:1"])
+    mock_client.download_url.assert_called_once_with("http://example.com/1.png")
+    assert [s["node_id"] for s in result["screenshots"]] == ["11:1"]
+    assert result["failed"] == []
+
+
+@pytest.mark.asyncio
 async def test_screenshots_non_stale_preserves_requested_node_order(tmp_path: Path) -> None:
     """INVARIANT: screenshot manifest preserves source node order with mixed cache hits/misses."""
     md_path = _write_md(tmp_path, _make_page(["11:1", "11:2", "11:3"]))

--- a/tests/test_screenshots.py
+++ b/tests/test_screenshots.py
@@ -252,6 +252,36 @@ async def test_screenshots_non_stale_reuses_existing_cache(tmp_path: Path) -> No
 
     # Existing cached frame is skipped from fetch list.
     mock_client.get_image_urls.assert_called_once_with("abc123", ["11:2"])
+    mock_client.download_url.assert_called_once_with("http://example.com/2.png")
+    node_ids = {s["node_id"] for s in result["screenshots"]}
+    assert node_ids == {"11:1", "11:2"}
+    assert result["failed"] == []
+
+
+@pytest.mark.asyncio
+async def test_screenshots_non_stale_all_cached_skips_figma_fetch(tmp_path: Path) -> None:
+    """INVARIANT: non-stale runs do zero Figma calls when all requested frames are cached."""
+    md_path = _write_md(tmp_path, _make_page(["11:1", "11:2"]))
+    cached_1 = screenshot_cache_path(tmp_path, "abc123", "11:1")
+    cached_2 = screenshot_cache_path(tmp_path, "abc123", "11:2")
+    cached_1.parent.mkdir(parents=True, exist_ok=True)
+    cached_1.write_bytes(b"\x89PNG\r\ncached-1")
+    cached_2.write_bytes(b"\x89PNG\r\ncached-2")
+
+    mock_client = MagicMock(spec=FigmaClient)
+    mock_client.get_image_urls = AsyncMock(return_value={})
+    mock_client.download_url = AsyncMock(return_value=b"\x89PNG\r\nfresh")
+
+    with patch.object(screenshots_module, "FigmaClient") as MockClientClass:
+        MockClientClass.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+        MockClientClass.return_value.__aexit__ = AsyncMock(return_value=False)
+
+        result = await screenshots_module._run(
+            "fake-key", tmp_path, md_path, pending_only=False, stale_only=False
+        )
+
+    mock_client.get_image_urls.assert_not_called()
+    mock_client.download_url.assert_not_called()
     node_ids = {s["node_id"] for s in result["screenshots"]}
     assert node_ids == {"11:1", "11:2"}
     assert result["failed"] == []
@@ -299,6 +329,7 @@ async def test_screenshots_stale_mode_downloads_even_if_cached(tmp_path: Path) -
 
     # Both stale frames are fetched, including one with an existing local cache file.
     mock_client.get_image_urls.assert_called_once_with("abc123", ["11:1", "11:2"])
+    assert mock_client.download_url.call_count == 2
     node_ids = {s["node_id"] for s in result["screenshots"]}
     assert node_ids == {"11:1", "11:2"}
 

--- a/tests/test_screenshots.py
+++ b/tests/test_screenshots.py
@@ -18,8 +18,9 @@ import pytest
 from figmaclaw.commands import screenshots as screenshots_module
 from figmaclaw.figma_client import FigmaClient
 from figmaclaw.figma_models import FigmaFrame, FigmaPage, FigmaSection
+from figmaclaw.figma_paths import screenshot_cache_path
 from figmaclaw.figma_render import scaffold_page
-from figmaclaw.figma_sync_state import PageEntry
+from figmaclaw.figma_sync_state import FileEntry, PageEntry
 
 
 def _make_page(node_ids: list[str] | None = None, described: bool = False) -> FigmaPage:
@@ -227,6 +228,79 @@ async def test_screenshots_pending_only_skips_described_frames(tmp_path: Path) -
     mock_client.get_image_urls.assert_called_once_with("abc123", ["11:2"])
     node_ids = {s["node_id"] for s in result["screenshots"]}
     assert node_ids == {"11:2"}
+
+
+@pytest.mark.asyncio
+async def test_screenshots_non_stale_reuses_existing_cache(tmp_path: Path) -> None:
+    """INVARIANT: non-stale runs skip re-downloading already cached screenshots."""
+    md_path = _write_md(tmp_path, _make_page(["11:1", "11:2"]))
+    cached = screenshot_cache_path(tmp_path, "abc123", "11:1")
+    cached.parent.mkdir(parents=True, exist_ok=True)
+    cached.write_bytes(b"\x89PNG\r\ncached")
+
+    mock_client = MagicMock(spec=FigmaClient)
+    mock_client.get_image_urls = AsyncMock(return_value={"11:2": "http://example.com/2.png"})
+    mock_client.download_url = AsyncMock(return_value=b"\x89PNG\r\nfresh")
+
+    with patch.object(screenshots_module, "FigmaClient") as MockClientClass:
+        MockClientClass.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+        MockClientClass.return_value.__aexit__ = AsyncMock(return_value=False)
+
+        result = await screenshots_module._run(
+            "fake-key", tmp_path, md_path, pending_only=False, stale_only=False
+        )
+
+    # Existing cached frame is skipped from fetch list.
+    mock_client.get_image_urls.assert_called_once_with("abc123", ["11:2"])
+    node_ids = {s["node_id"] for s in result["screenshots"]}
+    assert node_ids == {"11:1", "11:2"}
+    assert result["failed"] == []
+
+
+@pytest.mark.asyncio
+async def test_screenshots_stale_mode_downloads_even_if_cached(tmp_path: Path) -> None:
+    """INVARIANT: --stale always refreshes selected stale frames, ignoring cache presence."""
+    md_path = _write_md(tmp_path, _make_page(["11:1", "11:2"]))
+    cached = screenshot_cache_path(tmp_path, "abc123", "11:1")
+    cached.parent.mkdir(parents=True, exist_ok=True)
+    cached.write_bytes(b"\x89PNG\r\nold")
+
+    state = screenshots_module.load_state(tmp_path)
+    state.manifest.files["abc123"] = FileEntry(
+        file_name="Web App",
+        version="v1",
+        last_modified="2026-03-31T00:00:00Z",
+        pages={},
+    )
+    page_entry = PageEntry(
+        page_name="Onboarding",
+        page_slug="onboarding",
+        md_path=str(md_path.relative_to(tmp_path)),
+        page_hash="deadbeef",
+        last_refreshed_at="2026-03-31T00:00:00Z",
+        frame_hashes={"11:1": "new-h1", "11:2": "new-h2"},
+    )
+    state.set_page_entry("abc123", "7741:45837", page_entry)
+    state.save()
+
+    mock_client = MagicMock(spec=FigmaClient)
+    mock_client.get_image_urls = AsyncMock(
+        return_value={"11:1": "http://example.com/1.png", "11:2": "http://example.com/2.png"}
+    )
+    mock_client.download_url = AsyncMock(return_value=b"\x89PNG\r\nfresh")
+
+    with patch.object(screenshots_module, "FigmaClient") as MockClientClass:
+        MockClientClass.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+        MockClientClass.return_value.__aexit__ = AsyncMock(return_value=False)
+
+        result = await screenshots_module._run(
+            "fake-key", tmp_path, md_path, pending_only=False, stale_only=True
+        )
+
+    # Both stale frames are fetched, including one with an existing local cache file.
+    mock_client.get_image_urls.assert_called_once_with("abc123", ["11:1", "11:2"])
+    node_ids = {s["node_id"] for s in result["screenshots"]}
+    assert node_ids == {"11:1", "11:2"}
 
 
 def test_screenshots_semaphore_limit_constant() -> None:


### PR DESCRIPTION
## Summary
This PR now includes three related reliability tracks:
1. hard-filter non-enrichable `_census.md` artifacts from `claude-run`
2. harden screenshot cache correctness/resumability in `screenshots`
3. fix checkpoint observability lifecycle so timeout-stop batches also emit `batch_end`

## What Changed
### 1) `claude-run` census filtering (DRY + defense-in-depth)
- Centralized non-enrichable markdown filtering logic.
- `_census.md` is excluded in discovery and still guarded in enrichment checks.
- Added/kept tests for single-file and directory discovery behavior, including dry-run paths.

### 2) Screenshot cache hardening
- Reuse cache only when artifact is:
  - supported extension (`.png`, `.jpg`, `.jpeg`, `.svg`)
  - regular file
  - non-empty
  - valid by lightweight format signature checks
- Acquire lock before cache classification (eliminates pre-lock TOCTOU window).
- Use atomic writes (`tmp` + `os.replace`) for downloaded screenshots.
- Preserve manifest ordering by requested node order.
- Added cache observability logs with contextual fields (`file_key`, `stale_only`, hit/miss/invalid counters).

### 3) Checkpoint loop observability lifecycle
- Emit `batch_end` on timeout-stop path for consistent batch lifecycle events.
- Added regression test for timeout-stop event sequence.

## Test Plan
Behavioral invariants covered by tests:
- `_census.md` is never an enrichment target (single file, directory, smoke dry-run).
- Non-stale screenshot runs reuse only valid cache entries.
- Invalid/unsupported/corrupt cache entries are treated as misses and re-fetched.
- All-cached non-stale path makes zero network calls.
- Manifest order remains deterministic with mixed cache hits/misses.
- Stale mode always refreshes targeted stale frames.
- Cache summary logs emit expected observability messages.
- Timeout-stop checkpoint path emits both timeout and `batch_end` lifecycle events.

## Validation Run
Executed locally:
- `uv run pytest -q tests/test_screenshots.py tests/test_claude_run.py tests/smoke/test_claude_run_smoke.py -k "screenshots or census or claude_run_dry_run_also_excludes_census_files"`
- `20 passed`

- `uv run pytest -q tests/test_checkpoint_pull_loop.py`
- `11 passed`

## Rollback Notes
If needed, rollback can be done per concern:
- `claude-run` filtering logic/tests
- `screenshots` cache hardening logic/tests
- checkpoint loop observability event change/tests
