### PR TITLE
ci: make Dependabot PRs auto-mergeable without weakening normal PR checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -173,6 +173,7 @@ jobs:
 
   smoke-api:
     name: smoke-api-ci
+    if: github.event_name != 'pull_request' || github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     timeout-minutes: 20
 
@@ -212,6 +213,7 @@ jobs:
 
   smoke-webhook:
     name: smoke-webhook-ci
+    if: github.event_name != 'pull_request' || github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     timeout-minutes: 20
 
@@ -251,6 +253,7 @@ jobs:
 
   smoke-mcp:
     name: smoke-mcp-ci
+    if: github.event_name != 'pull_request' || github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     timeout-minutes: 20
 

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -14,7 +14,6 @@ on:
 permissions:
   contents: write
   pull-requests: write
-  workflows: write
 
 jobs:
   auto-merge-event:


### PR DESCRIPTION
## Summary
- skip secret-dependent smoke jobs only for Dependabot `pull_request` events
- remove invalid `workflows: write` permission from Dependabot auto-merge workflow (workflow currently fails on startup)

## Why this fixes red Dependabot PRs
- Dependabot PRs cannot read repo secrets, so `smoke-api-ci`, `smoke-webhook-ci`, and `smoke-mcp-ci` fail immediately today
- those smoke jobs are not in branch protection required checks, but they still make PRs red/unstable
- with this guard they are skipped only for Dependabot PRs; required checks still run

## Safety proof
- guard expression: `github.event_name != 'pull_request' || github.actor != 'dependabot[bot]'`
- dependabot PR => `false` (skip smoke)
- normal PR => `true` (run smoke)
- push to main => `true` (run smoke)

## Validation
- YAML parse OK for both changed workflow files
- existing branch protection required checks unchanged: `ruff-format`, `ruff-lint`, `typecheck`, `test`, `Analyze (python)`
