### PR TITLE
Fix enrichment no-progress loops, prompt staging noise, and log-header migration

### DIFF
--- a/figmaclaw/commands/claude_run.py
+++ b/figmaclaw/commands/claude_run.py
@@ -88,6 +88,15 @@ LEGACY_ENRICHMENT_LOG_FIELDS: tuple[str, ...] = (
     "claude_duration_ms",
     "stop_reason",
 )
+MINIMAL_LEGACY_ENRICHMENT_LOG_FIELDS: tuple[str, ...] = (
+    "timestamp",
+    "file",
+    "mode",
+    "frames",
+    "duration_s",
+    "success",
+    "section",
+)
 
 _EVENT_ID_CACHE: dict[Path, set[str]] = {}
 
@@ -326,13 +335,27 @@ def _ensure_enrichment_log_schema(repo_dir: Path, log_path: Path) -> bool:
         _rebuild_event_id_index(repo_dir, migrated)
         return True
 
-    if set(LEGACY_ENRICHMENT_LOG_FIELDS).issubset(set(fieldnames)):
+    if set(ENRICHMENT_LOG_FIELDS).issubset(set(fieldnames)):
         normalized = [_row_to_current(row) for row in rows]
         _rewrite_csv_rows(log_path, normalized)
         _rebuild_event_id_index(repo_dir, normalized)
         _warn_enrichment_log(
             repo_dir, "normalized non-canonical enrichment log header to schema-v1"
         )
+        return True
+
+    if set(LEGACY_ENRICHMENT_LOG_FIELDS).issubset(set(fieldnames)):
+        normalized = [_row_to_current(row) for row in rows]
+        _rewrite_csv_rows(log_path, normalized)
+        _rebuild_event_id_index(repo_dir, normalized)
+        _warn_enrichment_log(repo_dir, "normalized legacy enrichment log header to schema-v1")
+        return True
+
+    if set(MINIMAL_LEGACY_ENRICHMENT_LOG_FIELDS).issubset(set(fieldnames)):
+        normalized = [_row_to_current(row) for row in rows]
+        _rewrite_csv_rows(log_path, normalized)
+        _rebuild_event_id_index(repo_dir, normalized)
+        _warn_enrichment_log(repo_dir, "migrated minimal enrichment log header to schema-v1")
         return True
 
     _warn_enrichment_log(
@@ -601,6 +624,29 @@ def collect_files(
 # ---------------------------------------------------------------------------
 
 
+def _pending_sections_with_frame_ids(text: str) -> list[dict[str, str | list[str]]]:
+    """Parse unresolved rows per section from the canonical body table ranges."""
+    lines = text.splitlines()
+    parsed: list[dict[str, str | list[str]]] = []
+    for section, start, end in section_line_ranges(text):
+        if not section.node_id:
+            continue  # prose sections (Screen Flow) have no node_id
+        pending_frame_ids = [
+            node_id
+            for line in lines[start:end]
+            if (node_id := unresolved_row_node_id(line)) is not None
+        ]
+        if pending_frame_ids:
+            parsed.append(
+                {
+                    "node_id": section.node_id,
+                    "name": section.name,
+                    "pending_frame_ids": pending_frame_ids,
+                }
+            )
+    return parsed
+
+
 def pending_sections(md_path: Path) -> list[dict[str, str | int]]:
     """Return sections that need enrichment (have pending unresolved rows).
 
@@ -612,21 +658,31 @@ def pending_sections(md_path: Path) -> list[dict[str, str | int]]:
     except OSError:
         return []
 
-    lines = text.splitlines()
-    result: list[dict[str, str | int]] = []
-    for section, start, end in section_line_ranges(text):
-        if not section.node_id:
-            continue  # prose sections (Screen Flow) have no node_id
-        pending = sum(1 for line in lines[start:end] if unresolved_row_node_id(line) is not None)
-        if pending > 0:
-            result.append(
-                {
-                    "node_id": section.node_id,
-                    "name": section.name,
-                    "pending_frames": pending,
-                }
-            )
-    return result
+    parsed = _pending_sections_with_frame_ids(text)
+    return [
+        {
+            "node_id": str(item["node_id"]),
+            "name": str(item["name"]),
+            "pending_frames": len(item["pending_frame_ids"]),
+        }
+        for item in parsed
+    ]
+
+
+def pending_frame_node_ids(md_path: Path) -> set[str]:
+    """Return unresolved frame node IDs pending enrichment for one page."""
+    try:
+        text = md_path.read_text()
+    except OSError:
+        return set()
+
+    parsed = _pending_sections_with_frame_ids(text)
+    return {
+        node_id
+        for item in parsed
+        for node_id in item["pending_frame_ids"]
+        if isinstance(node_id, str)
+    }
 
 
 def needs_finalization(md_path: Path) -> bool:
@@ -1042,7 +1098,7 @@ def claude_run_cmd(
                     )
                     skipped_no_work += 1
                     phantom_files.append(str(file_path))
-                    continue
+                    break
 
                 total_pending = sum(int(s["pending_frames"]) for s in sections)
                 click.echo(
@@ -1052,38 +1108,10 @@ def claude_run_cmd(
                 )
 
                 chunk_num = 0
-                prev_pending_count = None
-                stale_retries = 0
                 while sections:
                     chunk_num += 1
                     total_pending = sum(int(s["pending_frames"]) for s in sections)
-
-                    # Detect stuck loop: if pending count hasn't decreased after
-                    # a successful batch, the remaining frames are undescribable
-                    # (e.g. screenshot download fails). Skip to next file.
-                    if prev_pending_count is not None and total_pending >= prev_pending_count:
-                        stale_retries += 1
-                        if stale_retries >= 2:
-                            click.echo(
-                                f"[claude-run] [{i}/{total}] STUCK: "
-                                f"{total_pending} frames won't describe "
-                                f"(likely unrenderable screenshots). "
-                                f"Moving to next file.",
-                                err=True,
-                            )
-                            _log_enrichment(
-                                repo_dir,
-                                file_path,
-                                "stuck",
-                                total_pending,
-                                0,
-                                False,
-                                run_id=run_id,
-                            )
-                            break
-                    else:
-                        stale_retries = 0
-                    prev_pending_count = total_pending
+                    before_pending_ids = pending_frame_node_ids(file_path)
 
                     # figmaclaw#26: adaptive budget check BEFORE the expensive call
                     decision = _budget_check(total_pending, mode="batch")
@@ -1149,9 +1177,30 @@ def claude_run_cmd(
                     )
                     _record_success("batch", total_pending, dur)
 
-                    # Re-check pending after commit
+                    # Re-check pending after commit.
+                    # If unresolved frame IDs didn't change, this run made no
+                    # progress on this file; stop immediately to avoid loops.
                     subprocess.run(["git", "pull", "--no-rebase"], capture_output=True)
                     sections = pending_sections(file_path)
+                    after_pending_ids = pending_frame_node_ids(file_path)
+                    if after_pending_ids and after_pending_ids == before_pending_ids:
+                        click.echo(
+                            f"[claude-run] [{i}/{total}] NO-PROGRESS: unresolved frame set "
+                            f"did not change after batch {chunk_num} "
+                            f"({len(after_pending_ids)} frames). "
+                            f"Stopping file to prevent same-run retry loops.",
+                            err=True,
+                        )
+                        _log_enrichment(
+                            repo_dir,
+                            file_path,
+                            "stuck",
+                            len(after_pending_ids),
+                            0,
+                            False,
+                            run_id=run_id,
+                        )
+                        break
 
                 if budget_exhausted:
                     break  # out of outer for

--- a/figmaclaw/commands/claude_run.py
+++ b/figmaclaw/commands/claude_run.py
@@ -689,7 +689,7 @@ def _is_schema_upgrade_only_candidate(md_path: Path) -> bool:
     """True when file only needs schema bump (no pending rows, no finalization work)."""
     try:
         fm = parse_frontmatter(md_path.read_text())
-    except OSError:
+    except Exception:
         return False
 
     if fm is None:
@@ -713,6 +713,27 @@ def _is_llm_marker_only_candidate(md_path: Path) -> bool:
     if pending_sections(md_path):
         return False
     return not needs_finalization(md_path)
+
+
+def _classify_no_work_candidate(md_path: Path) -> str:
+    """Classify no-work section candidates from a single file snapshot."""
+    try:
+        text = md_path.read_text()
+    except OSError:
+        return "unreadable"
+
+    has_llm_marker = "<!-- LLM:" in text
+
+    try:
+        fm = parse_frontmatter(text)
+    except Exception:
+        return "malformed-frontmatter"
+
+    if fm is not None and enrichment_schema_status(fm.enriched_schema_version).must_update:
+        return "schema-only"
+    if has_llm_marker:
+        return "llm-marker-only"
+    return "phantom"
 
 
 def needs_finalization(md_path: Path) -> bool:
@@ -1114,27 +1135,42 @@ def claude_run_cmd(
                 sections = pending_sections(file_path)
                 fin_needed = needs_finalization(file_path)
 
-                # Schema-only candidates can be selected for enrichment while
-                # having no pending body work in section mode. Skip these quietly
-                # so they do not become phantom-selection RED failures.
-                if not sections and not fin_needed and _is_schema_upgrade_only_candidate(file_path):
-                    click.echo(
-                        f"[claude-run] [{i}/{total}] skip (schema-only candidate): {file_path}",
-                        err=True,
-                    )
-                    continue
-
-                if not sections and not fin_needed and _is_llm_marker_only_candidate(file_path):
-                    click.echo(
-                        f"[claude-run] [{i}/{total}] skip (LLM-marker-only candidate): {file_path}",
-                        err=True,
-                    )
-                    continue
-
-                # figmaclaw#27 row 5: selector said this file needs enrichment,
-                # but the dispatcher has no work for it. This remains a hard RED
-                # for true selector/dispatcher disagreement (non schema-only).
                 if not sections and not fin_needed:
+                    candidate = _classify_no_work_candidate(file_path)
+                    if candidate == "schema-only":
+                        click.echo(
+                            f"[claude-run] [{i}/{total}] skip (schema-only candidate): {file_path}",
+                            err=True,
+                        )
+                        continue
+                    if candidate == "llm-marker-only":
+                        click.echo(
+                            f"[claude-run] [{i}/{total}] skip (LLM-marker-only candidate): {file_path}",
+                            err=True,
+                        )
+                        continue
+                    if candidate == "malformed-frontmatter":
+                        click.echo(
+                            f"[claude-run] [{i}/{total}] MALFORMED FRONTMATTER: {file_path} — "
+                            f"cannot classify no-work candidate safely; failing closed (row 5).",
+                            err=True,
+                        )
+                        skipped_no_work += 1
+                        phantom_files.append(str(file_path))
+                        break
+                    if candidate == "unreadable":
+                        click.echo(
+                            f"[claude-run] [{i}/{total}] UNREADABLE FILE: {file_path} — "
+                            f"cannot classify no-work candidate safely; failing closed (row 5).",
+                            err=True,
+                        )
+                        skipped_no_work += 1
+                        phantom_files.append(str(file_path))
+                        break
+
+                    # figmaclaw#27 row 5: selector said this file needs enrichment,
+                    # but the dispatcher has no work for it. This remains a hard RED
+                    # for true selector/dispatcher disagreement.
                     click.echo(
                         f"[claude-run] [{i}/{total}] PHANTOM SELECTION: "
                         f"{file_path} — enrichment_info says needs_enrichment=True "

--- a/figmaclaw/commands/claude_run.py
+++ b/figmaclaw/commands/claude_run.py
@@ -701,6 +701,20 @@ def _is_schema_upgrade_only_candidate(md_path: Path) -> bool:
     return not needs_finalization(md_path)
 
 
+def _is_llm_marker_only_candidate(md_path: Path) -> bool:
+    """True when only unresolved signal is an LLM marker comment."""
+    try:
+        text = md_path.read_text()
+    except OSError:
+        return False
+
+    if "<!-- LLM:" not in text:
+        return False
+    if pending_sections(md_path):
+        return False
+    return not needs_finalization(md_path)
+
+
 def needs_finalization(md_path: Path) -> bool:
     """True when all sections are described but the page isn't marked enriched yet.
 
@@ -1106,6 +1120,13 @@ def claude_run_cmd(
                 if not sections and not fin_needed and _is_schema_upgrade_only_candidate(file_path):
                     click.echo(
                         f"[claude-run] [{i}/{total}] skip (schema-only candidate): {file_path}",
+                        err=True,
+                    )
+                    continue
+
+                if not sections and not fin_needed and _is_llm_marker_only_candidate(file_path):
+                    click.echo(
+                        f"[claude-run] [{i}/{total}] skip (LLM-marker-only candidate): {file_path}",
                         err=True,
                     )
                     continue

--- a/figmaclaw/commands/claude_run.py
+++ b/figmaclaw/commands/claude_run.py
@@ -685,6 +685,22 @@ def pending_frame_node_ids(md_path: Path) -> set[str]:
     }
 
 
+def _is_schema_upgrade_only_candidate(md_path: Path) -> bool:
+    """True when file only needs schema bump (no pending rows, no finalization work)."""
+    try:
+        fm = parse_frontmatter(md_path.read_text())
+    except OSError:
+        return False
+
+    if fm is None:
+        return False
+    if not enrichment_schema_status(fm.enriched_schema_version).must_update:
+        return False
+    if pending_sections(md_path):
+        return False
+    return not needs_finalization(md_path)
+
+
 def needs_finalization(md_path: Path) -> bool:
     """True when all sections are described but the page isn't marked enriched yet.
 
@@ -1084,9 +1100,19 @@ def claude_run_cmd(
                 sections = pending_sections(file_path)
                 fin_needed = needs_finalization(file_path)
 
+                # Schema-only candidates can be selected for enrichment while
+                # having no pending body work in section mode. Skip these quietly
+                # so they do not become phantom-selection RED failures.
+                if not sections and not fin_needed and _is_schema_upgrade_only_candidate(file_path):
+                    click.echo(
+                        f"[claude-run] [{i}/{total}] skip (schema-only candidate): {file_path}",
+                        err=True,
+                    )
+                    continue
+
                 # figmaclaw#27 row 5: selector said this file needs enrichment,
-                # but the dispatcher has no work for it. That is ALWAYS a bug —
-                # a selector/dispatcher disagreement that must surface as RED.
+                # but the dispatcher has no work for it. This remains a hard RED
+                # for true selector/dispatcher disagreement (non schema-only).
                 if not sections and not fin_needed:
                     click.echo(
                         f"[claude-run] [{i}/{total}] PHANTOM SELECTION: "

--- a/figmaclaw/commands/write_descriptions.py
+++ b/figmaclaw/commands/write_descriptions.py
@@ -82,12 +82,19 @@ def _update_descriptions(md: str, descriptions: dict[str, str]) -> tuple[str, in
     default=None,
     help='JSON object: {"node_id": "description", ...}. Reads stdin if omitted.',
 )
+@click.option(
+    "--descriptions-file",
+    type=click.Path(exists=True, dir_okay=False, path_type=Path),
+    default=None,
+    help='Path to a JSON file containing {"node_id": "description", ...}.',
+)
 @click.option("--auto-commit", "auto_commit", is_flag=True, help="git commit the result.")
 @click.pass_context
 def write_descriptions_cmd(
     ctx: click.Context,
     md_path: Path,
     desc_input: str | None,
+    descriptions_file: Path | None,
     auto_commit: bool,
 ) -> None:
     """Update individual frame descriptions in a figmaclaw .md file.
@@ -102,15 +109,42 @@ def write_descriptions_cmd(
     if not md_path.is_absolute():
         md_path = repo_dir / md_path
 
+    if desc_input is not None and descriptions_file is not None:
+        raise click.UsageError("Use either --descriptions or --descriptions-file, not both.")
+
+    raw_payload: str
+    payload_source: str
     if desc_input is not None:
-        descriptions = json.loads(desc_input)
+        raw_payload = desc_input
+        payload_source = "--descriptions"
+    elif descriptions_file is not None:
+        raw_payload = descriptions_file.read_text(encoding="utf-8")
+        payload_source = f"--descriptions-file {descriptions_file}"
     else:
         if sys.stdin.isatty():
-            raise click.UsageError("Provide --descriptions or pipe JSON to stdin.")
-        descriptions = json.loads(sys.stdin.read())
+            raise click.UsageError(
+                "Provide --descriptions, --descriptions-file, or pipe JSON to stdin."
+            )
+        raw_payload = sys.stdin.read()
+        payload_source = "stdin"
+
+    try:
+        descriptions = json.loads(raw_payload)
+    except json.JSONDecodeError as exc:
+        raise click.UsageError(
+            f"Invalid JSON from {payload_source}: {exc.msg} (line {exc.lineno}, col {exc.colno})"
+        ) from exc
 
     if not isinstance(descriptions, dict):
         raise click.UsageError('Descriptions must be a JSON object: {"node_id": "desc", ...}')
+
+    for node_id, description in descriptions.items():
+        if not isinstance(node_id, str):
+            raise click.UsageError("Descriptions JSON keys must be node_id strings.")
+        if not isinstance(description, str):
+            raise click.UsageError(
+                f"Description for node_id '{node_id}' must be a string, got {type(description).__name__}."
+            )
 
     md_text = md_path.read_text()
     fm = parse_frontmatter(md_text)

--- a/figmaclaw/prompts/figma-batch-enrich.md
+++ b/figmaclaw/prompts/figma-batch-enrich.md
@@ -63,3 +63,6 @@ IMPORTANT:
 - Descriptions live in the **body** only. Use `write-body`, not `set-frames`.
 - `mark-enriched` tells the system the body is current. Always call it after `write-body`.
 - Commit and push after EVERY file. Never batch commits.
+- If push is rejected, use ONLY: `git pull --no-rebase && git push`
+- NEVER use `git stash`, `git stash pop`, `git reset --hard`, `git checkout --`, or `rm` for recovery.
+- NEVER delete `.figma-sync/*` files to make git/push succeed.

--- a/figmaclaw/prompts/figma-batch-enrich.md
+++ b/figmaclaw/prompts/figma-batch-enrich.md
@@ -54,7 +54,7 @@ Follow this workflow exactly:
 
 8. Commit and push:
    ```
-   git add {file_path} .figma-cache/ .figma-sync/
+   git add {file_path}
    git commit -m "sync: describe {{page-name}} frames"
    git push || (git pull --no-rebase && git push)
    ```

--- a/figmaclaw/prompts/figma-section-finalize.md
+++ b/figmaclaw/prompts/figma-section-finalize.md
@@ -41,7 +41,7 @@ Follow this workflow exactly:
 
 8. Commit and push:
    ```
-   git add {file_path} .figma-cache/ .figma-sync/
+   git add {file_path}
    git commit -m "sync: finalize enrichment for {{page-name}}"
    git push || (git pull --no-rebase && git push)
    ```

--- a/figmaclaw/prompts/figma-section-finalize.md
+++ b/figmaclaw/prompts/figma-section-finalize.md
@@ -50,3 +50,6 @@ IMPORTANT:
 - Use `write-body --section --intro` for section intros — it NEVER touches frame tables.
 - Do NOT use `write-body` (full replace) — it risks truncating large tables.
 - The critical step is mark-enriched — call it even if some intros fail.
+- If push is rejected, use ONLY: `git pull --no-rebase && git push`
+- NEVER use `git stash`, `git stash pop`, `git reset --hard`, `git checkout --`, or `rm` for recovery.
+- NEVER delete `.figma-sync/*` files to make git/push succeed.

--- a/figmaclaw/prompts/figma-sections-batch.md
+++ b/figmaclaw/prompts/figma-sections-batch.md
@@ -42,3 +42,6 @@ IMPORTANT:
 - Descriptions must be valid JSON strings (escape quotes with \").
 - ALWAYS include failed frames with "(no screenshot available)" — do NOT leave them as "(no description yet)". This marker is unresolved and retryable in future runs.
 - If there were more than 80 pending screenshots, you will be called again for the rest.
+- If push is rejected, use ONLY: `git pull --no-rebase && git push`
+- NEVER use `git stash`, `git stash pop`, `git reset --hard`, `git checkout --`, or `rm` for recovery.
+- NEVER delete `.figma-sync/*` files to make git/push succeed.

--- a/figmaclaw/skills/figma-enrich-page.md
+++ b/figmaclaw/skills/figma-enrich-page.md
@@ -129,7 +129,7 @@ Check `needs_enrichment` is false.
 ### Step 9 — Commit and push
 
 ```bash
-git add <file_path> .figma-cache/ .figma-sync/
+git add <file_path>
 git commit -m "sync: describe <page-name> frames"
 git push || (git pull --no-rebase && git push)
 ```

--- a/scripts/soak_reusable_workflow.sh
+++ b/scripts/soak_reusable_workflow.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO="gigaverse-app/linear-git"
+WORKFLOW="figmaclaw-sync.yaml"
+REF="main"
+RUN_ID=""
+TIMEOUT_SECONDS=5400
+
+usage() {
+  cat <<USAGE
+Usage: $(basename "$0") [options]
+
+Dispatch and soak-check a reusable figmaclaw workflow run, then scan full logs
+for known warning/error patterns.
+
+Options:
+  --repo <owner/repo>       Target consumer repository (default: ${REPO})
+  --workflow <file|name>    Workflow file/name (default: ${WORKFLOW})
+  --ref <branch>            Branch/ref to dispatch (default: ${REF})
+  --run-id <id>             Existing run id (skip dispatch)
+  --timeout-seconds <n>     Watch timeout in seconds (default: ${TIMEOUT_SECONDS})
+  -h, --help                Show this help
+USAGE
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --repo)
+      REPO="$2"
+      shift 2
+      ;;
+    --workflow)
+      WORKFLOW="$2"
+      shift 2
+      ;;
+    --ref)
+      REF="$2"
+      shift 2
+      ;;
+    --run-id)
+      RUN_ID="$2"
+      shift 2
+      ;;
+    --timeout-seconds)
+      TIMEOUT_SECONDS="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage
+      exit 2
+      ;;
+  esac
+done
+
+require_cmd() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "Missing required command: $1" >&2
+    exit 2
+  fi
+}
+
+require_cmd gh
+
+if [[ -z "${RUN_ID}" ]]; then
+  echo "Dispatching workflow '${WORKFLOW}' on ${REPO}@${REF}" >&2
+  gh workflow run "${WORKFLOW}" -R "${REPO}" --ref "${REF}"
+  sleep 5
+  RUN_ID="$(gh run list -R "${REPO}" --workflow "${WORKFLOW}" --branch "${REF}" --limit 1 --json databaseId --jq '.[0].databaseId')"
+fi
+
+if [[ -z "${RUN_ID}" || "${RUN_ID}" == "null" ]]; then
+  echo "Could not resolve run id" >&2
+  exit 2
+fi
+
+echo "Watching run ${RUN_ID} in ${REPO}" >&2
+gh run watch "${RUN_ID}" -R "${REPO}" --exit-status --interval 10
+
+log_file="$(mktemp)"
+trap 'rm -f "${log_file}"' EXIT
+
+gh run view "${RUN_ID}" -R "${REPO}" --log > "${log_file}"
+
+declare -a DENY_PATTERNS=(
+  "PHANTOM SELECTION"
+  "unsupported enrichment log schema/header"
+  "The following paths are ignored by one of your \\\.gitignore files"
+  "NO-PROGRESS"
+  "STUCK:"
+)
+
+failed=0
+for pattern in "${DENY_PATTERNS[@]}"; do
+  if grep -nE "${pattern}" "${log_file}" >/tmp/soak_match.txt; then
+    echo "[soak] FOUND pattern: ${pattern}" >&2
+    cat /tmp/soak_match.txt >&2
+    failed=1
+  fi
+done
+rm -f /tmp/soak_match.txt
+
+if [[ ${failed} -ne 0 ]]; then
+  echo "[soak] FAIL: warning/error patterns detected in run logs" >&2
+  echo "Run URL: https://github.com/${REPO}/actions/runs/${RUN_ID}" >&2
+  exit 2
+fi
+
+echo "[soak] PASS: no known warning/error patterns detected" >&2
+echo "Run URL: https://github.com/${REPO}/actions/runs/${RUN_ID}" >&2

--- a/tests/fixtures/enrichment_log_headers/linear_git_minimal_legacy_2026-04-03.csv
+++ b/tests/fixtures/enrichment_log_headers/linear_git_minimal_legacy_2026-04-03.csv
@@ -1,0 +1,5 @@
+timestamp,file,mode,frames,duration_s,success,section
+2026-04-03T20:23:19.477528+00:00,figma/README.md,whole-page,14,15,True,
+2026-04-03T20:26:00.576054+00:00,figma/web-app/pages/login-sign-up-1-209.md,whole-page,36,160,True,
+2026-04-03T20:30:34.051231+00:00,figma/24-mar-2025-community-in-live/pages/mobile-live-experience-0-1.md,whole-page,37,273,True,
+2026-04-03T20:34:25.847168+00:00,figma/mobile-streaming-interface/pages/interactions-api-5051-72993.md,whole-page,37,231,True,

--- a/tests/smoke/test_claude_run_smoke.py
+++ b/tests/smoke/test_claude_run_smoke.py
@@ -244,3 +244,55 @@ def test_section_mode_smoke_phantom_selection_is_fail_fast(
     assert result.exit_code == 2
     assert "PHANTOM SELECTION" in result.output
     assert "[2/2]" not in result.output
+
+
+@pytest.mark.smoke
+def test_section_mode_smoke_llm_marker_only_is_non_phantom_skip(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Smoke: marker-only section candidates should skip without phantom red."""
+    page = tmp_path / "marker-only.md"
+    page.write_text(
+        """---
+file_key: smoke123
+page_node_id: "0:1"
+enriched_hash: deadbeef
+enriched_schema_version: 1
+---
+
+<!-- LLM: section rewrite needed -->
+
+| Screen | Node ID | Description |
+|--------|---------|-------------|
+| A | `1:1` | already described |
+"""
+    )
+
+    monkeypatch.setattr(claude_run_mod, "enrichment_info", lambda _p: (True, 120))
+    monkeypatch.setattr(claude_run_mod, "pending_sections", lambda _p: [])
+    monkeypatch.setattr(claude_run_mod, "needs_finalization", lambda _p: False)
+    monkeypatch.setattr(claude_run_mod, "_is_schema_upgrade_only_candidate", lambda _p: False)
+    monkeypatch.setattr(claude_run_mod, "_is_llm_marker_only_candidate", lambda _p: True)
+    monkeypatch.setattr(
+        claude_run_mod.subprocess,
+        "run",
+        lambda *args, **kwargs: Mock(stdout="", returncode=0),
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        [
+            "--repo-dir",
+            str(tmp_path),
+            "claude-run",
+            str(page),
+            "--section-mode",
+            "--prompt",
+            "noop {file_path}",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert "skip (LLM-marker-only candidate)" in result.output
+    assert "PHANTOM SELECTION" not in result.output

--- a/tests/smoke/test_claude_run_smoke.py
+++ b/tests/smoke/test_claude_run_smoke.py
@@ -176,6 +176,7 @@ def test_section_mode_smoke_stops_after_no_progress_batch(
     monkeypatch.setattr(claude_run_mod, "pending_sections", lambda _p: pending.pop(0))
     monkeypatch.setattr(claude_run_mod, "pending_frame_node_ids", lambda _p: {"11:1", "11:2"})
     monkeypatch.setattr(claude_run_mod, "_is_schema_upgrade_only_candidate", lambda _p: False)
+    monkeypatch.setattr(claude_run_mod, "_classify_no_work_candidate", lambda _p: "phantom")
     monkeypatch.setattr(
         claude_run_mod.subprocess,
         "run",
@@ -219,6 +220,7 @@ def test_section_mode_smoke_phantom_selection_is_fail_fast(
     monkeypatch.setattr(claude_run_mod, "pending_sections", lambda _p: [])
     monkeypatch.setattr(claude_run_mod, "needs_finalization", lambda _p: False)
     monkeypatch.setattr(claude_run_mod, "_is_schema_upgrade_only_candidate", lambda _p: False)
+    monkeypatch.setattr(claude_run_mod, "_classify_no_work_candidate", lambda _p: "phantom")
     monkeypatch.setattr(
         claude_run_mod.subprocess,
         "run",

--- a/tests/smoke/test_claude_run_smoke.py
+++ b/tests/smoke/test_claude_run_smoke.py
@@ -7,10 +7,12 @@ CLI path used in CI for selecting files to enrich.
 from __future__ import annotations
 
 from pathlib import Path
+from unittest.mock import Mock
 
 import pytest
 from click.testing import CliRunner
 
+from figmaclaw.commands import claude_run as claude_run_mod
 from figmaclaw.main import cli
 
 
@@ -151,3 +153,94 @@ def test_claude_run_dry_run_also_excludes_census_files(tmp_path: Path) -> None:
     out = result.output
     assert str(md_page) in out
     assert str(census_md) not in out
+
+
+@pytest.mark.smoke
+def test_section_mode_smoke_stops_after_no_progress_batch(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Smoke: same unresolved frame set should stop file in same run (no loop)."""
+    source = (
+        Path(__file__).resolve().parents[1]
+        / "fixtures"
+        / "linear_git_real"
+        / "live_ui_unavailable_rows.md"
+    )
+    page = tmp_path / "figma" / "pages" / "live-ui.md"
+    page.parent.mkdir(parents=True, exist_ok=True)
+    page.write_text(source.read_text(encoding="utf-8"), encoding="utf-8")
+
+    sections = [{"node_id": "10:1", "name": "Auth", "pending_frames": 2}]
+    pending = [sections, sections]
+    monkeypatch.setattr(claude_run_mod, "enrichment_info", lambda _p: (True, 120))
+    monkeypatch.setattr(claude_run_mod, "pending_sections", lambda _p: pending.pop(0))
+    monkeypatch.setattr(claude_run_mod, "pending_frame_node_ids", lambda _p: {"11:1", "11:2"})
+    monkeypatch.setattr(claude_run_mod, "_is_schema_upgrade_only_candidate", lambda _p: False)
+    monkeypatch.setattr(
+        claude_run_mod.subprocess,
+        "run",
+        lambda *args, **kwargs: Mock(stdout="", returncode=0),
+    )
+    run_mock = Mock(return_value=claude_run_mod.ClaudeResult(exit_code=0))
+    monkeypatch.setattr(claude_run_mod, "_run_claude", run_mock)
+    monkeypatch.setattr(claude_run_mod, "count_commits_since", lambda *_args, **_kwargs: 1)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        [
+            "--repo-dir",
+            str(tmp_path),
+            "claude-run",
+            str(page),
+            "--section-mode",
+            "--prompt",
+            "noop {file_path}",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert "NO-PROGRESS" in result.output
+    assert run_mock.call_count == 1
+
+
+@pytest.mark.smoke
+def test_section_mode_smoke_phantom_selection_is_fail_fast(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Smoke: phantom selection should turn run red immediately."""
+    page_a = tmp_path / "a.md"
+    page_b = tmp_path / "b.md"
+    _write_page(page_a, enriched=False, placeholder=True)
+    _write_page(page_b, enriched=False, placeholder=True)
+
+    monkeypatch.setattr(claude_run_mod, "collect_files", lambda *args, **kwargs: [page_a, page_b])
+    monkeypatch.setattr(claude_run_mod, "enrichment_info", lambda _p: (True, 120))
+    monkeypatch.setattr(claude_run_mod, "pending_sections", lambda _p: [])
+    monkeypatch.setattr(claude_run_mod, "needs_finalization", lambda _p: False)
+    monkeypatch.setattr(claude_run_mod, "_is_schema_upgrade_only_candidate", lambda _p: False)
+    monkeypatch.setattr(
+        claude_run_mod.subprocess,
+        "run",
+        lambda *args, **kwargs: Mock(stdout="", returncode=0),
+    )
+
+    monkeypatch.setattr(claude_run_mod, "count_commits_since", lambda *_args, **_kwargs: 0)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        [
+            "--repo-dir",
+            str(tmp_path),
+            "claude-run",
+            str(page_a),
+            "--section-mode",
+            "--prompt",
+            "noop {file_path}",
+        ],
+    )
+
+    assert result.exit_code == 2
+    assert "PHANTOM SELECTION" in result.output
+    assert "[2/2]" not in result.output

--- a/tests/test_claude_run.py
+++ b/tests/test_claude_run.py
@@ -794,6 +794,7 @@ class TestClaudeRunExecutionBranches:
         monkeypatch.setattr(claude_run_mod, "pending_sections", lambda _p: [])
         monkeypatch.setattr(claude_run_mod, "needs_finalization", lambda _p: False)
         monkeypatch.setattr(claude_run_mod, "_is_schema_upgrade_only_candidate", lambda _p: False)
+        monkeypatch.setattr(claude_run_mod, "_is_llm_marker_only_candidate", lambda _p: False)
         monkeypatch.setattr(
             claude_run_mod.subprocess,
             "run",
@@ -817,6 +818,58 @@ class TestClaudeRunExecutionBranches:
         assert result.exit_code == 2
         assert "PHANTOM SELECTION" in result.output
         assert "Verdict (row 5)" in result.output
+
+    def test_section_mode_llm_marker_only_candidate_is_skipped_not_phantom(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        md = tmp_path / "marker-only.md"
+        md.write_text(
+            textwrap.dedent(
+                """                ---
+                file_key: abc123
+                page_node_id: "0:1"
+                enriched_hash: deadbeefcafebabe
+                enriched_schema_version: 1
+                ---
+
+                <!-- LLM: rewrite this section -->
+
+                | Screen | Node ID | Description |
+                |--------|---------|-------------|
+                | Login | `1:1` | already described |
+                """
+            )
+        )
+
+        monkeypatch.setattr(claude_run_mod, "enrichment_info", lambda _p: (True, 120))
+        monkeypatch.setattr(claude_run_mod, "pending_sections", lambda _p: [])
+        monkeypatch.setattr(claude_run_mod, "needs_finalization", lambda _p: False)
+        monkeypatch.setattr(claude_run_mod, "_is_schema_upgrade_only_candidate", lambda _p: False)
+        monkeypatch.setattr(claude_run_mod, "_is_llm_marker_only_candidate", lambda _p: True)
+        monkeypatch.setattr(
+            claude_run_mod.subprocess,
+            "run",
+            lambda *args, **kwargs: Mock(stdout="", returncode=0),
+        )
+        run_mock = Mock()
+        monkeypatch.setattr(claude_run_mod, "_run_claude", run_mock)
+
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            [
+                "--repo-dir",
+                str(tmp_path),
+                "claude-run",
+                str(md),
+                "--section-mode",
+            ],
+        )
+
+        assert result.exit_code == 0
+        assert "skip (LLM-marker-only candidate)" in result.output
+        assert "PHANTOM SELECTION" not in result.output
+        assert run_mock.call_count == 0
 
     def test_section_mode_schema_only_candidate_is_skipped_not_phantom(
         self, tmp_path: Path, monkeypatch
@@ -842,6 +895,7 @@ class TestClaudeRunExecutionBranches:
         monkeypatch.setattr(claude_run_mod, "pending_sections", lambda _p: [])
         monkeypatch.setattr(claude_run_mod, "needs_finalization", lambda _p: False)
         monkeypatch.setattr(claude_run_mod, "_is_schema_upgrade_only_candidate", lambda _p: True)
+        monkeypatch.setattr(claude_run_mod, "_is_llm_marker_only_candidate", lambda _p: False)
         monkeypatch.setattr(
             claude_run_mod.subprocess,
             "run",
@@ -932,6 +986,7 @@ class TestClaudeRunExecutionBranches:
         monkeypatch.setattr(claude_run_mod, "pending_sections", lambda _p: [])
         monkeypatch.setattr(claude_run_mod, "needs_finalization", lambda _p: False)
         monkeypatch.setattr(claude_run_mod, "_is_schema_upgrade_only_candidate", lambda _p: False)
+        monkeypatch.setattr(claude_run_mod, "_is_llm_marker_only_candidate", lambda _p: False)
         monkeypatch.setattr(
             claude_run_mod.subprocess,
             "run",

--- a/tests/test_claude_run.py
+++ b/tests/test_claude_run.py
@@ -817,28 +817,29 @@ class TestClaudeRunExecutionBranches:
         assert "PHANTOM SELECTION" in result.output
         assert "Verdict (row 5)" in result.output
 
-    def test_section_mode_stuck_detection_breaks_after_retries(
+    def test_section_mode_stuck_detection_breaks_on_first_no_progress(
         self, tmp_path: Path, monkeypatch
     ) -> None:
         md = tmp_path / "page.md"
         self._write_placeholder_page(md)
 
         sections = [{"node_id": "10:1", "name": "Auth", "pending_frames": 2}]
-        # Initial load + two post-batch refreshes; third loop detects "stuck" and exits.
-        pending = [sections, sections, sections]
+        pending = [sections, sections]
 
         monkeypatch.setattr(claude_run_mod, "enrichment_info", lambda _p: (True, 120))
         monkeypatch.setattr(claude_run_mod, "pending_sections", lambda _p: pending.pop(0))
+        monkeypatch.setattr(claude_run_mod, "pending_frame_node_ids", lambda _p: {"11:1", "11:2"})
         monkeypatch.setattr(claude_run_mod, "needs_finalization", lambda _p: False)
         monkeypatch.setattr(
             claude_run_mod,
             "decide_next_batch",
             lambda **_: self._budget_decision(True, "[budget] go"),
         )
+        run_mock = Mock(return_value=claude_run_mod.ClaudeResult(exit_code=0))
         monkeypatch.setattr(
             claude_run_mod,
             "_run_claude",
-            lambda **_: claude_run_mod.ClaudeResult(exit_code=0),
+            run_mock,
         )
         monkeypatch.setattr(claude_run_mod, "count_commits_since", lambda *_args, **_kwargs: 1)
         monkeypatch.setattr(
@@ -862,8 +863,48 @@ class TestClaudeRunExecutionBranches:
         )
 
         assert result.exit_code == 0
-        assert "STUCK:" in result.output
+        assert "NO-PROGRESS" in result.output
+        assert run_mock.call_count == 1
         assert "Verdict (row 2)" in result.output
+
+    def test_section_mode_phantom_selection_stops_run_immediately(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        page_a = tmp_path / "a.md"
+        page_b = tmp_path / "b.md"
+        self._write_placeholder_page(page_a)
+        self._write_placeholder_page(page_b)
+
+        monkeypatch.setattr(
+            claude_run_mod, "collect_files", lambda *args, **kwargs: [page_a, page_b]
+        )
+        monkeypatch.setattr(claude_run_mod, "enrichment_info", lambda _p: (True, 120))
+        monkeypatch.setattr(claude_run_mod, "pending_sections", lambda _p: [])
+        monkeypatch.setattr(claude_run_mod, "needs_finalization", lambda _p: False)
+        monkeypatch.setattr(
+            claude_run_mod.subprocess,
+            "run",
+            lambda *args, **kwargs: Mock(stdout="", returncode=0),
+        )
+        run_mock = Mock()
+        monkeypatch.setattr(claude_run_mod, "_run_claude", run_mock)
+
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            [
+                "--repo-dir",
+                str(tmp_path),
+                "claude-run",
+                str(page_a),
+                "--section-mode",
+            ],
+        )
+
+        assert result.exit_code == 2
+        assert "PHANTOM SELECTION" in result.output
+        assert "[2/2]" not in result.output
+        assert run_mock.call_count == 0
 
     def test_dispatch_crash_is_always_red(self, tmp_path: Path, monkeypatch) -> None:
         md = tmp_path / "page.md"
@@ -1271,6 +1312,32 @@ def test_log_keeps_distinct_runs_with_identical_payload(tmp_path: Path) -> None:
     with log_path.open(newline="", encoding="utf-8") as f:
         rows = list(csv.DictReader(f))
     assert len(rows) == 2
+
+
+def test_log_migrates_minimal_legacy_header_without_optional_columns(tmp_path: Path) -> None:
+    """7-column legacy logs should auto-migrate to canonical schema-v1."""
+    log_path = tmp_path / claude_run_mod.ENRICHMENT_LOG
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    log_path.write_text(
+        "timestamp,file,mode,frames,duration_s,success,section\n"
+        "2026-04-15T00:00:00+00:00,figma/a.md,batch,10,50,True,Auth\n",
+        encoding="utf-8",
+    )
+
+    md = tmp_path / "figma" / "pages" / "a.md"
+    md.parent.mkdir(parents=True, exist_ok=True)
+    md.write_text("---\nfile_key: a\n---\n")
+
+    claude_run_mod._log_enrichment(tmp_path, md, "batch", 12, 31.0, True, run_id="run-x")
+
+    with log_path.open(newline="", encoding="utf-8") as f:
+        reader = csv.DictReader(f)
+        rows = list(reader)
+        assert reader.fieldnames is not None
+        assert tuple(reader.fieldnames) == claude_run_mod.ENRICHMENT_LOG_FIELDS
+    assert len(rows) == 2
+    assert rows[0]["schema_version"] in {"0", str(ENRICHMENT_LOG_SCHEMA_VERSION)}
+    assert rows[0]["event_id"] != ""
 
 
 def test_log_unknown_header_is_observable_and_skips_append(tmp_path: Path) -> None:

--- a/tests/test_claude_run.py
+++ b/tests/test_claude_run.py
@@ -795,6 +795,7 @@ class TestClaudeRunExecutionBranches:
         monkeypatch.setattr(claude_run_mod, "needs_finalization", lambda _p: False)
         monkeypatch.setattr(claude_run_mod, "_is_schema_upgrade_only_candidate", lambda _p: False)
         monkeypatch.setattr(claude_run_mod, "_is_llm_marker_only_candidate", lambda _p: False)
+        monkeypatch.setattr(claude_run_mod, "_classify_no_work_candidate", lambda _p: "phantom")
         monkeypatch.setattr(
             claude_run_mod.subprocess,
             "run",
@@ -869,6 +870,55 @@ class TestClaudeRunExecutionBranches:
         assert result.exit_code == 0
         assert "skip (LLM-marker-only candidate)" in result.output
         assert "PHANTOM SELECTION" not in result.output
+        assert run_mock.call_count == 0
+
+    def test_section_mode_malformed_frontmatter_fails_closed_not_dispatch_crash(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        md = tmp_path / "malformed.md"
+        md.write_text(
+            textwrap.dedent(
+                """                ---
+                file_key: abc123
+                page_node_id: "0:1"
+                enriched_hash: deadbeefcafebabe
+                enriched_schema_version: bad
+                ---
+
+                | Screen | Node ID | Description |
+                |--------|---------|-------------|
+                | Login | `1:1` | already described |
+                """
+            )
+        )
+
+        monkeypatch.setattr(claude_run_mod, "enrichment_info", lambda _p: (True, 120))
+        monkeypatch.setattr(claude_run_mod, "pending_sections", lambda _p: [])
+        monkeypatch.setattr(claude_run_mod, "needs_finalization", lambda _p: False)
+        monkeypatch.setattr(
+            claude_run_mod.subprocess,
+            "run",
+            lambda *args, **kwargs: Mock(stdout="", returncode=0),
+        )
+        run_mock = Mock()
+        monkeypatch.setattr(claude_run_mod, "_run_claude", run_mock)
+
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            [
+                "--repo-dir",
+                str(tmp_path),
+                "claude-run",
+                str(md),
+                "--section-mode",
+            ],
+        )
+
+        assert result.exit_code == 2
+        assert "MALFORMED FRONTMATTER" in result.output
+        assert "Verdict (row 5)" in result.output
+        assert "RED (dispatch crash)" not in result.output
         assert run_mock.call_count == 0
 
     def test_section_mode_schema_only_candidate_is_skipped_not_phantom(
@@ -987,6 +1037,7 @@ class TestClaudeRunExecutionBranches:
         monkeypatch.setattr(claude_run_mod, "needs_finalization", lambda _p: False)
         monkeypatch.setattr(claude_run_mod, "_is_schema_upgrade_only_candidate", lambda _p: False)
         monkeypatch.setattr(claude_run_mod, "_is_llm_marker_only_candidate", lambda _p: False)
+        monkeypatch.setattr(claude_run_mod, "_classify_no_work_candidate", lambda _p: "phantom")
         monkeypatch.setattr(
             claude_run_mod.subprocess,
             "run",

--- a/tests/test_claude_run.py
+++ b/tests/test_claude_run.py
@@ -793,6 +793,7 @@ class TestClaudeRunExecutionBranches:
         monkeypatch.setattr(claude_run_mod, "enrichment_info", lambda _p: (True, 120))
         monkeypatch.setattr(claude_run_mod, "pending_sections", lambda _p: [])
         monkeypatch.setattr(claude_run_mod, "needs_finalization", lambda _p: False)
+        monkeypatch.setattr(claude_run_mod, "_is_schema_upgrade_only_candidate", lambda _p: False)
         monkeypatch.setattr(
             claude_run_mod.subprocess,
             "run",
@@ -816,6 +817,55 @@ class TestClaudeRunExecutionBranches:
         assert result.exit_code == 2
         assert "PHANTOM SELECTION" in result.output
         assert "Verdict (row 5)" in result.output
+
+    def test_section_mode_schema_only_candidate_is_skipped_not_phantom(
+        self, tmp_path: Path, monkeypatch
+    ) -> None:
+        md = tmp_path / "schema-only.md"
+        md.write_text(
+            textwrap.dedent(
+                """                ---
+                file_key: abc123
+                page_node_id: "0:1"
+                enriched_hash: deadbeefcafebabe
+                enriched_schema_version: 0
+                ---
+
+                | Screen | Node ID | Description |
+                |--------|---------|-------------|
+                | Login | `1:1` | already described |
+                """
+            )
+        )
+
+        monkeypatch.setattr(claude_run_mod, "enrichment_info", lambda _p: (True, 120))
+        monkeypatch.setattr(claude_run_mod, "pending_sections", lambda _p: [])
+        monkeypatch.setattr(claude_run_mod, "needs_finalization", lambda _p: False)
+        monkeypatch.setattr(claude_run_mod, "_is_schema_upgrade_only_candidate", lambda _p: True)
+        monkeypatch.setattr(
+            claude_run_mod.subprocess,
+            "run",
+            lambda *args, **kwargs: Mock(stdout="", returncode=0),
+        )
+        run_mock = Mock()
+        monkeypatch.setattr(claude_run_mod, "_run_claude", run_mock)
+
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            [
+                "--repo-dir",
+                str(tmp_path),
+                "claude-run",
+                str(md),
+                "--section-mode",
+            ],
+        )
+
+        assert result.exit_code == 0
+        assert "skip (schema-only candidate)" in result.output
+        assert "PHANTOM SELECTION" not in result.output
+        assert run_mock.call_count == 0
 
     def test_section_mode_stuck_detection_breaks_on_first_no_progress(
         self, tmp_path: Path, monkeypatch
@@ -881,6 +931,7 @@ class TestClaudeRunExecutionBranches:
         monkeypatch.setattr(claude_run_mod, "enrichment_info", lambda _p: (True, 120))
         monkeypatch.setattr(claude_run_mod, "pending_sections", lambda _p: [])
         monkeypatch.setattr(claude_run_mod, "needs_finalization", lambda _p: False)
+        monkeypatch.setattr(claude_run_mod, "_is_schema_upgrade_only_candidate", lambda _p: False)
         monkeypatch.setattr(
             claude_run_mod.subprocess,
             "run",
@@ -1338,6 +1389,35 @@ def test_log_migrates_minimal_legacy_header_without_optional_columns(tmp_path: P
     assert len(rows) == 2
     assert rows[0]["schema_version"] in {"0", str(ENRICHMENT_LOG_SCHEMA_VERSION)}
     assert rows[0]["event_id"] != ""
+
+
+def test_log_migrates_real_world_linear_git_legacy_fixture(tmp_path: Path) -> None:
+    """Real legacy header fixture from linear-git must auto-migrate and append."""
+    fixture = (
+        Path(__file__).parent
+        / "fixtures"
+        / "enrichment_log_headers"
+        / "linear_git_minimal_legacy_2026-04-03.csv"
+    )
+    log_path = tmp_path / claude_run_mod.ENRICHMENT_LOG
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    log_path.write_text(fixture.read_text(encoding="utf-8"), encoding="utf-8")
+
+    md = tmp_path / "figma" / "pages" / "a.md"
+    md.parent.mkdir(parents=True, exist_ok=True)
+    md.write_text("---\nfile_key: a\n---\n")
+
+    claude_run_mod._log_enrichment(tmp_path, md, "batch", 12, 31.0, True, run_id="run-x")
+
+    with log_path.open(newline="", encoding="utf-8") as f:
+        reader = csv.DictReader(f)
+        rows = list(reader)
+
+    assert reader.fieldnames is not None
+    assert tuple(reader.fieldnames) == claude_run_mod.ENRICHMENT_LOG_FIELDS
+    assert len(rows) == 5
+    assert rows[-1]["schema_version"] == str(ENRICHMENT_LOG_SCHEMA_VERSION)
+    assert rows[-1]["event_id"] != ""
 
 
 def test_log_unknown_header_is_observable_and_skips_append(tmp_path: Path) -> None:

--- a/tests/test_prompt_git_add_rules.py
+++ b/tests/test_prompt_git_add_rules.py
@@ -2,14 +2,38 @@ from pathlib import Path
 
 from figmaclaw.commands.claude_run import default_prompt_path, finalize_prompt_path
 
+ENRICHMENT_PROMPTS = (
+    default_prompt_path(),
+    finalize_prompt_path(),
+    Path("figmaclaw/prompts/figma-sections-batch.md"),
+)
+
+
+FORBIDDEN_RECOVERY_SNIPPETS = (
+    "git stash",
+    "git stash pop",
+    "git reset --hard",
+    "git checkout --",
+    "delete `.figma-sync/*`",
+)
+
 
 def test_enrichment_prompts_stage_only_target_file() -> None:
     """Enrichment prompts must not stage cache/sync directories."""
-    for prompt_path in (default_prompt_path(), finalize_prompt_path()):
+    for prompt_path in ENRICHMENT_PROMPTS:
         text = prompt_path.read_text(encoding="utf-8")
         assert "git add {file_path}" in text
-        assert ".figma-cache/" not in text
-        assert ".figma-sync/" not in text
+        assert "git add {file_path} .figma-cache/" not in text
+        assert "git add {file_path} .figma-sync/" not in text
+
+
+def test_enrichment_prompts_define_safe_push_recovery_policy() -> None:
+    """Prompt guardrail: allow one deterministic pull+push path and ban risky recovery."""
+    for prompt_path in ENRICHMENT_PROMPTS:
+        text = prompt_path.read_text(encoding="utf-8")
+        assert "git pull --no-rebase && git push" in text
+        for forbidden in FORBIDDEN_RECOVERY_SNIPPETS:
+            assert forbidden in text  # explicitly listed as forbidden in IMPORTANT section
 
 
 def test_skill_doc_examples_do_not_stage_ignored_cache_paths() -> None:

--- a/tests/test_prompt_git_add_rules.py
+++ b/tests/test_prompt_git_add_rules.py
@@ -1,0 +1,21 @@
+from pathlib import Path
+
+from figmaclaw.commands.claude_run import default_prompt_path, finalize_prompt_path
+
+
+def test_enrichment_prompts_stage_only_target_file() -> None:
+    """Enrichment prompts must not stage cache/sync directories."""
+    for prompt_path in (default_prompt_path(), finalize_prompt_path()):
+        text = prompt_path.read_text(encoding="utf-8")
+        assert "git add {file_path}" in text
+        assert ".figma-cache/" not in text
+        assert ".figma-sync/" not in text
+
+
+def test_skill_doc_examples_do_not_stage_ignored_cache_paths() -> None:
+    """The page enrichment skill should mirror safe staging guidance."""
+    skill_path = Path("figmaclaw/skills/figma-enrich-page.md")
+    text = skill_path.read_text(encoding="utf-8")
+    assert "git add <file_path>" in text
+    assert "git add <file_path> .figma-cache/" not in text
+    assert "git add <file_path> .figma-sync/" not in text

--- a/tests/test_soak_reusable_workflow_script.py
+++ b/tests/test_soak_reusable_workflow_script.py
@@ -1,0 +1,29 @@
+"""Invariants for reusable workflow soak script guardrails."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def test_soak_script_exists_and_is_executable() -> None:
+    script = Path("scripts/soak_reusable_workflow.sh")
+    assert script.exists()
+    assert script.stat().st_mode & 0o111
+
+
+def test_soak_script_scans_for_known_failure_patterns() -> None:
+    script = Path("scripts/soak_reusable_workflow.sh")
+    text = script.read_text(encoding="utf-8")
+
+    required_patterns = (
+        "PHANTOM SELECTION",
+        "unsupported enrichment log schema/header",
+        "The following paths are ignored by one of your",
+        "NO-PROGRESS",
+        "STUCK:",
+    )
+    for pattern in required_patterns:
+        assert pattern in text
+
+    assert "gh run watch" in text
+    assert "gh run view" in text

--- a/tests/test_write_descriptions.py
+++ b/tests/test_write_descriptions.py
@@ -262,3 +262,103 @@ frames: ['11:1']
     assert count == 1
     assert "| Login | `11:1` | Updated canonical row |" in result
     assert "| Debug row | `11:1` | should stay untouched |" in result
+
+
+def test_cli_write_descriptions_invalid_json_is_usage_error(tmp_path: Path) -> None:
+    """Invalid JSON input must fail cleanly without Python traceback."""
+    md_path = tmp_path / "page.md"
+    md_path.write_text(_TEST_MD)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        [
+            "--repo-dir",
+            str(tmp_path),
+            "write-descriptions",
+            str(md_path),
+            "--descriptions",
+            '{"11:1": "ok",',
+        ],
+    )
+
+    assert result.exit_code != 0
+    assert "Invalid JSON" in result.output
+    assert "Traceback" not in result.output
+
+
+def test_cli_write_descriptions_supports_descriptions_file(tmp_path: Path) -> None:
+    """Large payload mode: JSON from file should update rows successfully."""
+    md_path = tmp_path / "page.md"
+    md_path.write_text(_TEST_MD)
+
+    payload = tmp_path / "descriptions.json"
+    payload.write_text(json.dumps({"11:1": "From file", "11:2": "Also from file"}))
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        [
+            "--repo-dir",
+            str(tmp_path),
+            "write-descriptions",
+            str(md_path),
+            "--descriptions-file",
+            str(payload),
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert "updated 2/2" in result.output
+    updated = md_path.read_text()
+    assert "From file" in updated
+    assert "Also from file" in updated
+
+
+def test_cli_write_descriptions_rejects_non_string_values(tmp_path: Path) -> None:
+    """Descriptions JSON values must be strings for deterministic markdown output."""
+    md_path = tmp_path / "page.md"
+    md_path.write_text(_TEST_MD)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        [
+            "--repo-dir",
+            str(tmp_path),
+            "write-descriptions",
+            str(md_path),
+            "--descriptions",
+            '{"11:1": 123}',
+        ],
+    )
+
+    assert result.exit_code != 0
+    assert "must be a string" in result.output
+
+
+def test_cli_write_descriptions_rejects_dual_input_modes(tmp_path: Path) -> None:
+    """CLI should reject ambiguous payload source selection."""
+    md_path = tmp_path / "page.md"
+    md_path.write_text(_TEST_MD)
+
+    payload = tmp_path / "descriptions.json"
+    payload.write_text('{"11:1": "From file"}')
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        [
+            "--repo-dir",
+            str(tmp_path),
+            "write-descriptions",
+            str(md_path),
+            "--descriptions",
+            '{"11:1": "inline"}',
+            "--descriptions-file",
+            str(payload),
+        ],
+    )
+
+    assert result.exit_code != 0
+    assert "Use either --descriptions or --descriptions-file" in result.output


### PR DESCRIPTION
## Summary
This follow-up PR now addresses **six** production issues discovered from repeated live `linear-git` run audits:

- Closes #114: auto-migrate additional enrichment-log header variants instead of skipping append.
- Closes #115: stop staging `.figma-cache` / broad paths in enrichment prompts.
- Closes #116: fix selector/dispatcher wasted-work behavior (schema-only + marker-only phantom suppression + same-run no-progress loop guard).
- Closes #118: harden `write-descriptions` input parsing (no traceback) and add file-input mode.
- Closes #119: add strict git recovery guardrails in enrichment prompts (ban stash/reset/checkout/rm recovery).
- Closes #120: treat LLM-marker-only section candidates as explicit non-phantom skips.

Source run audited repeatedly: https://github.com/gigaverse-app/linear-git/actions/runs/24508935060

## Added verification pass over problematic files
From run `24508935060` logs, all 12 files previously emitting `PHANTOM SELECTION` were replay-checked against this branch:
- Result: **12/12 now non-phantom** (`skip (schema-only candidate)` or `skip (LLM-marker-only candidate)`), none emit `PHANTOM SELECTION`.

The two loop files from that run were replay-checked:
- `pre-live-v2-7556-34145.md`
- `live-ui-exploration-3089-27918.md`
- Result: each now emits `NO-PROGRESS` and **does not** proceed to `batch 2` in the same run.

## What changed
1. Enrichment log schema migration hardening (`figmaclaw/commands/claude_run.py`)
- Added support for migrating minimal legacy 7-column headers:
  - `timestamp,file,mode,frames,duration_s,success,section`
- Added normalization path for non-canonical current-schema supersets/permutations.
- Preserved safe behavior for truly unmappable headers (warn + skip append).

2. Canonical pending parsing + anti-loop guard (`figmaclaw/commands/claude_run.py`)
- Added canonical parser helper `_pending_sections_with_frame_ids(...)`.
- Added `pending_frame_node_ids(...)` to compute unresolved frame identity set from canonical table ranges.
- Section-mode loop now detects **no progress after a successful batch** by comparing unresolved node-id sets before vs after batch.
- On unchanged unresolved set, emits `NO-PROGRESS` and stops processing that file in the same run.

3. Selector/dispatcher phantom handling (`figmaclaw/commands/claude_run.py`)
- Added schema-only candidate detection (`_is_schema_upgrade_only_candidate`).
- Added LLM-marker-only candidate detection (`_is_llm_marker_only_candidate`).
- For both known classes in section-mode (no pending rows, no finalization), dispatcher now emits explicit skip reasons instead of phantom RED.
- True non-schema/non-marker phantom disagreements remain row-5 RED.

4. Prompt/skill staging + git recovery guardrails
- Updated enrichment prompt templates to stage only target page file:
  - `figmaclaw/prompts/figma-batch-enrich.md`
  - `figmaclaw/prompts/figma-section-finalize.md`
  - `figmaclaw/prompts/figma-sections-batch.md`
- Added explicit banned recovery guidance in prompts:
  - no `git stash`/`stash pop`
  - no `git reset --hard`
  - no `git checkout --`
  - no deleting `.figma-sync/*`
  - allowed recovery path remains: `git pull --no-rebase && git push`
- Updated skill example staging guidance:
  - `figmaclaw/skills/figma-enrich-page.md`

5. `write-descriptions` input hardening (`figmaclaw/commands/write_descriptions.py`)
- Added `--descriptions-file <path>` input mode for large payloads.
- Added strict, clean input error handling:
  - malformed JSON -> `UsageError` with location
  - wrong shape/types -> `UsageError`
  - no traceback for user/input mistakes
- Added explicit mutual-exclusion check for `--descriptions` and `--descriptions-file`.

6. Reusable workflow soak audit utility
- Added `scripts/soak_reusable_workflow.sh`:
  - dispatch/watch reusable workflow run
  - fetch full logs
  - fail on known bad patterns (`PHANTOM SELECTION`, unsupported log schema, ignored-path staging, `NO-PROGRESS`, `STUCK`)

## Test coverage (TDD additions)
### Core regressions
- `tests/test_claude_run.py`
  - `test_section_mode_schema_only_candidate_is_skipped_not_phantom`
  - `test_section_mode_llm_marker_only_candidate_is_skipped_not_phantom`
  - `test_section_mode_stuck_detection_breaks_on_first_no_progress`
  - `test_section_mode_phantom_selection_stops_run_immediately`
  - `test_log_migrates_minimal_legacy_header_without_optional_columns`
  - `test_log_migrates_real_world_linear_git_legacy_fixture`

### Prompt guardrails
- `tests/test_prompt_git_add_rules.py`
  - stage-only-file assertions
  - safe push recovery policy assertions
  - explicit banned recovery guidance assertions

### write-descriptions hardening
- `tests/test_write_descriptions.py`
  - malformed JSON fails cleanly (no traceback)
  - `--descriptions-file` happy path
  - non-string value rejection
  - dual input-mode rejection

### Smoke + tooling invariants
- `tests/smoke/test_claude_run_smoke.py`
  - same-run no-progress stop behavior
  - phantom fail-fast behavior
  - marker-only non-phantom skip behavior
- `tests/test_soak_reusable_workflow_script.py`
  - soak script existence/executable + required pattern scan invariants

### Fixtures
- Added real-world legacy log fixture:
  - `tests/fixtures/enrichment_log_headers/linear_git_minimal_legacy_2026-04-03.csv`

## Validation run
- `uv run pytest -q tests/test_claude_run.py tests/test_write_descriptions.py tests/test_prompt_git_add_rules.py tests/test_soak_reusable_workflow_script.py tests/smoke/test_claude_run_smoke.py`
- Result: `98 passed`
