### PR TITLE
Fix cross-run enrichment loops: frame-keyed invariants, body orphan prune, YELLOW verdict, anti-loop policy (#121)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -198,10 +198,24 @@ Do:
 ### 5. Log writers — no WARN-and-drop
 
 A log writer that emits `WARN … skipped until file is fixed` but never
-fixes the file silently loses data every run forever. If schema
-migration is possible, do it atomically on the first mismatch. If not,
-hard-fail. Never accept "warn and forget" as a terminal state for a
-writer.
+fixes the file silently loses data every run forever. Acceptable
+resolutions, in order of preference:
+
+1. **Migrate** — if the schema is recognizable (including legacy
+   superset/subset cases), migrate in place on the first mismatch.
+   This is the happy path.
+2. **Auto-archive and reset** — if no migration path applies, rename
+   the prior file to `<name>.bak.<UTC-timestamp><ext>` and start a
+   fresh schema-v1 log. History is preserved, the writer heals itself,
+   and subsequent runs append normally. Required: emit a human-readable
+   error line describing the archive event — don't hide the self-heal.
+3. **Hard-fail** — only for critical writers where silently resetting
+   would corrupt load-bearing state. Log writers used for observability
+   do not qualify.
+
+Never accept "warn and forget every run" as a terminal state. The test
+shape that pins this: run 1 with bad input triggers the heal, run 2
+with no new bad input does NOT re-emit the error.
 
 ### Review checklist for enrichment / pull / logging PRs
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -152,10 +152,11 @@ flag.
 ### 2. Cross-field frontmatter key-set invariants
 
 The frontmatter has multiple frame-keyed dicts: `enriched_frame_hashes`,
-`raw_frames`, `raw_tokens`, `frame_sections`. The invariant
-`keys(d) ⊆ frames` must hold for every one of them after every write.
-Enforced centrally in `figma_render._build_frontmatter` — the single
-chokepoint for frontmatter serialization.
+`raw_frames`, `raw_tokens`, `frame_sections`, `unresolvable_frames`.
+The invariant `keys(d) ⊆ frames` must hold for every one of them after
+every write. Enforced centrally in `figma_render._build_frontmatter` —
+the single chokepoint for frontmatter serialization — and defensively
+on parse by `FigmaPageFrontmatter._cap_unresolvable_frames_to_frames`.
 
 **If you add a new frame-keyed field**:
 - Extend `_build_frontmatter` to prune it too

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,3 +117,102 @@ Rationale: figmaclaw runs in a CI loop. Any unconditional write — even just a 
 - All imports at file top, never inside functions
 - 100% coverage for new code
 - Exit code 0 = success, exit code 2 = error. Never use exit 1 for business logic.
+
+## Anti-loop engineering policy (figmaclaw#121)
+
+Enrichment runs in a loop (hourly CI). Any bug that causes `claude-run`
+to do the same work over and over costs real money and hides real
+regressions behind RED-forever CI. We learned this the hard way over
+the course of 5+ PRs (#88 #92 #103 #112 #117) that each added
+same-run guards but left cross-run failure modes untouched.
+
+When adding or modifying any enrichment / pull / logging code path,
+review against these three dimensions in addition to the usual unit /
+same-run / schema / body-frontmatter / observability tests:
+
+### 1. Cross-run state invariants
+
+Any guard that prevents retries **within one run** must be paired with
+an invariant that prevents retries **across runs**. Test shape:
+
+```
+state_0 := fixture
+run code against state_0  → produces state_1
+run code against state_1  → produces state_2
+assert state_2 is cheaper/different from state_1,
+       OR state_2 does not re-select work that state_1 already addressed
+```
+
+If your PR adds a loop-break (like a NO-PROGRESS guard), also add a
+cross-run test showing the selector does not reselect the same file
+given the state produced by the previous run. "Same input, same
+expensive output, forever" is the bug shape row 9 YELLOW exists to
+flag.
+
+### 2. Cross-field frontmatter key-set invariants
+
+The frontmatter has multiple frame-keyed dicts: `enriched_frame_hashes`,
+`raw_frames`, `raw_tokens`, `frame_sections`. The invariant
+`keys(d) ⊆ frames` must hold for every one of them after every write.
+Enforced centrally in `figma_render._build_frontmatter` — the single
+chokepoint for frontmatter serialization.
+
+**If you add a new frame-keyed field**:
+- Extend `_build_frontmatter` to prune it too
+- Add a test in `tests/test_frontmatter_key_set_invariant.py` asserting
+  orphan keys are dropped on write
+- Do not rely on callers to pre-prune — the chokepoint is the guarantee
+
+### 3. Terminal-state completeness for LLM-dispatched work
+
+Every "pending" state must have a terminal counterpart. If the LLM can
+produce an output that says "I cannot resolve this right now" (e.g.
+`(no screenshot available)`), that output must be recordable as a
+tombstone so we don't re-dispatch the same question on the next run.
+Tombstones auto-invalidate when the underlying content hash changes.
+
+**If you introduce a new "soft-done" row marker**: design the tombstone
+protocol in the same PR. Do not ship a retryable marker without a
+matching terminal state — that guarantees cross-run loops.
+
+### 4. Canonical walker reuse
+
+Body frame-row iteration has exactly one canonical implementation:
+`body_validation.iter_body_frame_rows`. Fence-aware, exact rendered
+header matching, yields `BodyFrameRow` pydantic models with
+`line_index` and `node_id`. Use it for any code that needs to inspect
+or mutate canonical body frame tables.
+
+Don't:
+- re-implement `is_table_separator` / `parse_frame_row` / fence tracking
+  in new code
+- copy loops from existing walkers
+- import `re` in pull / claude-run / write-body code to match row shapes
+
+Do:
+- use `iter_body_frame_rows` for row-by-row work
+- use `body_frame_node_ids` (a thin projection over the iterator) when
+  you only need the node_id list
+- use `section_line_ranges` / `parse_sections` for section-level work
+
+### 5. Log writers — no WARN-and-drop
+
+A log writer that emits `WARN … skipped until file is fixed` but never
+fixes the file silently loses data every run forever. If schema
+migration is possible, do it atomically on the first mismatch. If not,
+hard-fail. Never accept "warn and forget" as a terminal state for a
+writer.
+
+### Review checklist for enrichment / pull / logging PRs
+
+- [ ] Does this PR add a loop-break? If yes, does it have a cross-run
+      test (dimension 1)?
+- [ ] Does this PR touch frontmatter fields? If yes, are frame-keyed
+      dicts pruned at the chokepoint and covered by key-set tests
+      (dimension 2)?
+- [ ] Does this PR introduce a new LLM row marker? If yes, is the
+      tombstone protocol designed in the same PR (dimension 3)?
+- [ ] Does this PR walk the body? If yes, does it use
+      `iter_body_frame_rows` / `section_line_ranges` (dimension 4)?
+- [ ] Does this PR touch a log writer? If yes, does it auto-heal or
+      hard-fail on schema drift (dimension 5)?

--- a/figmaclaw/body_validation.py
+++ b/figmaclaw/body_validation.py
@@ -3,9 +3,17 @@
 This module enforces the key safety invariant:
 frontmatter ``frames`` is authoritative, and the body frame tables must
 contain exactly those node IDs (no missing, no extras, no duplicates).
+
+Also exposes :func:`iter_body_frame_rows` — the canonical, fence-aware,
+exact-header-matching walker that yields each frame row's
+``(line_index, node_id)``. It is the single source of truth for callers
+that need to mutate or inspect canonical body frame tables (e.g. pull-time
+orphan pruning — figmaclaw#121).
 """
 
 from __future__ import annotations
+
+from collections.abc import Iterator
 
 import pydantic
 
@@ -16,6 +24,18 @@ from figmaclaw.figma_schema import (
     render_frame_table_header,
     render_variant_table_header,
 )
+
+
+class BodyFrameRow(pydantic.BaseModel):
+    """One parsed canonical frame row with its location in the body.
+
+    Pydantic per figmaclaw CLAUDE.md "Use pydantic, not dataclass".
+    """
+
+    model_config = pydantic.ConfigDict(frozen=True)
+
+    line_index: int
+    node_id: str
 
 
 class BodyValidationResult(pydantic.BaseModel):
@@ -61,8 +81,17 @@ def _duplicate_node_ids(node_ids: list[str]) -> list[str]:
     return duplicates
 
 
-def body_frame_node_ids(body: str) -> list[str]:
-    """Return frame node IDs from canonical figmaclaw tables in frame sections only."""
+def iter_body_frame_rows(body: str) -> Iterator[BodyFrameRow]:
+    """Yield one :class:`BodyFrameRow` per canonical frame row in *body*.
+
+    Canonical = appears inside a frame-section (``## Name (`node_id`)``),
+    under an exact rendered header (frame or variant), outside any fenced
+    code block. This is the strictest body walker — callers that need to
+    inspect or mutate frame rows must use this function rather than
+    re-implementing a walk.
+
+    The order is document order. Line indices are relative to *body*.
+    """
     lines = body.splitlines()
     frame_header, frame_separator = render_frame_table_header()
     variant_header, variant_separator = render_variant_table_header()
@@ -72,7 +101,6 @@ def body_frame_node_ids(body: str) -> list[str]:
         (variant_header, variant_separator),
     }
 
-    # Discover frame-section ranges using heading parser; prose sections have empty node_id.
     section_starts: list[int] = []
     for i, line in enumerate(lines):
         parsed = parse_section_heading(line)
@@ -80,9 +108,7 @@ def body_frame_node_ids(body: str) -> list[str]:
             section_starts.append(i)
 
     if not section_starts:
-        return []
-
-    node_ids: list[str] = []
+        return
 
     for idx, start in enumerate(section_starts):
         end = section_starts[idx + 1] if idx + 1 < len(section_starts) else len(lines)
@@ -99,25 +125,29 @@ def body_frame_node_ids(body: str) -> list[str]:
                 continue
 
             if i + 1 < end and (stripped, lines[i + 1].strip()) in canonical_tables:
-                # Parse canonical frame rows until table ends.
                 i += 2
                 while i < end:
                     row_line = lines[i]
                     row_stripped = row_line.strip()
-                    if row_stripped.startswith("```"):
-                        break
-                    if not row_stripped:
+                    if row_stripped.startswith("```") or not row_stripped:
                         break
                     row = parse_frame_row(row_line)
                     if row is None:
                         break
-                    node_ids.append(row.node_id)
+                    yield BodyFrameRow(line_index=i, node_id=row.node_id)
                     i += 1
                 continue
 
             i += 1
 
-    return node_ids
+
+def body_frame_node_ids(body: str) -> list[str]:
+    """Return frame node IDs from canonical figmaclaw tables in document order.
+
+    Thin wrapper over :func:`iter_body_frame_rows` — single source of truth
+    for canonical body frame-row discovery.
+    """
+    return [row.node_id for row in iter_body_frame_rows(body)]
 
 
 def validate_body_against_frames(body: str, expected_frames: list[str]) -> BodyValidationResult:

--- a/figmaclaw/commands/claude_run.py
+++ b/figmaclaw/commands/claude_run.py
@@ -366,9 +366,7 @@ def _ensure_enrichment_log_schema(repo_dir: Path, log_path: Path) -> bool:
     # caller's row is then appended to the new empty log; prior history
     # is preserved in the .bak file and recoverable by hand if needed.
     archived = log_path.with_name(
-        f"{log_path.stem}.bak."
-        f"{datetime.now(UTC).strftime('%Y%m%dT%H%M%SZ')}"
-        f"{log_path.suffix}"
+        f"{log_path.stem}.bak.{datetime.now(UTC).strftime('%Y%m%dT%H%M%SZ')}{log_path.suffix}"
     )
     log_path.rename(archived)
     _rewrite_csv_rows(log_path, [])
@@ -524,9 +522,7 @@ def _migrate_missing_enrichment_schema_version(md_path: Path, text: str) -> str:
     return migrated
 
 
-def enrichment_info(
-    md_path: Path, repo_dir: Path | None = None
-) -> tuple[bool, int]:
+def enrichment_info(md_path: Path, repo_dir: Path | None = None) -> tuple[bool, int]:
     """Fast selector for enrichment candidacy and frame-size estimate.
 
     Returns ``(needs_it, frame_count)``.
@@ -701,9 +697,7 @@ def _tombstoned_ids_for_path(md_path: Path, repo_dir: Path | None) -> set[str]:
     return active_tombstoned_node_ids(fm, repo_dir)
 
 
-def pending_sections(
-    md_path: Path, repo_dir: Path | None = None
-) -> list[dict[str, str | int]]:
+def pending_sections(md_path: Path, repo_dir: Path | None = None) -> list[dict[str, str | int]]:
     """Return sections that need enrichment (have pending unresolved rows).
 
     Returns ``[{"node_id": ..., "name": ..., "pending_frames": N}]`` for
@@ -757,9 +751,7 @@ def pending_frame_node_ids(md_path: Path, repo_dir: Path | None = None) -> set[s
     return pending - _tombstoned_ids_for_path(md_path, repo_dir)
 
 
-def _record_tombstones(
-    md_path: Path, repo_dir: Path, node_ids: set[str]
-) -> int:
+def _record_tombstones(md_path: Path, repo_dir: Path, node_ids: set[str]) -> int:
     """Record unresolvable-frame tombstones for *node_ids* in *md_path*'s frontmatter.
 
     The tombstone value is the current manifest frame_hash for each
@@ -1440,9 +1432,7 @@ def claude_run_cmd(
                             False,
                             run_id=run_id,
                         )
-                        tombstoned = _record_tombstones(
-                            file_path, repo_dir, after_pending_ids
-                        )
+                        tombstoned = _record_tombstones(file_path, repo_dir, after_pending_ids)
                         if tombstoned:
                             click.echo(
                                 f"[claude-run] [{i}/{total}] recorded {tombstoned} tombstone(s) "

--- a/figmaclaw/commands/claude_run.py
+++ b/figmaclaw/commands/claude_run.py
@@ -39,7 +39,9 @@ import pydantic
 from figmaclaw.budget import BudgetDecision, decide_next_batch, load_per_frame_history
 from figmaclaw.figma_md_parse import frame_row_count, section_line_ranges
 from figmaclaw.figma_parse import parse_frontmatter, split_frontmatter
+from figmaclaw.figma_render import rebuild_frontmatter_from_parsed
 from figmaclaw.figma_schema import unresolved_row_node_id
+from figmaclaw.figma_sync_state import FigmaSyncState
 from figmaclaw.schema_status import enrichment_schema_status
 from figmaclaw.staleness import active_tombstoned_node_ids
 from figmaclaw.verdict import (
@@ -763,13 +765,12 @@ def _record_tombstones(md_path: Path, repo_dir: Path, node_ids: set[str]) -> int
     no manifest context was available or none of the node_ids had a
     current hash to anchor to.
 
-    Uses the canonical frontmatter write path (``build_page_frontmatter``
-    + ``_rewrite_frontmatter_preserving_body``) so the key-set invariant
-    from figmaclaw#121 applies: tombstones for node_ids not in ``frames``
-    are pruned by the chokepoint before serialization.
+    Uses the public :func:`figma_render.rebuild_frontmatter_from_parsed`
+    helper — same ``_build_frontmatter`` chokepoint as
+    ``build_page_frontmatter`` and ``build_component_frontmatter`` — so
+    the key-set invariant from figmaclaw#121 applies: tombstones for
+    node_ids not in ``frames`` are pruned before serialization.
     """
-    from figmaclaw.figma_sync_state import FigmaSyncState
-
     try:
         text = md_path.read_text()
     except OSError:
@@ -802,27 +803,7 @@ def _record_tombstones(md_path: Path, repo_dir: Path, node_ids: set[str]) -> int
     if added == 0:
         return 0
 
-    # Rewrite just the frontmatter via the canonical builder — no body
-    # mutation. ``frames`` set is the page's authoritative frame list,
-    # so the chokepoint prunes any tombstone for a node not in frames.
-    from figmaclaw.figma_render import _build_frontmatter
-
-    new_fm = _build_frontmatter(
-        file_key=fm.file_key,
-        page_node_id=fm.page_node_id,
-        section_node_id=fm.section_node_id,
-        frame_ids=fm.frames,
-        flows=[(src, dst) for src, dst in fm.flows],
-        enriched_hash=fm.enriched_hash,
-        enriched_at=fm.enriched_at,
-        enriched_frame_hashes=fm.enriched_frame_hashes or None,
-        enriched_schema_version=fm.enriched_schema_version,
-        component_set_keys=fm.component_set_keys or None,
-        raw_frames=fm.raw_frames or None,
-        raw_tokens=fm.raw_tokens or None,
-        frame_sections=fm.frame_sections or None,
-        unresolvable_frames=existing,
-    )
+    new_fm = rebuild_frontmatter_from_parsed(fm, unresolvable_frames=existing)
     parts = split_frontmatter(text)
     if parts is None:
         return 0
@@ -831,8 +812,14 @@ def _record_tombstones(md_path: Path, repo_dir: Path, node_ids: set[str]) -> int
     return added
 
 
-def _is_schema_upgrade_only_candidate(md_path: Path) -> bool:
-    """True when file only needs schema bump (no pending rows, no finalization work)."""
+def _is_schema_upgrade_only_candidate(md_path: Path, repo_dir: Path | None = None) -> bool:
+    """True when file only needs schema bump (no pending rows, no finalization work).
+
+    *repo_dir* is threaded to ``pending_sections`` and ``needs_finalization``
+    so tombstoned frames are not counted as pending. Without this, a file
+    whose only remaining unresolved rows are fully tombstoned would
+    wrongly return False here (selector/dispatcher disagreement).
+    """
     try:
         fm = parse_frontmatter(md_path.read_text())
     except Exception:
@@ -842,13 +829,17 @@ def _is_schema_upgrade_only_candidate(md_path: Path) -> bool:
         return False
     if not enrichment_schema_status(fm.enriched_schema_version).must_update:
         return False
-    if pending_sections(md_path):
+    if pending_sections(md_path, repo_dir=repo_dir):
         return False
-    return not needs_finalization(md_path)
+    return not needs_finalization(md_path, repo_dir=repo_dir)
 
 
-def _is_llm_marker_only_candidate(md_path: Path) -> bool:
-    """True when only unresolved signal is an LLM marker comment."""
+def _is_llm_marker_only_candidate(md_path: Path, repo_dir: Path | None = None) -> bool:
+    """True when only unresolved signal is an LLM marker comment.
+
+    *repo_dir* is threaded so tombstoned rows don't prevent recognition
+    of the marker-only candidate state.
+    """
     try:
         text = md_path.read_text()
     except OSError:
@@ -856,13 +847,18 @@ def _is_llm_marker_only_candidate(md_path: Path) -> bool:
 
     if "<!-- LLM:" not in text:
         return False
-    if pending_sections(md_path):
+    if pending_sections(md_path, repo_dir=repo_dir):
         return False
-    return not needs_finalization(md_path)
+    return not needs_finalization(md_path, repo_dir=repo_dir)
 
 
-def _classify_no_work_candidate(md_path: Path) -> str:
-    """Classify no-work section candidates from a single file snapshot."""
+def _classify_no_work_candidate(md_path: Path, repo_dir: Path | None = None) -> str:
+    """Classify no-work section candidates from a single file snapshot.
+
+    *repo_dir* is currently unused here but accepted for signature parity
+    with the other candidate checks — lets callers thread it uniformly.
+    """
+    _ = repo_dir  # reserved for future tombstone-aware classification
     try:
         text = md_path.read_text()
     except OSError:
@@ -882,19 +878,32 @@ def _classify_no_work_candidate(md_path: Path) -> str:
     return "phantom"
 
 
-def needs_finalization(md_path: Path) -> bool:
+def needs_finalization(md_path: Path, repo_dir: Path | None = None) -> bool:
     """True when all sections are described but the page isn't marked enriched yet.
 
     This means section-by-section enrichment is complete and the finalization
     step (page summary + mermaid + mark-enriched) should run.
+
+    *repo_dir* is threaded so that tombstoned rows are NOT counted as
+    pending — otherwise a file with all unresolved rows tombstoned would
+    never be allowed to finalize.
     """
     try:
         text = md_path.read_text()
     except OSError:
         return False
 
-    # If there are still pending unresolved rows anywhere, not ready.
-    if any(unresolved_row_node_id(line) is not None for line in text.splitlines()):
+    # If there are still pending unresolved rows anywhere (excluding
+    # tombstoned ones), not ready.
+    try:
+        fm = parse_frontmatter(text)
+    except Exception:
+        fm = None
+    tombstoned = active_tombstoned_node_ids(fm, repo_dir)
+    if any(
+        (nid := unresolved_row_node_id(line)) is not None and nid not in tombstoned
+        for line in text.splitlines()
+    ):
         return False
 
     # If already marked as enriched, no need to finalize
@@ -1186,7 +1195,7 @@ def claude_run_cmd(
             _, fc = enrichment_info(f, repo_dir=repo_dir)
             if section_mode and fc > SECTION_THRESHOLD:
                 sections = pending_sections(f, repo_dir=repo_dir)
-                fin = needs_finalization(f)
+                fin = needs_finalization(f, repo_dir=repo_dir)
                 click.echo(
                     f"  {f} ({fc} frames, section-mode: {len(sections)} pending sections, finalize={fin})"
                 )
@@ -1269,7 +1278,7 @@ def claude_run_cmd(
             subprocess.run(["git", "pull", "--no-rebase"], capture_output=True)
 
             # Re-check after pull — file may now have enriched_hash
-            needs_it, frame_count = enrichment_info(file_path)
+            needs_it, frame_count = enrichment_info(file_path, repo_dir=repo_dir)
             if not needs_it:
                 click.echo(
                     f"[claude-run] [{i}/{total}] skip (already enriched): {file_path}",
@@ -1282,10 +1291,10 @@ def claude_run_cmd(
                 # using write-descriptions (cross-section, mechanical row updates).
                 batch_template = _prompt_path("figma-sections-batch.md").read_text()
                 sections = pending_sections(file_path, repo_dir=repo_dir)
-                fin_needed = needs_finalization(file_path)
+                fin_needed = needs_finalization(file_path, repo_dir=repo_dir)
 
                 if not sections and not fin_needed:
-                    candidate = _classify_no_work_candidate(file_path)
+                    candidate = _classify_no_work_candidate(file_path, repo_dir=repo_dir)
                     if candidate == "schema-only":
                         click.echo(
                             f"[claude-run] [{i}/{total}] skip (schema-only candidate): {file_path}",
@@ -1448,7 +1457,7 @@ def claude_run_cmd(
                     break  # out of outer for
 
                 # All frames described → finalize (page summary + intros + mermaid)
-                if needs_finalization(file_path):
+                if needs_finalization(file_path, repo_dir=repo_dir):
                     decision = _budget_check(frame_count, mode="finalize")
                     click.echo(decision.reason, err=True)
                     if not decision.should_start:

--- a/figmaclaw/commands/claude_run.py
+++ b/figmaclaw/commands/claude_run.py
@@ -1061,9 +1061,11 @@ def claude_run_cmd(
     work_attempted = 0
     errors = 0
     skipped_no_work = 0
+    stuck = 0
     budget_exhausted = False
     budget_stop_reason: str | None = None
     phantom_files: list[str] = []
+    stuck_files: list[str] = []
     dispatch_crashed = False
 
     # Sha snapshot before any work — used to count commits that actually
@@ -1283,6 +1285,8 @@ def claude_run_cmd(
                             False,
                             run_id=run_id,
                         )
+                        stuck += 1
+                        stuck_files.append(str(file_path))
                         break
 
                 if budget_exhausted:
@@ -1421,6 +1425,7 @@ def claude_run_cmd(
         errors=errors,
         budget_exhausted=budget_exhausted,
         skipped_no_work=skipped_no_work,
+        stuck=stuck,
     )
     if dispatch_crashed:
         verdict = RunVerdict(
@@ -1433,7 +1438,7 @@ def claude_run_cmd(
         f"[claude-run] Done: files_selected={files_selected} "
         f"work_attempted={work_attempted} commits_made={commits_made} "
         f"errors={errors} budget_exhausted={str(budget_exhausted).lower()} "
-        f"skipped_no_work={skipped_no_work}",
+        f"skipped_no_work={skipped_no_work} stuck={stuck}",
         err=True,
     )
     click.echo(f"[claude-run] Verdict ({verdict.row}): {verdict.label}", err=True)
@@ -1446,7 +1451,9 @@ def claude_run_cmd(
         errors=errors,
         budget_exhausted=budget_exhausted,
         skipped_no_work=skipped_no_work,
+        stuck=stuck,
         phantom_files=phantom_files or None,
+        stuck_files=stuck_files or None,
         budget_stop_reason=budget_stop_reason,
     )
     write_step_summary(summary)

--- a/figmaclaw/commands/claude_run.py
+++ b/figmaclaw/commands/claude_run.py
@@ -359,11 +359,26 @@ def _ensure_enrichment_log_schema(repo_dir: Path, log_path: Path) -> bool:
         _warn_enrichment_log(repo_dir, "migrated minimal enrichment log header to schema-v1")
         return True
 
+    # Unrecognized schema — no known migration path applies. Rather than
+    # silently skipping appends forever (the figmaclaw#121 incident shape,
+    # where this WARN recurred hourly and the file was never "fixed"),
+    # archive the current log with a UTC timestamp and start fresh. The
+    # caller's row is then appended to the new empty log; prior history
+    # is preserved in the .bak file and recoverable by hand if needed.
+    archived = log_path.with_name(
+        f"{log_path.stem}.bak."
+        f"{datetime.now(UTC).strftime('%Y%m%dT%H%M%SZ')}"
+        f"{log_path.suffix}"
+    )
+    log_path.rename(archived)
+    _rewrite_csv_rows(log_path, [])
+    _rebuild_event_id_index(repo_dir, [])
     _warn_enrichment_log(
         repo_dir,
-        "unsupported enrichment log schema/header; append skipped until file is fixed",
+        f"unrecognized enrichment log schema (fieldnames={list(fieldnames)}); "
+        f"archived prior log to {archived.name} and started a fresh schema-v1 log",
     )
-    return False
+    return True
 
 
 def _log_enrichment(

--- a/figmaclaw/commands/claude_run.py
+++ b/figmaclaw/commands/claude_run.py
@@ -41,6 +41,7 @@ from figmaclaw.figma_md_parse import frame_row_count, section_line_ranges
 from figmaclaw.figma_parse import parse_frontmatter, split_frontmatter
 from figmaclaw.figma_schema import unresolved_row_node_id
 from figmaclaw.schema_status import enrichment_schema_status
+from figmaclaw.staleness import active_tombstoned_node_ids
 from figmaclaw.verdict import (
     EXIT_RED,
     RunVerdict,
@@ -508,13 +509,21 @@ def _migrate_missing_enrichment_schema_version(md_path: Path, text: str) -> str:
     return migrated
 
 
-def enrichment_info(md_path: Path) -> tuple[bool, int]:
+def enrichment_info(
+    md_path: Path, repo_dir: Path | None = None
+) -> tuple[bool, int]:
     """Fast selector for enrichment candidacy and frame-size estimate.
 
     Returns ``(needs_it, frame_count)``.
 
     Contract: selector must match ``inspect`` for ENRICH MUST decisions and
     must migrate legacy files lacking explicit schema version.
+
+    When *repo_dir* is provided, body rows whose node_id is actively
+    tombstoned (``unresolvable_frames[nid]`` matches current manifest
+    hash) are NOT counted as unresolved — otherwise the selector would
+    keep picking files whose only remaining "pending" rows are ones the
+    LLM has already confirmed unresolvable. See figmaclaw#121.
     """
     # Inventory artifacts are never page-enrichment targets.
     if _is_non_enrichable_markdown(md_path):
@@ -533,7 +542,15 @@ def enrichment_info(md_path: Path) -> tuple[bool, int]:
 
     # Frame-size estimate from canonical body parser (frame sections only).
     frame_count = frame_row_count(text)
-    has_unresolved = any(unresolved_row_node_id(line) is not None for line in text.splitlines())
+    try:
+        fm_for_tombstones = parse_frontmatter(text)
+    except Exception:
+        fm_for_tombstones = None
+    tombstoned = active_tombstoned_node_ids(fm_for_tombstones, repo_dir)
+    has_unresolved = any(
+        (nid := unresolved_row_node_id(line)) is not None and nid not in tombstoned
+        for line in text.splitlines()
+    )
     has_llm_marker = "<!-- LLM:" in text
 
     if has_unresolved or has_llm_marker:
@@ -564,6 +581,7 @@ def collect_files(
     needs_enrichment: bool = False,
     min_frames: int = 0,
     max_frames: int = 0,
+    repo_dir: Path | None = None,
 ) -> list[Path]:
     """Discover files to process, optionally filtering by enrichment status.
 
@@ -589,7 +607,7 @@ def collect_files(
         skipped_small = 0
         skipped_big = 0
         for f in files:
-            needs_it, frame_count = enrichment_info(f)
+            needs_it, frame_count = enrichment_info(f, repo_dir=repo_dir)
             if not needs_it:
                 continue
             if min_frames > 0 and frame_count < min_frames:
@@ -647,11 +665,39 @@ def _pending_sections_with_frame_ids(text: str) -> list[dict[str, str | list[str
     return parsed
 
 
-def pending_sections(md_path: Path) -> list[dict[str, str | int]]:
+def _tombstoned_ids_for_path(md_path: Path, repo_dir: Path | None) -> set[str]:
+    """Read the file's frontmatter and return its active tombstones.
+
+    Thin wrapper around :func:`figmaclaw.staleness.active_tombstoned_node_ids`
+    that takes a path (for callers that already only have the path).
+    Returns empty set when no manifest is available or tombstones are
+    empty — safe to subtract from a pending set unconditionally.
+    """
+    if repo_dir is None:
+        return set()
+    try:
+        text = md_path.read_text()
+    except OSError:
+        return set()
+    try:
+        fm = parse_frontmatter(text)
+    except Exception:
+        return set()
+    return active_tombstoned_node_ids(fm, repo_dir)
+
+
+def pending_sections(
+    md_path: Path, repo_dir: Path | None = None
+) -> list[dict[str, str | int]]:
     """Return sections that need enrichment (have pending unresolved rows).
 
     Returns ``[{"node_id": ..., "name": ..., "pending_frames": N}]`` for
     sections with unresolved description markers.
+
+    When *repo_dir* is provided, frames with an ACTIVE tombstone (recorded
+    ``unresolvable_frames[nid]`` equals the current manifest hash) are
+    excluded from the pending count — a terminal state means "not
+    pending" until Figma content changes. See figmaclaw#121.
     """
     try:
         text = md_path.read_text()
@@ -659,30 +705,123 @@ def pending_sections(md_path: Path) -> list[dict[str, str | int]]:
         return []
 
     parsed = _pending_sections_with_frame_ids(text)
-    return [
-        {
-            "node_id": str(item["node_id"]),
-            "name": str(item["name"]),
-            "pending_frames": len(item["pending_frame_ids"]),
-        }
-        for item in parsed
-    ]
+    tombstoned = _tombstoned_ids_for_path(md_path, repo_dir)
+    result: list[dict[str, str | int]] = []
+    for item in parsed:
+        pending = [nid for nid in item["pending_frame_ids"] if nid not in tombstoned]
+        if not pending:
+            continue
+        result.append(
+            {
+                "node_id": str(item["node_id"]),
+                "name": str(item["name"]),
+                "pending_frames": len(pending),
+            }
+        )
+    return result
 
 
-def pending_frame_node_ids(md_path: Path) -> set[str]:
-    """Return unresolved frame node IDs pending enrichment for one page."""
+def pending_frame_node_ids(md_path: Path, repo_dir: Path | None = None) -> set[str]:
+    """Return unresolved frame node IDs pending enrichment for one page.
+
+    When *repo_dir* is provided, tombstones whose recorded hash equals
+    the current manifest hash are excluded (terminal state honored).
+    """
     try:
         text = md_path.read_text()
     except OSError:
         return set()
 
     parsed = _pending_sections_with_frame_ids(text)
-    return {
+    pending = {
         node_id
         for item in parsed
         for node_id in item["pending_frame_ids"]
         if isinstance(node_id, str)
     }
+    return pending - _tombstoned_ids_for_path(md_path, repo_dir)
+
+
+def _record_tombstones(
+    md_path: Path, repo_dir: Path, node_ids: set[str]
+) -> int:
+    """Record unresolvable-frame tombstones for *node_ids* in *md_path*'s frontmatter.
+
+    The tombstone value is the current manifest frame_hash for each
+    node_id. When the manifest has no entry for a node_id (orphan frame,
+    or never-pulled page), the node is skipped — there's nothing to key
+    the tombstone against, so retry next run is the safe default.
+
+    Returns the number of tombstones actually written. Zero means either
+    no manifest context was available or none of the node_ids had a
+    current hash to anchor to.
+
+    Uses the canonical frontmatter write path (``build_page_frontmatter``
+    + ``_rewrite_frontmatter_preserving_body``) so the key-set invariant
+    from figmaclaw#121 applies: tombstones for node_ids not in ``frames``
+    are pruned by the chokepoint before serialization.
+    """
+    from figmaclaw.figma_sync_state import FigmaSyncState
+
+    try:
+        text = md_path.read_text()
+    except OSError:
+        return 0
+    fm = parse_frontmatter(text)
+    if fm is None or not fm.file_key or not fm.page_node_id:
+        return 0
+
+    try:
+        state = FigmaSyncState(repo_dir)
+        state.load()
+    except Exception:
+        return 0
+    file_entry = state.manifest.files.get(fm.file_key)
+    if file_entry is None:
+        return 0
+    page_entry = file_entry.pages.get(fm.page_node_id)
+    if page_entry is None:
+        return 0
+    current = page_entry.frame_hashes
+
+    existing = dict(fm.unresolvable_frames or {})
+    before = len(existing)
+    for nid in node_ids:
+        h = current.get(nid)
+        if h is None:
+            continue
+        existing[nid] = h
+    added = len(existing) - before
+    if added == 0:
+        return 0
+
+    # Rewrite just the frontmatter via the canonical builder — no body
+    # mutation. ``frames`` set is the page's authoritative frame list,
+    # so the chokepoint prunes any tombstone for a node not in frames.
+    from figmaclaw.figma_render import _build_frontmatter
+
+    new_fm = _build_frontmatter(
+        file_key=fm.file_key,
+        page_node_id=fm.page_node_id,
+        section_node_id=fm.section_node_id,
+        frame_ids=fm.frames,
+        flows=[(src, dst) for src, dst in fm.flows],
+        enriched_hash=fm.enriched_hash,
+        enriched_at=fm.enriched_at,
+        enriched_frame_hashes=fm.enriched_frame_hashes or None,
+        enriched_schema_version=fm.enriched_schema_version,
+        component_set_keys=fm.component_set_keys or None,
+        raw_frames=fm.raw_frames or None,
+        raw_tokens=fm.raw_tokens or None,
+        frame_sections=fm.frame_sections or None,
+        unresolvable_frames=existing,
+    )
+    parts = split_frontmatter(text)
+    if parts is None:
+        return 0
+    _, body = parts
+    md_path.write_text(f"{new_fm}\n{body}")
+    return added
 
 
 def _is_schema_upgrade_only_candidate(md_path: Path) -> bool:
@@ -1024,6 +1163,7 @@ def claude_run_cmd(
         needs_enrichment,
         min_frames=min_frames,
         max_frames=max_frames,
+        repo_dir=repo_dir,
     )
     if max_files > 0 and len(files) > max_files:
         click.echo(f"[claude-run] limiting to {max_files}/{len(files)} files", err=True)
@@ -1036,9 +1176,9 @@ def claude_run_cmd(
     if dry_run:
         click.echo("[claude-run] DRY RUN — files that would be passed to claude:")
         for f in files:
-            _, fc = enrichment_info(f)
+            _, fc = enrichment_info(f, repo_dir=repo_dir)
             if section_mode and fc > SECTION_THRESHOLD:
-                sections = pending_sections(f)
+                sections = pending_sections(f, repo_dir=repo_dir)
                 fin = needs_finalization(f)
                 click.echo(
                     f"  {f} ({fc} frames, section-mode: {len(sections)} pending sections, finalize={fin})"
@@ -1134,7 +1274,7 @@ def claude_run_cmd(
                 # Batch mode: describe up to 80 pending frames per Claude invocation
                 # using write-descriptions (cross-section, mechanical row updates).
                 batch_template = _prompt_path("figma-sections-batch.md").read_text()
-                sections = pending_sections(file_path)
+                sections = pending_sections(file_path, repo_dir=repo_dir)
                 fin_needed = needs_finalization(file_path)
 
                 if not sections and not fin_needed:
@@ -1196,7 +1336,7 @@ def claude_run_cmd(
                 while sections:
                     chunk_num += 1
                     total_pending = sum(int(s["pending_frames"]) for s in sections)
-                    before_pending_ids = pending_frame_node_ids(file_path)
+                    before_pending_ids = pending_frame_node_ids(file_path, repo_dir=repo_dir)
 
                     # figmaclaw#26: adaptive budget check BEFORE the expensive call
                     decision = _budget_check(total_pending, mode="batch")
@@ -1266,8 +1406,8 @@ def claude_run_cmd(
                     # If unresolved frame IDs didn't change, this run made no
                     # progress on this file; stop immediately to avoid loops.
                     subprocess.run(["git", "pull", "--no-rebase"], capture_output=True)
-                    sections = pending_sections(file_path)
-                    after_pending_ids = pending_frame_node_ids(file_path)
+                    sections = pending_sections(file_path, repo_dir=repo_dir)
+                    after_pending_ids = pending_frame_node_ids(file_path, repo_dir=repo_dir)
                     if after_pending_ids and after_pending_ids == before_pending_ids:
                         click.echo(
                             f"[claude-run] [{i}/{total}] NO-PROGRESS: unresolved frame set "
@@ -1285,6 +1425,16 @@ def claude_run_cmd(
                             False,
                             run_id=run_id,
                         )
+                        tombstoned = _record_tombstones(
+                            file_path, repo_dir, after_pending_ids
+                        )
+                        if tombstoned:
+                            click.echo(
+                                f"[claude-run] [{i}/{total}] recorded {tombstoned} tombstone(s) "
+                                f"in unresolvable_frames — these frames will be skipped on "
+                                f"future runs until their Figma content hash changes.",
+                                err=True,
+                            )
                         stuck += 1
                         stuck_files.append(str(file_path))
                         break

--- a/figmaclaw/figma_frontmatter.py
+++ b/figmaclaw/figma_frontmatter.py
@@ -188,6 +188,25 @@ class FigmaPageFrontmatter(BaseModel):
     # extra REST API calls. See figmaclaw issues #35 and #38.
     frame_sections: dict[str, list[SectionNode]] = Field(default_factory=dict)
 
+    # unresolvable_frames: terminal-state tombstones for frames the LLM
+    # has confirmed it cannot describe at the current content hash (e.g.
+    # because no screenshot is available and the raw composition doesn't
+    # give enough context). Maps node_id → frame_hash at the time the
+    # tombstone was recorded.
+    #
+    # Contract:
+    # - A node_id appears here AT MOST when the same-run NO-PROGRESS guard
+    #   fires on it (figmaclaw#117) — i.e. the LLM tried to resolve the row
+    #   and failed.
+    # - A body row for a tombstoned node_id is treated as NOT pending by
+    #   ``pending_frame_node_ids`` *while* its current manifest hash equals
+    #   the recorded tombstone hash. When Figma content changes and the
+    #   hash moves, the tombstone auto-invalidates and the row becomes
+    #   pending again (one retry per content change).
+    # - Pruned to ``⊆ frames`` by the frontmatter-write chokepoint, same
+    #   as every other frame-keyed dict (figmaclaw#121).
+    unresolvable_frames: dict[str, str] = Field(default_factory=dict)
+
     @model_validator(mode="before")
     @classmethod
     def _normalize_frames(cls, data: Any) -> Any:

--- a/figmaclaw/figma_frontmatter.py
+++ b/figmaclaw/figma_frontmatter.py
@@ -71,9 +71,22 @@ Enrichment schema changelog:
 
 from __future__ import annotations
 
+import re
 from typing import Annotated, Any
 
-from pydantic import BaseModel, Field, model_validator
+from pydantic import BaseModel, Field, field_validator, model_validator
+
+# node_id shape: "<number>:<number>" (Figma's canonical node ID format).
+# Used to validate tombstone keys in unresolvable_frames so a malicious
+# or accidentally-corrupted commit can't inject non-Figma strings.
+_NODE_ID_RE = re.compile(r"^\d+:\d+$")
+
+# Maximum length of a tombstone hash value. The manifest stores content
+# hashes as lowercase hex (compute_frame_hash uses 16-char blake2b output);
+# we accept up to 64 chars to allow future hash upgrades without a schema
+# bump, but reject unbounded strings that could bloat the frontmatter.
+_MAX_TOMBSTONE_HASH_LEN = 64
+_TOMBSTONE_HASH_RE = re.compile(r"^[0-9a-f]+$")
 
 # Pull-pass schema version. Bump when pull_file writes new frontmatter fields.
 # Files in the manifest with pull_schema_version < this get frontmatter-refreshed
@@ -207,6 +220,41 @@ class FigmaPageFrontmatter(BaseModel):
     #   as every other frame-keyed dict (figmaclaw#121).
     unresolvable_frames: dict[str, str] = Field(default_factory=dict)
 
+    @field_validator("unresolvable_frames")
+    @classmethod
+    def _validate_unresolvable_frames(cls, value: dict[str, str]) -> dict[str, str]:
+        """Reject malformed tombstones — node IDs must look like Figma node IDs
+        and hash values must be short lowercase hex.
+
+        See security review in figmaclaw#121: without this, a malicious
+        actor (or accidental corruption) could inject arbitrary strings
+        as "tombstones" to make the enricher skip frames indefinitely.
+        Strict shape validation closes that vector at parse time.
+        """
+        if not value:
+            return value
+        for node_id, hash_value in value.items():
+            if not _NODE_ID_RE.match(node_id):
+                raise ValueError(
+                    f"unresolvable_frames key {node_id!r} is not a valid Figma "
+                    f"node_id (expected '<number>:<number>')"
+                )
+            if not isinstance(hash_value, str):
+                raise ValueError(
+                    f"unresolvable_frames[{node_id!r}] must be a string, "
+                    f"got {type(hash_value).__name__}"
+                )
+            if not 0 < len(hash_value) <= _MAX_TOMBSTONE_HASH_LEN:
+                raise ValueError(
+                    f"unresolvable_frames[{node_id!r}] hash length "
+                    f"{len(hash_value)} out of range (1..{_MAX_TOMBSTONE_HASH_LEN})"
+                )
+            if not _TOMBSTONE_HASH_RE.match(hash_value):
+                raise ValueError(
+                    f"unresolvable_frames[{node_id!r}] is not lowercase hex: {hash_value!r}"
+                )
+        return value
+
     @model_validator(mode="before")
     @classmethod
     def _normalize_frames(cls, data: Any) -> Any:
@@ -215,6 +263,28 @@ class FigmaPageFrontmatter(BaseModel):
             data = dict(data)  # don't mutate caller's dict
             data["frames"] = list(data["frames"].keys())
         return data
+
+    @model_validator(mode="after")
+    def _cap_unresolvable_frames_to_frames(self) -> FigmaPageFrontmatter:
+        """Tombstone set must be ⊆ frames.
+
+        The build-time chokepoint in ``_build_frontmatter`` strips
+        orphan tombstones on write, but a hand-edited file could land on
+        disk with extras. Validate on parse so downstream code never
+        sees a tombstone for a non-existent frame.
+        """
+        if not self.unresolvable_frames:
+            return self
+        frame_set = set(self.frames)
+        orphans = [nid for nid in self.unresolvable_frames if nid not in frame_set]
+        if orphans:
+            # Prune rather than error — the invariant is "cannot surface
+            # orphans", not "cannot tolerate them". Logs already warn via
+            # the key-set chokepoint on the next write.
+            self.unresolvable_frames = {
+                nid: h for nid, h in self.unresolvable_frames.items() if nid in frame_set
+            }
+        return self
 
     @model_validator(mode="after")
     def _require_both_ids_or_neither(self) -> FigmaPageFrontmatter:

--- a/figmaclaw/figma_frontmatter.py
+++ b/figmaclaw/figma_frontmatter.py
@@ -64,6 +64,12 @@ Pull schema changelog:
       instances[] and raw_count (issue #38 coverage queries)
   v6: extended frame_sections inventory with stable instance_component_ids[] to
       support rename-robust coverage/autodiscovery queries
+  v7: added unresolvable_frames field (tombstones for NO-PROGRESS frames),
+      enforced frame-keyed key-set invariant at the _build_frontmatter
+      chokepoint, and added pull-time orphan body-row pruning via
+      iter_body_frame_rows (issue #121). Forcing a refresh cleans up
+      existing files whose `frames` list shrank in a prior pull but whose
+      enriched_frame_hashes / body-table rows retained the orphans.
 
 Enrichment schema changelog:
   v1: initial enrichment format — frame table + page summary + Mermaid flows
@@ -90,8 +96,9 @@ _TOMBSTONE_HASH_RE = re.compile(r"^[0-9a-f]+$")
 
 # Pull-pass schema version. Bump when pull_file writes new frontmatter fields.
 # Files in the manifest with pull_schema_version < this get frontmatter-refreshed
-# on the next pull run even if Figma content is unchanged. Body is never touched.
-CURRENT_PULL_SCHEMA_VERSION: int = 6
+# on the next pull run even if Figma content is unchanged. Body is never touched
+# (except for the narrow orphan-row prune in figmaclaw#121 — structural, not prose).
+CURRENT_PULL_SCHEMA_VERSION: int = 7
 
 # Enrichment schema version. Bump when the LLM prompt or output format changes.
 # Pages with enriched_schema_version < MIN_REQUIRED MUST be re-enriched (broken output).

--- a/figmaclaw/figma_md_parse.py
+++ b/figmaclaw/figma_md_parse.py
@@ -89,10 +89,23 @@ class ParsedSection:
 
 
 def _collect_frames_in_range(lines: list[str], start: int, end: int) -> list[ParsedFrame]:
-    """Collect parsed frame rows inside one line range."""
+    """Collect parsed frame rows inside one line range.
+
+    Tracks fenced code blocks (``` ``` ```), matching the fence-awareness in
+    :func:`figmaclaw.body_validation.iter_body_frame_rows` so both
+    canonical body walkers agree on what counts as a frame row. See the
+    figmaclaw#121 anti-loop policy #4 (canonical walker reuse).
+    """
     in_table = False
+    in_fence = False
     frames: list[ParsedFrame] = []
     for line in lines[start:end]:
+        if line.lstrip().startswith("```"):
+            in_fence = not in_fence
+            in_table = False
+            continue
+        if in_fence:
+            continue
         if is_table_separator(line):
             in_table = True
             continue

--- a/figmaclaw/figma_render.py
+++ b/figmaclaw/figma_render.py
@@ -85,6 +85,17 @@ _FrontmatterDumper.add_representer(
 )
 
 
+def _prune_to_allowed(d: dict | None, allowed: set[str]) -> dict | None:
+    """Return *d* restricted to keys in *allowed*, or None if *d* is falsy.
+
+    Enforces the frame-keyed key-set invariant at the single frontmatter
+    write chokepoint (``_build_frontmatter``). See figmaclaw#121.
+    """
+    if not d:
+        return d
+    return {k: v for k, v in d.items() if k in allowed}
+
+
 def _build_frontmatter(
     file_key: str,
     page_node_id: str,
@@ -101,7 +112,25 @@ def _build_frontmatter(
     raw_tokens: dict[str, RawTokenCounts] | None = None,
     frame_sections: dict[str, list[SectionNode]] | None = None,
 ) -> str:
-    """Render compact YAML frontmatter block (between --- markers)."""
+    """Render compact YAML frontmatter block (between --- markers).
+
+    Enforces the frame-keyed key-set invariant: any frame-keyed dict
+    (``enriched_frame_hashes``, ``raw_frames``, ``raw_tokens``, ``frame_sections``)
+    is pruned to ``⊆ frame_ids`` before rendering. This is the single chokepoint
+    for frontmatter writes — orphan frame-keyed entries cannot survive a
+    round-trip through this function, regardless of caller correctness.
+
+    Rationale: see figmaclaw#121 (cross-run enrichment loops). Orphan entries
+    in ``enriched_frame_hashes`` that survived a shrinking ``frames`` list in
+    ``pull`` caused hourly CI failures on stuck files the selector kept
+    reselecting across runs.
+    """
+    allowed_frame_ids = set(frame_ids)
+    enriched_frame_hashes = _prune_to_allowed(enriched_frame_hashes, allowed_frame_ids)
+    raw_frames = _prune_to_allowed(raw_frames, allowed_frame_ids)
+    raw_tokens = _prune_to_allowed(raw_tokens, allowed_frame_ids)
+    frame_sections = _prune_to_allowed(frame_sections, allowed_frame_ids)
+
     fm: dict = {"file_key": file_key, "page_node_id": page_node_id}
     if section_node_id:
         fm["section_node_id"] = section_node_id

--- a/figmaclaw/figma_render.py
+++ b/figmaclaw/figma_render.py
@@ -111,6 +111,7 @@ def _build_frontmatter(
     raw_frames: dict[str, FrameComposition] | None = None,
     raw_tokens: dict[str, RawTokenCounts] | None = None,
     frame_sections: dict[str, list[SectionNode]] | None = None,
+    unresolvable_frames: dict[str, str] | None = None,
 ) -> str:
     """Render compact YAML frontmatter block (between --- markers).
 
@@ -130,6 +131,7 @@ def _build_frontmatter(
     raw_frames = _prune_to_allowed(raw_frames, allowed_frame_ids)
     raw_tokens = _prune_to_allowed(raw_tokens, allowed_frame_ids)
     frame_sections = _prune_to_allowed(frame_sections, allowed_frame_ids)
+    unresolvable_frames = _prune_to_allowed(unresolvable_frames, allowed_frame_ids)
 
     fm: dict = {"file_key": file_key, "page_node_id": page_node_id}
     if section_node_id:
@@ -144,6 +146,8 @@ def _build_frontmatter(
         fm["enriched_at"] = enriched_at
     if enriched_frame_hashes:
         fm["enriched_frame_hashes"] = _FlowDict(enriched_frame_hashes)
+    if unresolvable_frames:
+        fm["unresolvable_frames"] = _FlowDict(unresolvable_frames)
     fm["enriched_schema_version"] = enriched_schema_version
     if component_set_keys:
         fm["component_set_keys"] = _FlowDict(component_set_keys)
@@ -229,6 +233,7 @@ def build_page_frontmatter(
     raw_frames: dict[str, FrameComposition] | None = None,
     raw_tokens: dict[str, RawTokenCounts] | None = None,
     frame_sections: dict[str, list[SectionNode]] | None = None,
+    unresolvable_frames: dict[str, str] | None = None,
 ) -> str:
     """Build the YAML frontmatter block for a screen page from a FigmaPage model.
 
@@ -243,6 +248,12 @@ def build_page_frontmatter(
     and per-section direct-child inventory (instances/raw_count + stable
     instance_component_ids). Used by build-context and coverage queries
     without extra API calls.
+
+    unresolvable_frames: tombstones (node_id → frame_hash at tombstone time)
+    for frames the LLM has confirmed it cannot describe at that content
+    hash. See FigmaPageFrontmatter.unresolvable_frames for the full
+    contract. None means no tombstones are being written; existing ones
+    carried via the caller are preserved (the chokepoint prunes orphans).
     """
     return _build_frontmatter(
         file_key=page.file_key,
@@ -257,6 +268,7 @@ def build_page_frontmatter(
         raw_frames=raw_frames,
         raw_tokens=raw_tokens,
         frame_sections=frame_sections,
+        unresolvable_frames=unresolvable_frames,
     )
 
 
@@ -269,6 +281,7 @@ def build_component_frontmatter(
     enriched_at: str | None = None,
     enriched_frame_hashes: dict[str, str] | None = None,
     enriched_schema_version: int = 0,
+    unresolvable_frames: dict[str, str] | None = None,
 ) -> str:
     """Build YAML frontmatter for a component-library section markdown file."""
     return _build_frontmatter(
@@ -282,6 +295,7 @@ def build_component_frontmatter(
         enriched_at=enriched_at,
         enriched_frame_hashes=enriched_frame_hashes,
         enriched_schema_version=enriched_schema_version,
+        unresolvable_frames=unresolvable_frames,
     )
 
 

--- a/figmaclaw/figma_render.py
+++ b/figmaclaw/figma_render.py
@@ -38,7 +38,12 @@ from __future__ import annotations
 
 import yaml
 
-from figmaclaw.figma_frontmatter import FrameComposition, RawTokenCounts, SectionNode
+from figmaclaw.figma_frontmatter import (
+    FigmaPageFrontmatter,
+    FrameComposition,
+    RawTokenCounts,
+    SectionNode,
+)
 from figmaclaw.figma_models import FigmaPage, FigmaSection
 from figmaclaw.figma_schema import (
     PLACEHOLDER_DESCRIPTION,
@@ -269,6 +274,45 @@ def build_page_frontmatter(
         raw_tokens=raw_tokens,
         frame_sections=frame_sections,
         unresolvable_frames=unresolvable_frames,
+    )
+
+
+def rebuild_frontmatter_from_parsed(
+    fm: FigmaPageFrontmatter,
+    *,
+    unresolvable_frames: dict[str, str] | None = None,
+) -> str:
+    """Rebuild YAML frontmatter from an existing parsed :class:`FigmaPageFrontmatter`.
+
+    Use this when you have a parsed frontmatter model in hand and need to
+    persist a small change (e.g. recording a tombstone in
+    ``unresolvable_frames``) without reconstructing a full
+    :class:`FigmaPage` model. Every field from *fm* is preserved and
+    flows through the same :func:`_build_frontmatter` chokepoint that
+    :func:`build_page_frontmatter` and :func:`build_component_frontmatter`
+    use, so the frame-keyed key-set invariant (figmaclaw#121) is
+    enforced uniformly.
+
+    When *unresolvable_frames* is None, the existing tombstones on *fm*
+    are preserved; pass an explicit dict to override.
+    """
+    return _build_frontmatter(
+        file_key=fm.file_key,
+        page_node_id=fm.page_node_id,
+        section_node_id=fm.section_node_id,
+        frame_ids=fm.frames,
+        flows=[(src, dst) for src, dst in fm.flows],
+        enriched_hash=fm.enriched_hash,
+        enriched_at=fm.enriched_at,
+        enriched_frame_hashes=fm.enriched_frame_hashes or None,
+        enriched_schema_version=fm.enriched_schema_version,
+        component_set_keys=fm.component_set_keys or None,
+        raw_frames=fm.raw_frames or None,
+        raw_tokens=fm.raw_tokens or None,
+        frame_sections=fm.frame_sections or None,
+        unresolvable_frames=unresolvable_frames
+        if unresolvable_frames is not None
+        else (fm.unresolvable_frames or None),
     )
 
 

--- a/figmaclaw/figma_render.py
+++ b/figmaclaw/figma_render.py
@@ -194,6 +194,31 @@ def _build_frontmatter(
     return f"---\n{body}\n---"
 
 
+def page_frame_ids(page: FigmaPage) -> list[str]:
+    """Return the node_ids of every frame in *page*'s screen (non-component) sections.
+
+    Single source of truth for "what are the authoritative frame IDs for
+    this page" — used by :func:`build_page_frontmatter` to render the
+    ``frames`` list and by pull-time body pruning to know which body rows
+    are orphans. Avoids the "extract frame IDs from page" loop being
+    re-implemented at every call site.
+    """
+    return [
+        frame.node_id
+        for section in page.sections
+        if not section.is_component_library
+        for frame in section.frames
+    ]
+
+
+def section_frame_ids(section: FigmaSection) -> list[str]:
+    """Return the node_ids of every frame in a component library *section*.
+
+    Mirror of :func:`page_frame_ids` for the component-section case.
+    """
+    return [frame.node_id for frame in section.frames]
+
+
 def build_page_frontmatter(
     page: FigmaPage,
     *,
@@ -219,15 +244,11 @@ def build_page_frontmatter(
     instance_component_ids). Used by build-context and coverage queries
     without extra API calls.
     """
-    screen_sections = [s for s in page.sections if not s.is_component_library]
-    frame_ids: list[str] = [
-        frame.node_id for section in screen_sections for frame in section.frames
-    ]
     return _build_frontmatter(
         file_key=page.file_key,
         page_node_id=page.page_node_id,
         section_node_id=None,
-        frame_ids=frame_ids,
+        frame_ids=page_frame_ids(page),
         flows=page.flows,
         enriched_hash=enriched_hash,
         enriched_at=enriched_at,
@@ -250,12 +271,11 @@ def build_component_frontmatter(
     enriched_schema_version: int = 0,
 ) -> str:
     """Build YAML frontmatter for a component-library section markdown file."""
-    frame_ids: list[str] = [f.node_id for f in section.frames]
     return _build_frontmatter(
         file_key=page.file_key,
         page_node_id=page.page_node_id,
         section_node_id=section.node_id,
-        frame_ids=frame_ids,
+        frame_ids=section_frame_ids(section),
         flows=[],
         component_set_keys=component_set_keys,
         enriched_hash=enriched_hash,

--- a/figmaclaw/pull_logic.py
+++ b/figmaclaw/pull_logic.py
@@ -45,6 +45,7 @@ from pathlib import Path
 import httpx
 from pydantic import BaseModel, Field
 
+from figmaclaw.body_validation import iter_body_frame_rows
 from figmaclaw.figma_client import FigmaClient
 from figmaclaw.figma_frontmatter import (
     CURRENT_PULL_SCHEMA_VERSION,
@@ -54,7 +55,7 @@ from figmaclaw.figma_frontmatter import (
 )
 from figmaclaw.figma_hash import compute_frame_hashes, compute_page_hash
 from figmaclaw.figma_models import FigmaPage, FigmaSection, from_page_node
-from figmaclaw.figma_parse import parse_flows, parse_frontmatter
+from figmaclaw.figma_parse import parse_flows, parse_frontmatter, split_frontmatter
 from figmaclaw.figma_paths import (
     census_path,
     component_path,
@@ -301,13 +302,55 @@ def update_component_frontmatter(
 
 
 def _rewrite_frontmatter_preserving_body(out_path: Path, md_text: str, new_fm: str) -> None:
-    """Rewrite frontmatter while preserving markdown body byte-for-byte."""
-    from figmaclaw.figma_parse import split_frontmatter
+    """Rewrite frontmatter and structurally prune orphan frame rows from body.
 
+    Frontmatter is replaced wholesale. Body prose is preserved verbatim — we
+    do NOT parse or rewrite prose. The only body edit this function performs
+    is surgical removal of canonical frame *rows* whose node_id is no longer
+    in the new frontmatter's ``frames`` list. Table headers, separators,
+    prose, section headings, and Mermaid blocks are untouched.
+
+    This is a structural operation, not a prose rewrite: a row whose node_id
+    points to a frame that no longer exists cannot possibly be correct, so
+    dropping it is the narrow exception to the "code never rewrites body"
+    rule. See figmaclaw#121 — orphan rows left behind by a shrinking pull are
+    what drive cross-run enrichment loops.
+    """
     parts = split_frontmatter(md_text)
     assert parts is not None, f"Failed to parse frontmatter from {out_path}"
     _, body = parts
+
+    new_fm_parsed = parse_frontmatter(f"{new_fm}\n\n# body\n")
+    allowed_frame_ids = set(new_fm_parsed.frames) if new_fm_parsed else set()
+    body = _prune_orphan_frame_rows(body, allowed_frame_ids)
+
     out_path.write_text(f"{new_fm}\n{body}")
+
+
+def _prune_orphan_frame_rows(body: str, allowed_frame_ids: set[str]) -> str:
+    """Remove canonical frame rows whose node_id is not in *allowed_frame_ids*.
+
+    Uses :func:`figmaclaw.body_validation.iter_body_frame_rows` — the single
+    canonical body frame-row walker (fence-aware, exact-header match). Prose,
+    section headings, table headers, separators, and Mermaid blocks are
+    preserved verbatim because they are not yielded by the walker.
+
+    Returns *body* unchanged when *allowed_frame_ids* is empty (nothing to
+    enforce against).
+    """
+    if not allowed_frame_ids:
+        return body
+
+    orphan_line_indices = {
+        row.line_index
+        for row in iter_body_frame_rows(body)
+        if row.node_id not in allowed_frame_ids
+    }
+    if not orphan_line_indices:
+        return body
+
+    lines = body.splitlines(keepends=True)
+    return "".join(line for i, line in enumerate(lines) if i not in orphan_line_indices)
 
 
 def _aggregate_issues(issues: list) -> list[dict]:

--- a/figmaclaw/pull_logic.py
+++ b/figmaclaw/pull_logic.py
@@ -237,6 +237,7 @@ def update_page_frontmatter(
     enriched_at = existing_fm.enriched_at if existing_fm else None
     enriched_frame_hashes = existing_fm.enriched_frame_hashes if existing_fm else None
     enriched_schema_version = existing_fm.enriched_schema_version if existing_fm else 0
+    unresolvable_frames = existing_fm.unresolvable_frames if existing_fm else None
 
     new_fm = build_page_frontmatter(
         page,
@@ -247,6 +248,7 @@ def update_page_frontmatter(
         raw_frames=raw_frames,
         raw_tokens=raw_tokens,
         frame_sections=frame_sections,
+        unresolvable_frames=unresolvable_frames or None,
     )
     _rewrite_frontmatter_preserving_body(
         out_path, md_text, new_fm, allowed_frame_ids=set(page_frame_ids(page))
@@ -291,6 +293,7 @@ def update_component_frontmatter(
     enriched_at = existing_fm.enriched_at if existing_fm else None
     enriched_frame_hashes = existing_fm.enriched_frame_hashes if existing_fm else None
     enriched_schema_version = existing_fm.enriched_schema_version if existing_fm else 0
+    unresolvable_frames = existing_fm.unresolvable_frames if existing_fm else None
 
     new_fm = build_component_frontmatter(
         section,
@@ -300,6 +303,7 @@ def update_component_frontmatter(
         enriched_at=enriched_at,
         enriched_frame_hashes=enriched_frame_hashes or None,
         enriched_schema_version=enriched_schema_version,
+        unresolvable_frames=unresolvable_frames or None,
     )
     _rewrite_frontmatter_preserving_body(
         out_path, md_text, new_fm, allowed_frame_ids=set(section_frame_ids(section))

--- a/figmaclaw/pull_logic.py
+++ b/figmaclaw/pull_logic.py
@@ -363,9 +363,7 @@ def _prune_orphan_frame_rows(body: str, allowed_frame_ids: set[str]) -> str:
         return body
 
     orphan_line_indices = {
-        row.line_index
-        for row in iter_body_frame_rows(body)
-        if row.node_id not in allowed_frame_ids
+        row.line_index for row in iter_body_frame_rows(body) if row.node_id not in allowed_frame_ids
     }
     if not orphan_line_indices:
         return body

--- a/figmaclaw/pull_logic.py
+++ b/figmaclaw/pull_logic.py
@@ -67,8 +67,10 @@ from figmaclaw.figma_paths import (
 from figmaclaw.figma_render import (
     build_component_frontmatter,
     build_page_frontmatter,
+    page_frame_ids,
     render_component_section,
     scaffold_page,
+    section_frame_ids,
 )
 from figmaclaw.figma_sync_state import FigmaSyncState, PageEntry
 from figmaclaw.figma_utils import write_json_if_changed
@@ -246,7 +248,9 @@ def update_page_frontmatter(
         raw_tokens=raw_tokens,
         frame_sections=frame_sections,
     )
-    _rewrite_frontmatter_preserving_body(out_path, md_text, new_fm)
+    _rewrite_frontmatter_preserving_body(
+        out_path, md_text, new_fm, allowed_frame_ids=set(page_frame_ids(page))
+    )
     return out_path
 
 
@@ -297,18 +301,32 @@ def update_component_frontmatter(
         enriched_frame_hashes=enriched_frame_hashes or None,
         enriched_schema_version=enriched_schema_version,
     )
-    _rewrite_frontmatter_preserving_body(out_path, md_text, new_fm)
+    _rewrite_frontmatter_preserving_body(
+        out_path, md_text, new_fm, allowed_frame_ids=set(section_frame_ids(section))
+    )
     return out_path
 
 
-def _rewrite_frontmatter_preserving_body(out_path: Path, md_text: str, new_fm: str) -> None:
+def _rewrite_frontmatter_preserving_body(
+    out_path: Path,
+    md_text: str,
+    new_fm: str,
+    *,
+    allowed_frame_ids: set[str] | None = None,
+) -> None:
     """Rewrite frontmatter and structurally prune orphan frame rows from body.
 
     Frontmatter is replaced wholesale. Body prose is preserved verbatim — we
     do NOT parse or rewrite prose. The only body edit this function performs
-    is surgical removal of canonical frame *rows* whose node_id is no longer
-    in the new frontmatter's ``frames`` list. Table headers, separators,
-    prose, section headings, and Mermaid blocks are untouched.
+    is surgical removal of canonical frame *rows* whose node_id is not in
+    *allowed_frame_ids*. Table headers, separators, prose, section headings,
+    and Mermaid blocks are untouched.
+
+    *allowed_frame_ids* is the authoritative set of frame node_ids for the
+    page — callers get it from :func:`figma_render.page_frame_ids` (screen
+    pages) or :func:`figma_render.section_frame_ids` (component sections).
+    None means "do not prune" (used by code paths that don't own the
+    authoritative frame list, e.g. legacy call sites).
 
     This is a structural operation, not a prose rewrite: a row whose node_id
     points to a frame that no longer exists cannot possibly be correct, so
@@ -320,9 +338,8 @@ def _rewrite_frontmatter_preserving_body(out_path: Path, md_text: str, new_fm: s
     assert parts is not None, f"Failed to parse frontmatter from {out_path}"
     _, body = parts
 
-    new_fm_parsed = parse_frontmatter(f"{new_fm}\n\n# body\n")
-    allowed_frame_ids = set(new_fm_parsed.frames) if new_fm_parsed else set()
-    body = _prune_orphan_frame_rows(body, allowed_frame_ids)
+    if allowed_frame_ids is not None:
+        body = _prune_orphan_frame_rows(body, allowed_frame_ids)
 
     out_path.write_text(f"{new_fm}\n{body}")
 

--- a/figmaclaw/staleness.py
+++ b/figmaclaw/staleness.py
@@ -1,7 +1,10 @@
-"""Shared helpers for stale frame detection across commands."""
+"""Shared helpers for stale frame detection and tombstone matching."""
 
 from __future__ import annotations
 
+from pathlib import Path
+
+from figmaclaw.figma_frontmatter import FigmaPageFrontmatter
 from figmaclaw.figma_sync_state import FigmaSyncState
 
 
@@ -36,3 +39,51 @@ def stale_frame_ids_from_manifest(
     if page_entry is None:
         return None
     return stale_frame_ids(page_entry.frame_hashes, enriched_frame_hashes)
+
+
+def active_tombstoned_node_ids(
+    fm: FigmaPageFrontmatter | None,
+    repo_dir: Path | None,
+) -> set[str]:
+    """Return node_ids with an ACTIVE tombstone (hash matches manifest).
+
+    An unresolvable-frame tombstone is active when the recorded
+    ``frame_hash`` equals the frame's current manifest hash — meaning the
+    Figma content has not changed since the LLM gave up on it. When the
+    content changes (hash moves), the tombstone auto-invalidates and the
+    frame becomes pending again (one retry per content change).
+
+    Returns an empty set when:
+    - *fm* has no unresolvable_frames
+    - *repo_dir* is None (callers without manifest access)
+    - the manifest can't be loaded or doesn't contain the file/page
+
+    Pairing with :func:`stale_frame_ids` is intentional — the two
+    functions are mirror queries against the same
+    enriched_frame_hashes / unresolvable_frames / manifest_hashes
+    triangle. Keep them together so any future contributor touching the
+    logic sees both.
+    """
+    if fm is None or repo_dir is None:
+        return set()
+    if not fm.unresolvable_frames:
+        return set()
+    if not fm.file_key or not fm.page_node_id:
+        return set()
+    try:
+        state = FigmaSyncState(repo_dir)
+        state.load()
+    except Exception:
+        return set()
+    file_entry = state.manifest.files.get(fm.file_key)
+    if file_entry is None:
+        return set()
+    page_entry = file_entry.pages.get(fm.page_node_id)
+    if page_entry is None:
+        return set()
+    current = page_entry.frame_hashes
+    return {
+        nid
+        for nid, tombstone_hash in fm.unresolvable_frames.items()
+        if current.get(nid) == tombstone_hash
+    }

--- a/figmaclaw/verdict.py
+++ b/figmaclaw/verdict.py
@@ -1,7 +1,7 @@
 """Run-conclusion verdict for ``claude-run`` (figmaclaw#27).
 
 This module decides whether a ``claude-run`` invocation should exit GREEN
-or RED based on six observable counters gathered by the dispatcher:
+or RED based on seven observable counters gathered by the dispatcher:
 
     files_selected      — how many files did ``collect_files`` return
     work_attempted      — how many Claude invocations were actually started
@@ -10,13 +10,17 @@ or RED based on six observable counters gathered by the dispatcher:
     budget_exhausted    — did the figmaclaw#26 adaptive self-limit fire
     skipped_no_work     — files the selector picked but the dispatcher
                           found no pending work for (phantom selection)
+    stuck               — files where the same-run NO-PROGRESS guard fired
+                          (figmaclaw#117): the unresolved frame set didn't
+                          change after a successful batch, so dispatch was
+                          stopped to prevent retry loops
 
 The output is a **pure function** of those counters. Same inputs → same
 verdict string → same exit code, byte-for-byte reproducible in tests and CI
 step summaries. Golden tests pin the verdict strings so future refactors
 can't silently change the semantics.
 
-Decision rows (see figmaclaw#27 for full rationale):
+Decision rows (see figmaclaw#27 and figmaclaw#121 for full rationale):
 
     1  selector empty OR all files raced to enriched  → GREEN (no-op)
     2  work attempted, commits landed, no errors      → GREEN (clean)
@@ -28,6 +32,8 @@ Decision rows (see figmaclaw#27 for full rationale):
     7  work attempted, 0 commits, errors > 0          → RED (classic failure)
     8  unhandled exception                            → RED (crash, handled
                                                             by the caller)
+    9  every attempted file hit NO-PROGRESS           → YELLOW (all stuck,
+       (stuck == work_attempted, commits=errors=0)      no progress possible)
 
 Row 1 covers two scenarios: (a) ``collect_files`` returned zero files,
 and (b) every selected file was re-checked and found already-enriched
@@ -38,6 +44,13 @@ Row 5 is evaluated **first** and wins over every other row: a single
 phantom-selected file makes the run RED even if other files succeeded.
 This is deliberate — selector/dispatcher disagreement is always a bug and
 should never be hidden by unrelated success on other files.
+
+Row 9 is evaluated **before** row 6 (silent dispatch failure). A run where
+every attempted file correctly stopped at NO-PROGRESS is a known, logged,
+steady state — not a silent failure. Reporting it as RED for hours would
+hide real regressions (this is exactly what happened in figmaclaw#121).
+The exit code stays 0 so CI doesn't block, but the label is YELLOW so the
+run is visibly distinct from a clean GREEN completion.
 
 See also ``figmaclaw.budget`` (figmaclaw#26), which produces the
 ``budget_exhausted`` flag that distinguishes row 3 from row 2.
@@ -51,7 +64,10 @@ from pathlib import Path
 import pydantic
 
 # Exit codes — two values only. No "soft red" nonsense.
+# YELLOW (row 9) deliberately exits 0: it is a diagnostic label, not a
+# failure mode. The CI must not block on a known steady state.
 EXIT_GREEN = 0
+EXIT_YELLOW = 0
 EXIT_RED = 2
 
 
@@ -81,8 +97,9 @@ def compute_verdict(
     errors: int,
     budget_exhausted: bool,
     skipped_no_work: int,
+    stuck: int = 0,
 ) -> RunVerdict:
-    """Decide the run verdict from the six observable counters.
+    """Decide the run verdict from the seven observable counters.
 
     This function is pure — no I/O, no clock, no environment reads. The
     mapping from counter tuple to verdict is deterministic and the output
@@ -93,9 +110,18 @@ def compute_verdict(
     RED. This is intentional — a single selector/dispatcher disagreement
     is always a bug and must never be hidden behind unrelated success.
 
+    Row 9 (all-stuck YELLOW) is evaluated before row 6 so that a run whose
+    every attempted file correctly stopped at NO-PROGRESS is reported as a
+    known steady state rather than a silent dispatch failure. See
+    figmaclaw#121 for the incident that motivated this.
+
     Row 8 (crash) is not handled here. The caller wraps the dispatch loop
     in a try/except and sets the exit code to :data:`EXIT_RED` directly
     on any unhandled exception.
+
+    *stuck* defaults to 0 so existing callers that have not yet been
+    updated to pass the NO-PROGRESS counter continue to behave exactly as
+    before (no change to rows 1–8 when stuck is 0).
     """
     # Row 5 — ALWAYS wins. Phantom selection is never defeasible.
     if skipped_no_work > 0:
@@ -116,13 +142,19 @@ def compute_verdict(
             row="row 1",
         )
 
-    # Row 6/7 — tried but no commits landed
+    # Row 6/7/9 — tried but no commits landed
     if commits_made == 0:
         if errors > 0:
             return RunVerdict(
                 label="RED (failure — no commits, errors present)",
                 exit_code=EXIT_RED,
                 row="row 7",
+            )
+        if stuck > 0 and stuck == work_attempted:
+            return RunVerdict(
+                label="YELLOW (all attempted files stuck — no progress possible)",
+                exit_code=EXIT_YELLOW,
+                row="row 9",
             )
         return RunVerdict(
             label="RED (silent dispatch failure — no commits, no errors)",
@@ -171,7 +203,9 @@ def format_step_summary(
     errors: int,
     budget_exhausted: bool,
     skipped_no_work: int,
+    stuck: int = 0,
     phantom_files: list[str] | None = None,
+    stuck_files: list[str] | None = None,
     budget_stop_reason: str | None = None,
 ) -> str:
     """Render the GitHub Actions step summary for a completed run.
@@ -182,8 +216,9 @@ def format_step_summary(
 
     The ``phantom_files`` list, when the verdict is row 5, names each
     file the dispatcher identified as phantom-selected. The
-    ``budget_stop_reason`` is the ``[budget]`` line that triggered the
-    row 3 stop, when applicable.
+    ``stuck_files`` list, when the verdict is row 9, names each file where
+    NO-PROGRESS fired. The ``budget_stop_reason`` is the ``[budget]`` line
+    that triggered the row 3 stop, when applicable.
     """
     lines: list[str] = []
     lines.append("## claude-run summary")
@@ -196,6 +231,7 @@ def format_step_summary(
     lines.append(f"| errors | {errors} |")
     lines.append(f"| budget_exhausted | {str(budget_exhausted).lower()} |")
     lines.append(f"| skipped_no_work | {skipped_no_work} |")
+    lines.append(f"| stuck | {stuck} |")
     lines.append("")
     lines.append(f"**Verdict ({verdict.row}): {verdict.label}**")
     lines.append("")
@@ -205,6 +241,15 @@ def format_step_summary(
         for path in phantom_files:
             lines.append(
                 f"- `{path}` — selector picked this file but the dispatcher found no pending work",
+            )
+        lines.append("")
+    if stuck_files:
+        lines.append("### Stuck files (NO-PROGRESS — unresolved set unchanged after batch)")
+        lines.append("")
+        for path in stuck_files:
+            lines.append(
+                f"- `{path}` — same-run NO-PROGRESS guard stopped enrichment "
+                f"to prevent a retry loop"
             )
         lines.append("")
     if budget_stop_reason:

--- a/tests/smoke/test_claude_run_smoke.py
+++ b/tests/smoke/test_claude_run_smoke.py
@@ -174,8 +174,12 @@ def test_section_mode_smoke_stops_after_no_progress_batch(
     pending = [sections, sections]
     monkeypatch.setattr(claude_run_mod, "enrichment_info", lambda _p, **_kw: (True, 120))
     monkeypatch.setattr(claude_run_mod, "pending_sections", lambda _p, **_kw: pending.pop(0))
-    monkeypatch.setattr(claude_run_mod, "pending_frame_node_ids", lambda _p, **_kw: {"11:1", "11:2"})
-    monkeypatch.setattr(claude_run_mod, "_is_schema_upgrade_only_candidate", lambda _p, **_kw: False)
+    monkeypatch.setattr(
+        claude_run_mod, "pending_frame_node_ids", lambda _p, **_kw: {"11:1", "11:2"}
+    )
+    monkeypatch.setattr(
+        claude_run_mod, "_is_schema_upgrade_only_candidate", lambda _p, **_kw: False
+    )
     monkeypatch.setattr(claude_run_mod, "_classify_no_work_candidate", lambda _p, **_kw: "phantom")
     monkeypatch.setattr(
         claude_run_mod.subprocess,
@@ -219,7 +223,9 @@ def test_section_mode_smoke_phantom_selection_is_fail_fast(
     monkeypatch.setattr(claude_run_mod, "enrichment_info", lambda _p, **_kw: (True, 120))
     monkeypatch.setattr(claude_run_mod, "pending_sections", lambda _p, **_kw: [])
     monkeypatch.setattr(claude_run_mod, "needs_finalization", lambda _p, **_kw: False)
-    monkeypatch.setattr(claude_run_mod, "_is_schema_upgrade_only_candidate", lambda _p, **_kw: False)
+    monkeypatch.setattr(
+        claude_run_mod, "_is_schema_upgrade_only_candidate", lambda _p, **_kw: False
+    )
     monkeypatch.setattr(claude_run_mod, "_classify_no_work_candidate", lambda _p, **_kw: "phantom")
     monkeypatch.setattr(
         claude_run_mod.subprocess,
@@ -273,7 +279,9 @@ enriched_schema_version: 1
     monkeypatch.setattr(claude_run_mod, "enrichment_info", lambda _p, **_kw: (True, 120))
     monkeypatch.setattr(claude_run_mod, "pending_sections", lambda _p, **_kw: [])
     monkeypatch.setattr(claude_run_mod, "needs_finalization", lambda _p, **_kw: False)
-    monkeypatch.setattr(claude_run_mod, "_is_schema_upgrade_only_candidate", lambda _p, **_kw: False)
+    monkeypatch.setattr(
+        claude_run_mod, "_is_schema_upgrade_only_candidate", lambda _p, **_kw: False
+    )
     monkeypatch.setattr(claude_run_mod, "_is_llm_marker_only_candidate", lambda _p, **_kw: True)
     monkeypatch.setattr(
         claude_run_mod.subprocess,

--- a/tests/smoke/test_claude_run_smoke.py
+++ b/tests/smoke/test_claude_run_smoke.py
@@ -172,11 +172,11 @@ def test_section_mode_smoke_stops_after_no_progress_batch(
 
     sections = [{"node_id": "10:1", "name": "Auth", "pending_frames": 2}]
     pending = [sections, sections]
-    monkeypatch.setattr(claude_run_mod, "enrichment_info", lambda _p: (True, 120))
-    monkeypatch.setattr(claude_run_mod, "pending_sections", lambda _p: pending.pop(0))
-    monkeypatch.setattr(claude_run_mod, "pending_frame_node_ids", lambda _p: {"11:1", "11:2"})
-    monkeypatch.setattr(claude_run_mod, "_is_schema_upgrade_only_candidate", lambda _p: False)
-    monkeypatch.setattr(claude_run_mod, "_classify_no_work_candidate", lambda _p: "phantom")
+    monkeypatch.setattr(claude_run_mod, "enrichment_info", lambda _p, **_kw: (True, 120))
+    monkeypatch.setattr(claude_run_mod, "pending_sections", lambda _p, **_kw: pending.pop(0))
+    monkeypatch.setattr(claude_run_mod, "pending_frame_node_ids", lambda _p, **_kw: {"11:1", "11:2"})
+    monkeypatch.setattr(claude_run_mod, "_is_schema_upgrade_only_candidate", lambda _p, **_kw: False)
+    monkeypatch.setattr(claude_run_mod, "_classify_no_work_candidate", lambda _p, **_kw: "phantom")
     monkeypatch.setattr(
         claude_run_mod.subprocess,
         "run",
@@ -216,11 +216,11 @@ def test_section_mode_smoke_phantom_selection_is_fail_fast(
     _write_page(page_b, enriched=False, placeholder=True)
 
     monkeypatch.setattr(claude_run_mod, "collect_files", lambda *args, **kwargs: [page_a, page_b])
-    monkeypatch.setattr(claude_run_mod, "enrichment_info", lambda _p: (True, 120))
-    monkeypatch.setattr(claude_run_mod, "pending_sections", lambda _p: [])
-    monkeypatch.setattr(claude_run_mod, "needs_finalization", lambda _p: False)
-    monkeypatch.setattr(claude_run_mod, "_is_schema_upgrade_only_candidate", lambda _p: False)
-    monkeypatch.setattr(claude_run_mod, "_classify_no_work_candidate", lambda _p: "phantom")
+    monkeypatch.setattr(claude_run_mod, "enrichment_info", lambda _p, **_kw: (True, 120))
+    monkeypatch.setattr(claude_run_mod, "pending_sections", lambda _p, **_kw: [])
+    monkeypatch.setattr(claude_run_mod, "needs_finalization", lambda _p, **_kw: False)
+    monkeypatch.setattr(claude_run_mod, "_is_schema_upgrade_only_candidate", lambda _p, **_kw: False)
+    monkeypatch.setattr(claude_run_mod, "_classify_no_work_candidate", lambda _p, **_kw: "phantom")
     monkeypatch.setattr(
         claude_run_mod.subprocess,
         "run",
@@ -270,11 +270,11 @@ enriched_schema_version: 1
 """
     )
 
-    monkeypatch.setattr(claude_run_mod, "enrichment_info", lambda _p: (True, 120))
-    monkeypatch.setattr(claude_run_mod, "pending_sections", lambda _p: [])
-    monkeypatch.setattr(claude_run_mod, "needs_finalization", lambda _p: False)
-    monkeypatch.setattr(claude_run_mod, "_is_schema_upgrade_only_candidate", lambda _p: False)
-    monkeypatch.setattr(claude_run_mod, "_is_llm_marker_only_candidate", lambda _p: True)
+    monkeypatch.setattr(claude_run_mod, "enrichment_info", lambda _p, **_kw: (True, 120))
+    monkeypatch.setattr(claude_run_mod, "pending_sections", lambda _p, **_kw: [])
+    monkeypatch.setattr(claude_run_mod, "needs_finalization", lambda _p, **_kw: False)
+    monkeypatch.setattr(claude_run_mod, "_is_schema_upgrade_only_candidate", lambda _p, **_kw: False)
+    monkeypatch.setattr(claude_run_mod, "_is_llm_marker_only_candidate", lambda _p, **_kw: True)
     monkeypatch.setattr(
         claude_run_mod.subprocess,
         "run",

--- a/tests/test_body_validation.py
+++ b/tests/test_body_validation.py
@@ -9,7 +9,12 @@ INVARIANTS:
 
 from __future__ import annotations
 
-from figmaclaw.body_validation import validate_body_against_frames
+from figmaclaw.body_validation import (
+    BodyFrameRow,
+    body_frame_node_ids,
+    iter_body_frame_rows,
+    validate_body_against_frames,
+)
 
 
 def test_validate_body_against_frames_ok() -> None:
@@ -106,3 +111,67 @@ def test_validate_body_rejects_duplicate_frontmatter_frame_ids() -> None:
     result = validate_body_against_frames(body, ["11:1", "11:1"])
     assert not result.ok
     assert result.duplicate_frontmatter_node_ids == ["11:1"]
+
+
+def test_iter_body_frame_rows_yields_line_index_and_node_id() -> None:
+    """Canonical walker yields BodyFrameRow pydantic models with line_index + node_id.
+
+    Anchors the single-source-of-truth contract: any caller that needs row
+    positions in a canonical body table must use this iterator rather than
+    re-walking the lines.
+    """
+    body = """\
+## Auth (`10:1`)
+
+| Screen | Node ID | Description |
+|--------|---------|-------------|
+| Login | `11:1` | desc |
+| Signup | `11:2` | desc |
+"""
+    rows = list(iter_body_frame_rows(body))
+    assert all(isinstance(row, BodyFrameRow) for row in rows)
+    assert [(row.line_index, row.node_id) for row in rows] == [(4, "11:1"), (5, "11:2")]
+
+
+def test_body_frame_node_ids_agrees_with_iter_body_frame_rows() -> None:
+    """The public node-id collector is a pure projection of the iterator.
+
+    Locks the DRY contract: body_frame_node_ids must be a one-liner over
+    iter_body_frame_rows, never a second independent walker.
+    """
+    body = """\
+## Auth (`10:1`)
+
+| Screen | Node ID | Description |
+|--------|---------|-------------|
+| Login | `11:1` | desc |
+
+## Settings (`10:2`)
+
+| Screen | Node ID | Description |
+|--------|---------|-------------|
+| Profile | `12:1` | desc |
+"""
+    assert body_frame_node_ids(body) == [row.node_id for row in iter_body_frame_rows(body)]
+
+
+def test_iter_body_frame_rows_skips_fenced_code_blocks() -> None:
+    """Lines that look like rows but live inside a code fence are not yielded.
+
+    Preserves the strictness that ``body_frame_node_ids`` already had — the
+    canonical walker must not leak mutation candidates from inside fences.
+    """
+    body = """\
+## Auth (`10:1`)
+
+```
+| Fake | `DEAD:1` | in a fence |
+```
+
+| Screen | Node ID | Description |
+|--------|---------|-------------|
+| Login | `11:1` | desc |
+"""
+    node_ids = [row.node_id for row in iter_body_frame_rows(body)]
+    assert node_ids == ["11:1"]
+    assert "DEAD:1" not in node_ids

--- a/tests/test_claude_run.py
+++ b/tests/test_claude_run.py
@@ -1526,8 +1526,16 @@ def test_log_migrates_real_world_linear_git_legacy_fixture(tmp_path: Path) -> No
     assert rows[-1]["event_id"] != ""
 
 
-def test_log_unknown_header_is_observable_and_skips_append(tmp_path: Path) -> None:
-    """Unsupported header must not crash and must emit an error marker."""
+def test_log_unknown_header_self_heals_by_archiving_and_starting_fresh(
+    tmp_path: Path,
+) -> None:
+    """Unsupported header must not become a silent-drop terminal state.
+
+    Contract (figmaclaw#121 anti-loop policy #5): if schema migration is
+    possible, auto-heal; if not, archive the prior file with a timestamp
+    and start a fresh schema-v1 log. Never leave the writer in a "warn
+    and skip forever" loop where every run loses its data.
+    """
     log_path = tmp_path / claude_run_mod.ENRICHMENT_LOG
     log_path.parent.mkdir(parents=True, exist_ok=True)
     log_path.write_text("foo,bar,baz\n1,2,3\n", encoding="utf-8")
@@ -1538,9 +1546,58 @@ def test_log_unknown_header_is_observable_and_skips_append(tmp_path: Path) -> No
 
     claude_run_mod._log_enrichment(tmp_path, md, "batch", 1, 1.0, True, run_id="run-x")
 
+    # 1. A loud error line is emitted so humans can notice the archive event
     err = tmp_path / claude_run_mod.ENRICHMENT_LOG_ERROR
     assert err.exists()
-    assert "unsupported enrichment log schema/header" in err.read_text(encoding="utf-8")
+    err_text = err.read_text(encoding="utf-8")
+    assert "unrecognized enrichment log schema" in err_text
+    assert "archived prior log" in err_text
+
+    # 2. The prior log was archived with a .bak. prefix (not deleted)
+    log_dir = log_path.parent
+    backups = list(log_dir.glob(f"{log_path.stem}.bak.*{log_path.suffix}"))
+    assert len(backups) == 1
+    assert backups[0].read_text(encoding="utf-8") == "foo,bar,baz\n1,2,3\n"
+
+    # 3. A fresh schema-v1 log replaced it, and the caller's row landed
+    with log_path.open(newline="", encoding="utf-8") as f:
+        reader = csv.DictReader(f)
+        rows = list(reader)
+    assert tuple(reader.fieldnames or ()) == claude_run_mod.ENRICHMENT_LOG_FIELDS
+    assert len(rows) == 1
+    assert rows[0]["mode"] == "batch"
+    assert rows[0]["frames"] == "1"
+
+
+def test_log_unknown_header_second_run_does_not_warn_again(tmp_path: Path) -> None:
+    """After self-healing on run N, run N+1 must NOT re-emit the error.
+
+    This is the cross-run idempotency shape from CLAUDE.md policy #1:
+    a fix-once event should not be a fix-every-run event. If the warn
+    recurred forever we'd still be silently losing signal.
+    """
+    log_path = tmp_path / claude_run_mod.ENRICHMENT_LOG
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    log_path.write_text("foo,bar,baz\n1,2,3\n", encoding="utf-8")
+
+    md = tmp_path / "figma" / "pages" / "a.md"
+    md.parent.mkdir(parents=True, exist_ok=True)
+    md.write_text("---\nfile_key: a\n---\n")
+
+    # Run 1 — archives + appends
+    claude_run_mod._log_enrichment(tmp_path, md, "batch", 1, 1.0, True, run_id="run-1")
+    err = tmp_path / claude_run_mod.ENRICHMENT_LOG_ERROR
+    err_len_after_run1 = len(err.read_text(encoding="utf-8"))
+
+    # Run 2 — clean log, should append without any new error line
+    claude_run_mod._log_enrichment(tmp_path, md, "batch", 2, 2.0, True, run_id="run-2")
+
+    assert len(err.read_text(encoding="utf-8")) == err_len_after_run1
+
+    with log_path.open(newline="", encoding="utf-8") as f:
+        reader = csv.DictReader(f)
+        rows = list(reader)
+    assert len(rows) == 2
 
 
 def test_log_malformed_legacy_csv_is_observable_and_does_not_crash(tmp_path: Path) -> None:

--- a/tests/test_claude_run.py
+++ b/tests/test_claude_run.py
@@ -790,12 +790,12 @@ class TestClaudeRunExecutionBranches:
         md = tmp_path / "page.md"
         self._write_placeholder_page(md)
 
-        monkeypatch.setattr(claude_run_mod, "enrichment_info", lambda _p: (True, 120))
-        monkeypatch.setattr(claude_run_mod, "pending_sections", lambda _p: [])
-        monkeypatch.setattr(claude_run_mod, "needs_finalization", lambda _p: False)
-        monkeypatch.setattr(claude_run_mod, "_is_schema_upgrade_only_candidate", lambda _p: False)
-        monkeypatch.setattr(claude_run_mod, "_is_llm_marker_only_candidate", lambda _p: False)
-        monkeypatch.setattr(claude_run_mod, "_classify_no_work_candidate", lambda _p: "phantom")
+        monkeypatch.setattr(claude_run_mod, "enrichment_info", lambda _p, **_kw: (True, 120))
+        monkeypatch.setattr(claude_run_mod, "pending_sections", lambda _p, **_kw: [])
+        monkeypatch.setattr(claude_run_mod, "needs_finalization", lambda _p, **_kw: False)
+        monkeypatch.setattr(claude_run_mod, "_is_schema_upgrade_only_candidate", lambda _p, **_kw: False)
+        monkeypatch.setattr(claude_run_mod, "_is_llm_marker_only_candidate", lambda _p, **_kw: False)
+        monkeypatch.setattr(claude_run_mod, "_classify_no_work_candidate", lambda _p, **_kw: "phantom")
         monkeypatch.setattr(
             claude_run_mod.subprocess,
             "run",
@@ -842,11 +842,11 @@ class TestClaudeRunExecutionBranches:
             )
         )
 
-        monkeypatch.setattr(claude_run_mod, "enrichment_info", lambda _p: (True, 120))
-        monkeypatch.setattr(claude_run_mod, "pending_sections", lambda _p: [])
-        monkeypatch.setattr(claude_run_mod, "needs_finalization", lambda _p: False)
-        monkeypatch.setattr(claude_run_mod, "_is_schema_upgrade_only_candidate", lambda _p: False)
-        monkeypatch.setattr(claude_run_mod, "_is_llm_marker_only_candidate", lambda _p: True)
+        monkeypatch.setattr(claude_run_mod, "enrichment_info", lambda _p, **_kw: (True, 120))
+        monkeypatch.setattr(claude_run_mod, "pending_sections", lambda _p, **_kw: [])
+        monkeypatch.setattr(claude_run_mod, "needs_finalization", lambda _p, **_kw: False)
+        monkeypatch.setattr(claude_run_mod, "_is_schema_upgrade_only_candidate", lambda _p, **_kw: False)
+        monkeypatch.setattr(claude_run_mod, "_is_llm_marker_only_candidate", lambda _p, **_kw: True)
         monkeypatch.setattr(
             claude_run_mod.subprocess,
             "run",
@@ -892,9 +892,9 @@ class TestClaudeRunExecutionBranches:
             )
         )
 
-        monkeypatch.setattr(claude_run_mod, "enrichment_info", lambda _p: (True, 120))
-        monkeypatch.setattr(claude_run_mod, "pending_sections", lambda _p: [])
-        monkeypatch.setattr(claude_run_mod, "needs_finalization", lambda _p: False)
+        monkeypatch.setattr(claude_run_mod, "enrichment_info", lambda _p, **_kw: (True, 120))
+        monkeypatch.setattr(claude_run_mod, "pending_sections", lambda _p, **_kw: [])
+        monkeypatch.setattr(claude_run_mod, "needs_finalization", lambda _p, **_kw: False)
         monkeypatch.setattr(
             claude_run_mod.subprocess,
             "run",
@@ -941,11 +941,11 @@ class TestClaudeRunExecutionBranches:
             )
         )
 
-        monkeypatch.setattr(claude_run_mod, "enrichment_info", lambda _p: (True, 120))
-        monkeypatch.setattr(claude_run_mod, "pending_sections", lambda _p: [])
-        monkeypatch.setattr(claude_run_mod, "needs_finalization", lambda _p: False)
-        monkeypatch.setattr(claude_run_mod, "_is_schema_upgrade_only_candidate", lambda _p: True)
-        monkeypatch.setattr(claude_run_mod, "_is_llm_marker_only_candidate", lambda _p: False)
+        monkeypatch.setattr(claude_run_mod, "enrichment_info", lambda _p, **_kw: (True, 120))
+        monkeypatch.setattr(claude_run_mod, "pending_sections", lambda _p, **_kw: [])
+        monkeypatch.setattr(claude_run_mod, "needs_finalization", lambda _p, **_kw: False)
+        monkeypatch.setattr(claude_run_mod, "_is_schema_upgrade_only_candidate", lambda _p, **_kw: True)
+        monkeypatch.setattr(claude_run_mod, "_is_llm_marker_only_candidate", lambda _p, **_kw: False)
         monkeypatch.setattr(
             claude_run_mod.subprocess,
             "run",
@@ -980,10 +980,10 @@ class TestClaudeRunExecutionBranches:
         sections = [{"node_id": "10:1", "name": "Auth", "pending_frames": 2}]
         pending = [sections, sections]
 
-        monkeypatch.setattr(claude_run_mod, "enrichment_info", lambda _p: (True, 120))
-        monkeypatch.setattr(claude_run_mod, "pending_sections", lambda _p: pending.pop(0))
-        monkeypatch.setattr(claude_run_mod, "pending_frame_node_ids", lambda _p: {"11:1", "11:2"})
-        monkeypatch.setattr(claude_run_mod, "needs_finalization", lambda _p: False)
+        monkeypatch.setattr(claude_run_mod, "enrichment_info", lambda _p, **_kw: (True, 120))
+        monkeypatch.setattr(claude_run_mod, "pending_sections", lambda _p, **_kw: pending.pop(0))
+        monkeypatch.setattr(claude_run_mod, "pending_frame_node_ids", lambda _p, **_kw: {"11:1", "11:2"})
+        monkeypatch.setattr(claude_run_mod, "needs_finalization", lambda _p, **_kw: False)
         monkeypatch.setattr(
             claude_run_mod,
             "decide_next_batch",
@@ -1032,12 +1032,12 @@ class TestClaudeRunExecutionBranches:
         monkeypatch.setattr(
             claude_run_mod, "collect_files", lambda *args, **kwargs: [page_a, page_b]
         )
-        monkeypatch.setattr(claude_run_mod, "enrichment_info", lambda _p: (True, 120))
-        monkeypatch.setattr(claude_run_mod, "pending_sections", lambda _p: [])
-        monkeypatch.setattr(claude_run_mod, "needs_finalization", lambda _p: False)
-        monkeypatch.setattr(claude_run_mod, "_is_schema_upgrade_only_candidate", lambda _p: False)
-        monkeypatch.setattr(claude_run_mod, "_is_llm_marker_only_candidate", lambda _p: False)
-        monkeypatch.setattr(claude_run_mod, "_classify_no_work_candidate", lambda _p: "phantom")
+        monkeypatch.setattr(claude_run_mod, "enrichment_info", lambda _p, **_kw: (True, 120))
+        monkeypatch.setattr(claude_run_mod, "pending_sections", lambda _p, **_kw: [])
+        monkeypatch.setattr(claude_run_mod, "needs_finalization", lambda _p, **_kw: False)
+        monkeypatch.setattr(claude_run_mod, "_is_schema_upgrade_only_candidate", lambda _p, **_kw: False)
+        monkeypatch.setattr(claude_run_mod, "_is_llm_marker_only_candidate", lambda _p, **_kw: False)
+        monkeypatch.setattr(claude_run_mod, "_classify_no_work_candidate", lambda _p, **_kw: "phantom")
         monkeypatch.setattr(
             claude_run_mod.subprocess,
             "run",
@@ -1067,7 +1067,7 @@ class TestClaudeRunExecutionBranches:
         md = tmp_path / "page.md"
         self._write_placeholder_page(md)
 
-        monkeypatch.setattr(claude_run_mod, "enrichment_info", lambda _p: (True, 1))
+        monkeypatch.setattr(claude_run_mod, "enrichment_info", lambda _p, **_kw: (True, 1))
         monkeypatch.setattr(
             claude_run_mod,
             "decide_next_batch",

--- a/tests/test_claude_run.py
+++ b/tests/test_claude_run.py
@@ -793,9 +793,15 @@ class TestClaudeRunExecutionBranches:
         monkeypatch.setattr(claude_run_mod, "enrichment_info", lambda _p, **_kw: (True, 120))
         monkeypatch.setattr(claude_run_mod, "pending_sections", lambda _p, **_kw: [])
         monkeypatch.setattr(claude_run_mod, "needs_finalization", lambda _p, **_kw: False)
-        monkeypatch.setattr(claude_run_mod, "_is_schema_upgrade_only_candidate", lambda _p, **_kw: False)
-        monkeypatch.setattr(claude_run_mod, "_is_llm_marker_only_candidate", lambda _p, **_kw: False)
-        monkeypatch.setattr(claude_run_mod, "_classify_no_work_candidate", lambda _p, **_kw: "phantom")
+        monkeypatch.setattr(
+            claude_run_mod, "_is_schema_upgrade_only_candidate", lambda _p, **_kw: False
+        )
+        monkeypatch.setattr(
+            claude_run_mod, "_is_llm_marker_only_candidate", lambda _p, **_kw: False
+        )
+        monkeypatch.setattr(
+            claude_run_mod, "_classify_no_work_candidate", lambda _p, **_kw: "phantom"
+        )
         monkeypatch.setattr(
             claude_run_mod.subprocess,
             "run",
@@ -845,7 +851,9 @@ class TestClaudeRunExecutionBranches:
         monkeypatch.setattr(claude_run_mod, "enrichment_info", lambda _p, **_kw: (True, 120))
         monkeypatch.setattr(claude_run_mod, "pending_sections", lambda _p, **_kw: [])
         monkeypatch.setattr(claude_run_mod, "needs_finalization", lambda _p, **_kw: False)
-        monkeypatch.setattr(claude_run_mod, "_is_schema_upgrade_only_candidate", lambda _p, **_kw: False)
+        monkeypatch.setattr(
+            claude_run_mod, "_is_schema_upgrade_only_candidate", lambda _p, **_kw: False
+        )
         monkeypatch.setattr(claude_run_mod, "_is_llm_marker_only_candidate", lambda _p, **_kw: True)
         monkeypatch.setattr(
             claude_run_mod.subprocess,
@@ -944,8 +952,12 @@ class TestClaudeRunExecutionBranches:
         monkeypatch.setattr(claude_run_mod, "enrichment_info", lambda _p, **_kw: (True, 120))
         monkeypatch.setattr(claude_run_mod, "pending_sections", lambda _p, **_kw: [])
         monkeypatch.setattr(claude_run_mod, "needs_finalization", lambda _p, **_kw: False)
-        monkeypatch.setattr(claude_run_mod, "_is_schema_upgrade_only_candidate", lambda _p, **_kw: True)
-        monkeypatch.setattr(claude_run_mod, "_is_llm_marker_only_candidate", lambda _p, **_kw: False)
+        monkeypatch.setattr(
+            claude_run_mod, "_is_schema_upgrade_only_candidate", lambda _p, **_kw: True
+        )
+        monkeypatch.setattr(
+            claude_run_mod, "_is_llm_marker_only_candidate", lambda _p, **_kw: False
+        )
         monkeypatch.setattr(
             claude_run_mod.subprocess,
             "run",
@@ -982,7 +994,9 @@ class TestClaudeRunExecutionBranches:
 
         monkeypatch.setattr(claude_run_mod, "enrichment_info", lambda _p, **_kw: (True, 120))
         monkeypatch.setattr(claude_run_mod, "pending_sections", lambda _p, **_kw: pending.pop(0))
-        monkeypatch.setattr(claude_run_mod, "pending_frame_node_ids", lambda _p, **_kw: {"11:1", "11:2"})
+        monkeypatch.setattr(
+            claude_run_mod, "pending_frame_node_ids", lambda _p, **_kw: {"11:1", "11:2"}
+        )
         monkeypatch.setattr(claude_run_mod, "needs_finalization", lambda _p, **_kw: False)
         monkeypatch.setattr(
             claude_run_mod,
@@ -1035,9 +1049,15 @@ class TestClaudeRunExecutionBranches:
         monkeypatch.setattr(claude_run_mod, "enrichment_info", lambda _p, **_kw: (True, 120))
         monkeypatch.setattr(claude_run_mod, "pending_sections", lambda _p, **_kw: [])
         monkeypatch.setattr(claude_run_mod, "needs_finalization", lambda _p, **_kw: False)
-        monkeypatch.setattr(claude_run_mod, "_is_schema_upgrade_only_candidate", lambda _p, **_kw: False)
-        monkeypatch.setattr(claude_run_mod, "_is_llm_marker_only_candidate", lambda _p, **_kw: False)
-        monkeypatch.setattr(claude_run_mod, "_classify_no_work_candidate", lambda _p, **_kw: "phantom")
+        monkeypatch.setattr(
+            claude_run_mod, "_is_schema_upgrade_only_candidate", lambda _p, **_kw: False
+        )
+        monkeypatch.setattr(
+            claude_run_mod, "_is_llm_marker_only_candidate", lambda _p, **_kw: False
+        )
+        monkeypatch.setattr(
+            claude_run_mod, "_classify_no_work_candidate", lambda _p, **_kw: "phantom"
+        )
         monkeypatch.setattr(
             claude_run_mod.subprocess,
             "run",

--- a/tests/test_cross_run_idempotency.py
+++ b/tests/test_cross_run_idempotency.py
@@ -1,0 +1,202 @@
+"""Cross-run idempotency — figmaclaw#121 incident replay.
+
+Pins the category of tests that was missing from the PR suite: given a
+repo state S, running the enrichment selector/dispatcher twice produces
+either a no-op second run or a strictly cheaper second run. A failing
+test in this file would mean we've regressed to the "run N and run N+1
+do identical expensive work forever" bug shape that burned 24+ hours of
+CI on gigaverse-app/linear-git.
+
+Tests here exercise the full fix stack end-to-end:
+- key-set invariant (orphan enriched_frame_hashes pruned by chokepoint)
+- body orphan prune (rows for frames not in ``frames`` dropped by pull)
+- tombstone protocol (NO-PROGRESS frames skipped until content changes)
+- YELLOW row 9 (all-stuck reports as exit 0)
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from figmaclaw.commands.claude_run import (
+    _record_tombstones,
+    enrichment_info,
+    pending_frame_node_ids,
+)
+from figmaclaw.figma_parse import parse_frontmatter
+from figmaclaw.figma_sync_state import FigmaSyncState, FileEntry, PageEntry
+from figmaclaw.verdict import compute_verdict, EXIT_GREEN
+
+
+def _write_manifest(repo_dir: Path, *, frame_hashes: dict[str, str]) -> None:
+    state = FigmaSyncState(repo_dir)
+    state.load()
+    page_entry = PageEntry(
+        page_name="Page",
+        page_slug="page",
+        md_path="figma/fk/pages/page.md",
+        page_hash="page-hash",
+        frame_hashes=frame_hashes,
+        last_refreshed_at="2026-04-18T00:00:00Z",
+    )
+    file_entry = FileEntry(
+        file_name="Test",
+        version="v1",
+        last_modified="2026-04-18T00:00:00Z",
+        last_refreshed_at="2026-04-18T00:00:00Z",
+        pages={"1:1": page_entry},
+    )
+    state.manifest.files["fk"] = file_entry
+    state.save()
+
+
+def _write_stuck_fixture(
+    md_path: Path,
+    *,
+    frames: list[str],
+    unresolvable_frames: dict[str, str] | None = None,
+) -> None:
+    """Write the shape of a figmaclaw#121 stuck file.
+
+    Body has one unresolved row per frame with the canonical
+    (no screenshot available) marker — the LLM has already answered and
+    cannot make progress.
+    """
+    lines = [
+        "---",
+        "file_key: fk",
+        "page_node_id: '1:1'",
+        f"frames: {frames!r}",
+        "enriched_hash: deadbeef",
+        "enriched_schema_version: 1",
+    ]
+    if unresolvable_frames:
+        lines.append(f"unresolvable_frames: {unresolvable_frames!r}")
+    lines.append("---")
+    lines.append("")
+    lines.append("# Page")
+    lines.append("")
+    lines.append("## Section (`10:1`)")
+    lines.append("")
+    lines.append("| Screen | Node ID | Description |")
+    lines.append("|--------|---------|-------------|")
+    for nid in frames:
+        lines.append(f"| Stuck row | `{nid}` | (no screenshot available) |")
+    md_path.write_text("\n".join(lines) + "\n")
+
+
+class TestIncidentReplay:
+    """Replay of the linear-git 24-hour loop on a synthetic fixture.
+
+    Run 1 mirrors the observed incident:
+    - selector picks the file (body has unresolved marker)
+    - dispatcher would invoke LLM, LLM writes same marker again
+    - NO-PROGRESS guard fires, tombstones get recorded
+
+    Run 2 is the contract this test pins:
+    - selector does NOT pick the file (tombstone + matching hash)
+    - if the selector somehow still picks it, the dispatcher agrees
+    - verdict for a fully-stuck run is YELLOW exit 0, not RED
+    """
+
+    def test_run2_selector_skips_fully_tombstoned_file(self, tmp_path: Path) -> None:
+        _write_manifest(tmp_path, frame_hashes={"11:1": "h1", "11:2": "h2"})
+        md = tmp_path / "page.md"
+        _write_stuck_fixture(md, frames=["11:1", "11:2"])
+
+        # Run 1: file needs enrichment.
+        needs_run1, _ = enrichment_info(md, repo_dir=tmp_path)
+        assert needs_run1 is True
+        pending_run1 = pending_frame_node_ids(md, repo_dir=tmp_path)
+        assert pending_run1 == {"11:1", "11:2"}
+
+        # Simulate NO-PROGRESS firing and the dispatcher writing tombstones.
+        added = _record_tombstones(md, tmp_path, pending_run1)
+        assert added == 2
+
+        # Run 2: fully tombstoned, matching hashes → selector skips.
+        needs_run2, _ = enrichment_info(md, repo_dir=tmp_path)
+        assert needs_run2 is False
+        pending_run2 = pending_frame_node_ids(md, repo_dir=tmp_path)
+        assert pending_run2 == set()
+
+    def test_run2_retries_after_figma_content_change(self, tmp_path: Path) -> None:
+        """One retry per content change — tombstone auto-invalidates when
+        the manifest hash diverges from the recorded tombstone.
+        """
+        _write_manifest(tmp_path, frame_hashes={"11:1": "h1"})
+        md = tmp_path / "page.md"
+        _write_stuck_fixture(md, frames=["11:1"])
+        _record_tombstones(md, tmp_path, {"11:1"})
+
+        # Between runs: Figma content changed → pull rewrote manifest hash.
+        _write_manifest(tmp_path, frame_hashes={"11:1": "h1-NEW"})
+
+        # Tombstone no longer active — frame pending again for one retry.
+        pending = pending_frame_node_ids(md, repo_dir=tmp_path)
+        assert pending == {"11:1"}
+        needs_it, _ = enrichment_info(md, repo_dir=tmp_path)
+        assert needs_it is True
+
+    def test_fully_stuck_run_is_yellow_not_red(self) -> None:
+        """Verdict for a run where every attempted file stopped at
+        NO-PROGRESS is YELLOW exit 0 — the shape of every nightly run in
+        the linear-git incident after tombstones land but before Figma
+        content changes.
+        """
+        v = compute_verdict(
+            files_selected=68,
+            work_attempted=6,
+            commits_made=0,
+            errors=0,
+            budget_exhausted=False,
+            skipped_no_work=0,
+            stuck=6,
+        )
+        assert v.exit_code == EXIT_GREEN
+        assert v.row == "row 9"
+        assert "YELLOW" in v.label
+
+
+class TestPartialProgressStillWorks:
+    """Counterpart: runs that CAN make progress must still make it.
+
+    Pins the "tombstone protocol does not over-filter" contract.
+    """
+
+    def test_partially_tombstoned_file_still_enrichable(self, tmp_path: Path) -> None:
+        """File has 2 frames, 1 tombstoned (matching hash) + 1 truly pending.
+        Selector still picks it, dispatcher still sees the pending one.
+        """
+        _write_manifest(tmp_path, frame_hashes={"11:1": "h1", "11:2": "h2"})
+        md = tmp_path / "page.md"
+        _write_stuck_fixture(
+            md,
+            frames=["11:1", "11:2"],
+            unresolvable_frames={"11:1": "h1"},  # 11:1 tombstoned, 11:2 not
+        )
+
+        needs_it, _ = enrichment_info(md, repo_dir=tmp_path)
+        assert needs_it is True
+
+        pending = pending_frame_node_ids(md, repo_dir=tmp_path)
+        assert pending == {"11:2"}
+
+    def test_repo_dir_absent_path_still_sees_all_pending(self, tmp_path: Path) -> None:
+        """Legacy callers without repo_dir get pre-figmaclaw#121 behavior.
+
+        Guarantees we didn't break any tool or test that invokes these
+        functions without manifest access.
+        """
+        md = tmp_path / "page.md"
+        _write_stuck_fixture(
+            md,
+            frames=["11:1"],
+            unresolvable_frames={"11:1": "h1"},
+        )
+
+        pending = pending_frame_node_ids(md)  # no repo_dir
+        assert pending == {"11:1"}
+
+        needs_it, _ = enrichment_info(md)
+        assert needs_it is True

--- a/tests/test_cross_run_idempotency.py
+++ b/tests/test_cross_run_idempotency.py
@@ -99,7 +99,7 @@ class TestIncidentReplay:
     """
 
     def test_run2_selector_skips_fully_tombstoned_file(self, tmp_path: Path) -> None:
-        _write_manifest(tmp_path, frame_hashes={"11:1": "h1", "11:2": "h2"})
+        _write_manifest(tmp_path, frame_hashes={"11:1": "a1a1a1a1", "11:2": "b2b2b2b2"})
         md = tmp_path / "page.md"
         _write_stuck_fixture(md, frames=["11:1", "11:2"])
 
@@ -123,13 +123,13 @@ class TestIncidentReplay:
         """One retry per content change — tombstone auto-invalidates when
         the manifest hash diverges from the recorded tombstone.
         """
-        _write_manifest(tmp_path, frame_hashes={"11:1": "h1"})
+        _write_manifest(tmp_path, frame_hashes={"11:1": "a1a1a1a1"})
         md = tmp_path / "page.md"
         _write_stuck_fixture(md, frames=["11:1"])
         _record_tombstones(md, tmp_path, {"11:1"})
 
         # Between runs: Figma content changed → pull rewrote manifest hash.
-        _write_manifest(tmp_path, frame_hashes={"11:1": "h1-NEW"})
+        _write_manifest(tmp_path, frame_hashes={"11:1": "a1a1a1a1feedface"})
 
         # Tombstone no longer active — frame pending again for one retry.
         pending = pending_frame_node_ids(md, repo_dir=tmp_path)
@@ -167,12 +167,12 @@ class TestPartialProgressStillWorks:
         """File has 2 frames, 1 tombstoned (matching hash) + 1 truly pending.
         Selector still picks it, dispatcher still sees the pending one.
         """
-        _write_manifest(tmp_path, frame_hashes={"11:1": "h1", "11:2": "h2"})
+        _write_manifest(tmp_path, frame_hashes={"11:1": "a1a1a1a1", "11:2": "b2b2b2b2"})
         md = tmp_path / "page.md"
         _write_stuck_fixture(
             md,
             frames=["11:1", "11:2"],
-            unresolvable_frames={"11:1": "h1"},  # 11:1 tombstoned, 11:2 not
+            unresolvable_frames={"11:1": "a1a1a1a1"},  # 11:1 tombstoned, 11:2 not
         )
 
         needs_it, _ = enrichment_info(md, repo_dir=tmp_path)
@@ -191,7 +191,7 @@ class TestPartialProgressStillWorks:
         _write_stuck_fixture(
             md,
             frames=["11:1"],
-            unresolvable_frames={"11:1": "h1"},
+            unresolvable_frames={"11:1": "a1a1a1a1"},
         )
 
         pending = pending_frame_node_ids(md)  # no repo_dir

--- a/tests/test_cross_run_idempotency.py
+++ b/tests/test_cross_run_idempotency.py
@@ -23,9 +23,8 @@ from figmaclaw.commands.claude_run import (
     enrichment_info,
     pending_frame_node_ids,
 )
-from figmaclaw.figma_parse import parse_frontmatter
 from figmaclaw.figma_sync_state import FigmaSyncState, FileEntry, PageEntry
-from figmaclaw.verdict import compute_verdict, EXIT_GREEN
+from figmaclaw.verdict import EXIT_GREEN, compute_verdict
 
 
 def _write_manifest(repo_dir: Path, *, frame_hashes: dict[str, str]) -> None:
@@ -43,7 +42,7 @@ def _write_manifest(repo_dir: Path, *, frame_hashes: dict[str, str]) -> None:
         file_name="Test",
         version="v1",
         last_modified="2026-04-18T00:00:00Z",
-        last_refreshed_at="2026-04-18T00:00:00Z",
+        last_checked_at="2026-04-18T00:00:00Z",
         pages={"1:1": page_entry},
     )
     state.manifest.files["fk"] = file_entry

--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -433,7 +433,11 @@ async def test_run_version_users_tracked(tmp_path: Path) -> None:
     canvas = _make_canvas("100:1", [_make_frame("11:1", "A"), _make_frame("11:3", "New")])
     old_canvas = _make_canvas("100:1", [_make_frame("11:1", "A")])
 
-    now = datetime.now(UTC)
+    # Compute fixture timestamps relative to the same _PINNED_NOW the
+    # test passes into _run so the 7d cutoff is deterministic. Previously
+    # this used datetime.now(UTC), which silently drifted into the range
+    # once wall-clock time advanced 15+ days past _PINNED_NOW.
+    now = _PINNED_NOW
     in_range_new = (
         (now - timedelta(days=2)).replace(microsecond=0).isoformat().replace("+00:00", "Z")
     )

--- a/tests/test_frontmatter_key_set_invariant.py
+++ b/tests/test_frontmatter_key_set_invariant.py
@@ -1,0 +1,188 @@
+"""Tests for the frame-keyed key-set invariant in _build_frontmatter.
+
+Issue: figmaclaw#121 — cross-run enrichment loops.
+
+Invariant under test:
+
+    ∀ d ∈ {enriched_frame_hashes, raw_frames, raw_tokens, frame_sections}:
+        keys(d) ⊆ frames
+
+Enforced at the single frontmatter write chokepoint (_build_frontmatter).
+Orphan keys cannot survive a round-trip through frontmatter rendering,
+regardless of caller correctness.
+
+Rationale: on 2026-04-15, a figmaclaw pull on showcase-v2-11550-42383.md
+shrank ``frames`` from 102 → 4 (Figma reorganization), but
+``enriched_frame_hashes`` retained ~100 orphan entries. The body still had
+~60 table rows for those dead IDs. The enricher then saw 60 unresolved
+frames, could not make progress, and burned ~5 min of CI every hour for 24+
+hours. The invariant in this file prevents the same failure mode from being
+reintroduced via a new frame-keyed dict or a caller that forgets to prune.
+"""
+
+from __future__ import annotations
+
+from figmaclaw.figma_frontmatter import (
+    FigmaPageFrontmatter,
+    FrameComposition,
+    RawTokenCounts,
+    SectionNode,
+)
+from figmaclaw.figma_parse import parse_frontmatter
+from figmaclaw.figma_render import build_page_frontmatter
+from figmaclaw.figma_models import FigmaFrame, FigmaPage, FigmaSection
+
+
+def _page_with_frames(node_ids: list[str]) -> FigmaPage:
+    section = FigmaSection(
+        node_id="10:10",
+        name="Section",
+        frames=[FigmaFrame(node_id=nid, name=f"F-{nid}") for nid in node_ids],
+    )
+    return FigmaPage(
+        file_key="fk",
+        file_name="F",
+        page_node_id="1:1",
+        page_name="Page",
+        page_slug="page",
+        figma_url="https://figma.com/design/fk?node-id=1-1",
+        sections=[section],
+        flows=[],
+        version="v",
+        last_modified="2026-04-18T00:00:00Z",
+    )
+
+
+def _parse(frontmatter_text: str) -> FigmaPageFrontmatter:
+    parsed = parse_frontmatter(f"{frontmatter_text}\n\n# body\n")
+    assert parsed is not None
+    return parsed
+
+
+def test_enriched_frame_hashes_orphans_pruned_on_write():
+    """Orphan keys in enriched_frame_hashes are stripped when writing frontmatter.
+
+    Reproduces figmaclaw#121 at the unit level: a caller passes
+    enriched_frame_hashes with keys for frames that no longer exist in the
+    page; the rendered frontmatter must contain only the valid keys.
+    """
+    page = _page_with_frames(["11:1", "11:2"])
+    stale_hashes = {"11:1": "a" * 8, "11:2": "b" * 8, "DEAD:1": "c" * 8, "DEAD:2": "d" * 8}
+
+    fm_text = build_page_frontmatter(page, enriched_frame_hashes=stale_hashes)
+    parsed = _parse(fm_text)
+
+    assert set(parsed.enriched_frame_hashes.keys()) == {"11:1", "11:2"}
+    assert set(parsed.enriched_frame_hashes.keys()) <= set(parsed.frames)
+
+
+def test_raw_frames_orphans_pruned_on_write():
+    page = _page_with_frames(["11:1"])
+    stale_raw = {
+        "11:1": FrameComposition(raw=3, ds=["ButtonV2"]),
+        "DEAD:1": FrameComposition(raw=1, ds=[]),
+    }
+
+    fm_text = build_page_frontmatter(page, raw_frames=stale_raw)
+    parsed = _parse(fm_text)
+
+    assert set(parsed.raw_frames.keys()) == {"11:1"}
+    assert set(parsed.raw_frames.keys()) <= set(parsed.frames)
+
+
+def test_raw_tokens_orphans_pruned_on_write():
+    page = _page_with_frames(["11:1"])
+    stale_tokens = {
+        "11:1": RawTokenCounts(raw=1, stale=0, valid=0),
+        "DEAD:1": RawTokenCounts(raw=2, stale=0, valid=0),
+    }
+
+    fm_text = build_page_frontmatter(page, raw_tokens=stale_tokens)
+    parsed = _parse(fm_text)
+
+    assert set(parsed.raw_tokens.keys()) == {"11:1"}
+    assert set(parsed.raw_tokens.keys()) <= set(parsed.frames)
+
+
+def test_frame_sections_orphans_pruned_on_write():
+    page = _page_with_frames(["11:1"])
+    stale_sections = {
+        "11:1": [SectionNode(node_id="11:1a", name="c", x=0, y=0, w=10, h=10)],
+        "DEAD:1": [SectionNode(node_id="DEAD:1a", name="g", x=0, y=0, w=10, h=10)],
+    }
+
+    fm_text = build_page_frontmatter(page, frame_sections=stale_sections)
+    parsed = _parse(fm_text)
+
+    assert set(parsed.frame_sections.keys()) == {"11:1"}
+    assert set(parsed.frame_sections.keys()) <= set(parsed.frames)
+
+
+def test_all_frame_keyed_dicts_pruned_in_one_write():
+    """All four frame-keyed dicts are pruned in a single call.
+
+    This pins the "every dict gets pruned every time" contract — if a future
+    contributor adds a fifth frame-keyed dict, they must either update this
+    test or pass this test by construction (i.e. by extending the chokepoint).
+    """
+    page = _page_with_frames(["11:1", "11:2"])
+    bad_keys = {"DEAD:1", "DEAD:2"}
+    ok_keys = {"11:1", "11:2"}
+
+    fm_text = build_page_frontmatter(
+        page,
+        enriched_frame_hashes={**dict.fromkeys(ok_keys, "a"), **dict.fromkeys(bad_keys, "b")},
+        raw_frames={
+            **{k: FrameComposition(raw=1) for k in ok_keys},
+            **{k: FrameComposition(raw=1) for k in bad_keys},
+        },
+        raw_tokens={
+            **{k: RawTokenCounts(raw=1) for k in ok_keys},
+            **{k: RawTokenCounts(raw=1) for k in bad_keys},
+        },
+        frame_sections={
+            **{
+                k: [SectionNode(node_id=f"{k}c", name="c", x=0, y=0, w=1, h=1)]
+                for k in ok_keys
+            },
+            **{
+                k: [SectionNode(node_id=f"{k}c", name="c", x=0, y=0, w=1, h=1)]
+                for k in bad_keys
+            },
+        },
+    )
+    parsed = _parse(fm_text)
+
+    frames_set = set(parsed.frames)
+    assert set(parsed.enriched_frame_hashes.keys()) <= frames_set
+    assert set(parsed.raw_frames.keys()) <= frames_set
+    assert set(parsed.raw_tokens.keys()) <= frames_set
+    assert set(parsed.frame_sections.keys()) <= frames_set
+    assert not (set(parsed.enriched_frame_hashes.keys()) & bad_keys)
+    assert not (set(parsed.raw_frames.keys()) & bad_keys)
+    assert not (set(parsed.raw_tokens.keys()) & bad_keys)
+    assert not (set(parsed.frame_sections.keys()) & bad_keys)
+
+
+def test_enriched_schema_version_preserved_through_rewrite():
+    """enriched_schema_version must never be silently dropped on write.
+
+    See figmaclaw#121: a real pull commit (f09548074) rewrote a file's
+    frontmatter and dropped `enriched_schema_version: 1`, which later had to
+    be reconstructed as 0 — downgrading the file's enrichment state.
+    """
+    page = _page_with_frames(["11:1"])
+    fm_text = build_page_frontmatter(page, enriched_schema_version=1)
+    parsed = _parse(fm_text)
+    assert parsed.enriched_schema_version == 1
+
+
+def test_pruning_is_no_op_when_all_keys_valid():
+    """Pruning must not mutate valid input — only orphans are removed."""
+    page = _page_with_frames(["11:1", "11:2"])
+    clean = {"11:1": "a" * 8, "11:2": "b" * 8}
+
+    fm_text = build_page_frontmatter(page, enriched_frame_hashes=clean)
+    parsed = _parse(fm_text)
+
+    assert parsed.enriched_frame_hashes == clean

--- a/tests/test_frontmatter_key_set_invariant.py
+++ b/tests/test_frontmatter_key_set_invariant.py
@@ -29,7 +29,11 @@ from figmaclaw.figma_frontmatter import (
     SectionNode,
 )
 from figmaclaw.figma_parse import parse_frontmatter
-from figmaclaw.figma_render import build_page_frontmatter
+from figmaclaw.figma_render import (
+    build_page_frontmatter,
+    page_frame_ids,
+    section_frame_ids,
+)
 from figmaclaw.figma_models import FigmaFrame, FigmaPage, FigmaSection
 
 
@@ -186,3 +190,24 @@ def test_pruning_is_no_op_when_all_keys_valid():
     parsed = _parse(fm_text)
 
     assert parsed.enriched_frame_hashes == clean
+
+
+def test_page_frame_ids_is_single_source_of_truth():
+    """page_frame_ids is the canonical extractor — the rendered frontmatter
+    must agree with it exactly. Pinning this prevents future callers from
+    re-implementing the "walk page → screen sections → frames" loop.
+    """
+    page = _page_with_frames(["11:1", "11:2", "11:3"])
+    fm_text = build_page_frontmatter(page)
+    parsed = _parse(fm_text)
+    assert parsed.frames == page_frame_ids(page)
+
+
+def test_section_frame_ids_is_single_source_of_truth():
+    """section_frame_ids is the canonical extractor for component sections."""
+    section = FigmaSection(
+        node_id="10:10",
+        name="Component",
+        frames=[FigmaFrame(node_id=nid, name=f"F-{nid}") for nid in ["30:1", "30:2"]],
+    )
+    assert section_frame_ids(section) == ["30:1", "30:2"]

--- a/tests/test_frontmatter_key_set_invariant.py
+++ b/tests/test_frontmatter_key_set_invariant.py
@@ -28,13 +28,13 @@ from figmaclaw.figma_frontmatter import (
     RawTokenCounts,
     SectionNode,
 )
+from figmaclaw.figma_models import FigmaFrame, FigmaPage, FigmaSection
 from figmaclaw.figma_parse import parse_frontmatter
 from figmaclaw.figma_render import (
     build_page_frontmatter,
     page_frame_ids,
     section_frame_ids,
 )
-from figmaclaw.figma_models import FigmaFrame, FigmaPage, FigmaSection
 
 
 def _page_with_frames(node_ids: list[str]) -> FigmaPage:
@@ -145,14 +145,8 @@ def test_all_frame_keyed_dicts_pruned_in_one_write():
             **{k: RawTokenCounts(raw=1) for k in bad_keys},
         },
         frame_sections={
-            **{
-                k: [SectionNode(node_id=f"{k}c", name="c", x=0, y=0, w=1, h=1)]
-                for k in ok_keys
-            },
-            **{
-                k: [SectionNode(node_id=f"{k}c", name="c", x=0, y=0, w=1, h=1)]
-                for k in bad_keys
-            },
+            **{k: [SectionNode(node_id=f"{k}c", name="c", x=0, y=0, w=1, h=1)] for k in ok_keys},
+            **{k: [SectionNode(node_id=f"{k}c", name="c", x=0, y=0, w=1, h=1)] for k in bad_keys},
         },
     )
     parsed = _parse(fm_text)

--- a/tests/test_pull_body_orphan_prune.py
+++ b/tests/test_pull_body_orphan_prune.py
@@ -116,7 +116,9 @@ enriched_schema_version: 0
         "---"
     )
 
-    _rewrite_frontmatter_preserving_body(path, md, new_fm)
+    _rewrite_frontmatter_preserving_body(
+        path, md, new_fm, allowed_frame_ids={"11:1", "11:2"}
+    )
     written = path.read_text()
 
     assert "frames: ['11:1', '11:2']" in written
@@ -155,7 +157,12 @@ enriched_schema_version: 0
         "---"
     )
 
-    _rewrite_frontmatter_preserving_body(path, md, new_fm)
+    _rewrite_frontmatter_preserving_body(
+        path,
+        md,
+        new_fm,
+        allowed_frame_ids={"11:1", "11:2", "DEAD:1", "DEAD:2"},
+    )
     written = path.read_text()
 
     _, _, body_after = written.partition("---\n")

--- a/tests/test_pull_body_orphan_prune.py
+++ b/tests/test_pull_body_orphan_prune.py
@@ -1,0 +1,165 @@
+"""Tests for orphan frame-row pruning in _rewrite_frontmatter_preserving_body.
+
+Issue: figmaclaw#121 — cross-run enrichment loops.
+
+Invariant under test:
+
+    After a pull that shrinks ``frames``, the body contains no frame rows
+    whose node_id is outside the new ``frames`` list.
+
+This is the structural twin of the key-set invariant (test_frontmatter_
+key_set_invariant.py). Both are required: frontmatter alone being consistent
+is not enough — the body's frame table also has to drop orphan rows, or the
+enricher's ``pending_frame_node_ids`` will keep reporting them as unresolved
+forever.
+
+Non-goal: mechanical rewrites of prose, section intros, or page summaries.
+Those are and remain the exclusive domain of the LLM enrich pass.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from figmaclaw.pull_logic import _prune_orphan_frame_rows, _rewrite_frontmatter_preserving_body
+
+
+BODY_WITH_ORPHAN_ROWS = """
+# Web App / Showcase v2
+
+[Open in Figma](https://www.figma.com/design/fk?node-id=1-1)
+
+This page covers the Showcase V2 feature end-to-end.
+
+## AI wireframes (`11579:137`)
+
+Early-stage wireframes.
+
+| Screen | Node ID | Description |
+|--------|---------|-------------|
+| Kept row | `11:1` | A real description. |
+| Orphan row 1 | `DEAD:1` | (no screenshot available) |
+| Orphan row 2 | `DEAD:2` | (no screenshot available) |
+| Another kept row | `11:2` | Another description. |
+
+## Screen flow
+
+```mermaid
+flowchart LR
+  A --> B
+```
+"""
+
+
+def test_prune_orphan_frame_rows_keeps_allowed_and_drops_orphans():
+    cleaned = _prune_orphan_frame_rows(BODY_WITH_ORPHAN_ROWS, {"11:1", "11:2"})
+
+    assert "`11:1`" in cleaned
+    assert "`11:2`" in cleaned
+    assert "`DEAD:1`" not in cleaned
+    assert "`DEAD:2`" not in cleaned
+
+
+def test_prune_orphan_frame_rows_preserves_prose_and_mermaid():
+    cleaned = _prune_orphan_frame_rows(BODY_WITH_ORPHAN_ROWS, {"11:1", "11:2"})
+
+    assert "# Web App / Showcase v2" in cleaned
+    assert "This page covers the Showcase V2 feature end-to-end." in cleaned
+    assert "## AI wireframes (`11579:137`)" in cleaned
+    assert "Early-stage wireframes." in cleaned
+    assert "```mermaid" in cleaned
+    assert "flowchart LR" in cleaned
+
+
+def test_prune_orphan_frame_rows_preserves_table_header_and_separator():
+    cleaned = _prune_orphan_frame_rows(BODY_WITH_ORPHAN_ROWS, {"11:1", "11:2"})
+
+    assert "| Screen | Node ID | Description |" in cleaned
+    assert "|--------|---------|-------------|" in cleaned
+
+
+def test_prune_orphan_frame_rows_empty_allowed_is_no_op():
+    """When the new frames list is empty, the body is left alone.
+
+    Legacy/bare files with no frontmatter shouldn't have their bodies
+    structurally mutated as a side-effect of pull.
+    """
+    cleaned = _prune_orphan_frame_rows(BODY_WITH_ORPHAN_ROWS, set())
+    assert cleaned == BODY_WITH_ORPHAN_ROWS
+
+
+def test_rewrite_frontmatter_preserving_body_end_to_end(tmp_path: Path):
+    """Full integration: rewriting a file with shrunken frames drops orphan rows.
+
+    This reproduces the showcase-v2-11550-42383.md incident shape: a page
+    with 4 kept frames and a body full of rows for stale node IDs from a
+    prior Figma reorganization.
+    """
+    md = f"""---
+file_key: fk
+page_node_id: '1:1'
+frames: ['11:1', '11:2', 'DEAD:1', 'DEAD:2']
+enriched_schema_version: 0
+---
+
+{BODY_WITH_ORPHAN_ROWS.strip()}
+"""
+    path = tmp_path / "page.md"
+    path.write_text(md)
+
+    new_fm = (
+        "---\n"
+        "file_key: fk\n"
+        "page_node_id: '1:1'\n"
+        "frames: ['11:1', '11:2']\n"
+        "enriched_schema_version: 0\n"
+        "---"
+    )
+
+    _rewrite_frontmatter_preserving_body(path, md, new_fm)
+    written = path.read_text()
+
+    assert "frames: ['11:1', '11:2']" in written
+    assert "`11:1`" in written
+    assert "`11:2`" in written
+    assert "`DEAD:1`" not in written
+    assert "`DEAD:2`" not in written
+    assert "## AI wireframes (`11579:137`)" in written
+    assert "```mermaid" in written
+
+
+def test_rewrite_frontmatter_preserving_body_no_shrink_no_body_change(tmp_path: Path):
+    """If frames don't shrink, body is byte-for-byte preserved.
+
+    This is the contract for the happy path — pull that doesn't remove any
+    frames must not touch the body at all, even structurally.
+    """
+    md = f"""---
+file_key: fk
+page_node_id: '1:1'
+frames: ['11:1', '11:2']
+enriched_schema_version: 0
+---
+
+{BODY_WITH_ORPHAN_ROWS.strip()}
+"""
+    path = tmp_path / "page.md"
+    path.write_text(md)
+
+    new_fm = (
+        "---\n"
+        "file_key: fk\n"
+        "page_node_id: '1:1'\n"
+        "frames: ['11:1', '11:2', 'DEAD:1', 'DEAD:2']\n"
+        "enriched_schema_version: 0\n"
+        "---"
+    )
+
+    _rewrite_frontmatter_preserving_body(path, md, new_fm)
+    written = path.read_text()
+
+    _, _, body_after = written.partition("---\n")
+    _, _, body_after = body_after.partition("---\n")
+    _, _, body_before = md.partition("---\n")
+    _, _, body_before = body_before.partition("---\n")
+    assert body_after == body_before

--- a/tests/test_pull_body_orphan_prune.py
+++ b/tests/test_pull_body_orphan_prune.py
@@ -23,7 +23,6 @@ from pathlib import Path
 
 from figmaclaw.pull_logic import _prune_orphan_frame_rows, _rewrite_frontmatter_preserving_body
 
-
 BODY_WITH_ORPHAN_ROWS = """
 # Web App / Showcase v2
 
@@ -116,9 +115,7 @@ enriched_schema_version: 0
         "---"
     )
 
-    _rewrite_frontmatter_preserving_body(
-        path, md, new_fm, allowed_frame_ids={"11:1", "11:2"}
-    )
+    _rewrite_frontmatter_preserving_body(path, md, new_fm, allowed_frame_ids={"11:1", "11:2"})
     written = path.read_text()
 
     assert "frames: ['11:1', '11:2']" in written

--- a/tests/test_pull_logic.py
+++ b/tests/test_pull_logic.py
@@ -52,7 +52,7 @@ from tests.conftest import (
 # Schema version registry — must contain every version that has been superseded.
 # When you bump CURRENT_PULL_SCHEMA_VERSION from N to N+1, add N here and add
 # a corresponding convergence test (like test_schema_upgrade_does_not_cause_infinite_loop_with_max_pages).
-TESTED_UPGRADE_FROM_VERSIONS: frozenset[int] = frozenset({1, 2, 3, 4, 5})
+TESTED_UPGRADE_FROM_VERSIONS: frozenset[int] = frozenset({1, 2, 3, 4, 5, 6})
 
 
 def test_schema_upgrade_coverage_is_current():
@@ -1841,6 +1841,71 @@ async def test_schema_upgrade_does_not_cause_infinite_loop_with_max_pages(tmp_pa
 
     # pull_schema_version must be updated after a schema-only pass
     assert state.manifest.files["abc123"].pull_schema_version == CURRENT_PULL_SCHEMA_VERSION
+
+
+@pytest.mark.asyncio
+async def test_schema_upgrade_v6_to_v7_prunes_orphan_enriched_frame_hashes(tmp_path: Path):
+    """INVARIANT for figmaclaw#121 / v7 schema bump: when a v6 file is
+    refreshed to v7, orphan entries in ``enriched_frame_hashes`` for
+    node_ids no longer in ``frames`` are pruned by the
+    ``_build_frontmatter`` chokepoint.
+
+    This is what lets existing stuck files in consumer repos (the
+    linear-git showcase-v2 shape) converge to clean state on the next
+    pull without any manual intervention.
+    """
+    from figmaclaw.figma_frontmatter import CURRENT_PULL_SCHEMA_VERSION
+    from figmaclaw.figma_parse import parse_frontmatter
+
+    state = FigmaSyncState(tmp_path)
+    state.load()
+    state.add_tracked_file("abc123", "Web App")
+
+    mock_client = MagicMock(spec=FigmaClient)
+    page_node = fake_page_node_with_children()
+    mock_client.get_file_meta = AsyncMock(return_value=fake_file_meta("v2", "2026-03-31T12:00:00Z"))
+    mock_client.get_page = AsyncMock(return_value=page_node)
+    mock_client.get_component_sets = AsyncMock(return_value=[])
+    mock_client.get_nodes = AsyncMock(return_value=fake_get_nodes_response())
+
+    # First pull: write the page fresh (v7).
+    await pull_file(mock_client, "abc123", state, tmp_path, force=False)
+    md_rel = state.manifest.files["abc123"].pages["7741:45837"].md_path
+    md_path = tmp_path / md_rel
+
+    # Seed the showcase-v2 incident shape: orphan entries in
+    # enriched_frame_hashes that are NOT in the real frames list.
+    text = md_path.read_text()
+    fm = parse_frontmatter(text)
+    real_frames = set(fm.frames)
+    orphan_nids = {"99:99", "88:88"}
+    assert not orphan_nids & real_frames
+    # Directly inject a v6-era frontmatter with orphan enriched_frame_hashes.
+    # We splice the raw YAML to bypass the write-time chokepoint (the
+    # chokepoint is exactly what this test asserts will re-prune the
+    # orphans on the NEXT pull).
+    injected = text.replace(
+        "---\n",
+        (
+            "---\n"
+            "enriched_frame_hashes: "
+            "{'11:1': aaaaaaaa, '11:2': bbbbbbbb, "
+            "'99:99': deaddead, '88:88': feedbeef}\n"
+        ),
+        1,
+    )
+    md_path.write_text(injected)
+    state.manifest.files["abc123"].pull_schema_version = 6  # simulate v6
+    state.save()
+
+    # Second pull: v6 < v7 → schema-stale refresh. The chokepoint must
+    # drop the orphans from enriched_frame_hashes.
+    await pull_file(mock_client, "abc123", state, tmp_path, force=False)
+
+    fm_after = parse_frontmatter(md_path.read_text())
+    assert state.manifest.files["abc123"].pull_schema_version == CURRENT_PULL_SCHEMA_VERSION
+    assert set(fm_after.enriched_frame_hashes.keys()) <= set(fm_after.frames)
+    assert not (set(fm_after.enriched_frame_hashes.keys()) & orphan_nids)
 
 
 @pytest.mark.asyncio

--- a/tests/test_pull_logic.py
+++ b/tests/test_pull_logic.py
@@ -1871,12 +1871,14 @@ async def test_schema_upgrade_v6_to_v7_prunes_orphan_enriched_frame_hashes(tmp_p
     # First pull: write the page fresh (v7).
     await pull_file(mock_client, "abc123", state, tmp_path, force=False)
     md_rel = state.manifest.files["abc123"].pages["7741:45837"].md_path
+    assert md_rel is not None
     md_path = tmp_path / md_rel
 
     # Seed the showcase-v2 incident shape: orphan entries in
     # enriched_frame_hashes that are NOT in the real frames list.
     text = md_path.read_text()
     fm = parse_frontmatter(text)
+    assert fm is not None
     real_frames = set(fm.frames)
     orphan_nids = {"99:99", "88:88"}
     assert not orphan_nids & real_frames
@@ -1903,6 +1905,7 @@ async def test_schema_upgrade_v6_to_v7_prunes_orphan_enriched_frame_hashes(tmp_p
     await pull_file(mock_client, "abc123", state, tmp_path, force=False)
 
     fm_after = parse_frontmatter(md_path.read_text())
+    assert fm_after is not None
     assert state.manifest.files["abc123"].pull_schema_version == CURRENT_PULL_SCHEMA_VERSION
     assert set(fm_after.enriched_frame_hashes.keys()) <= set(fm_after.frames)
     assert not (set(fm_after.enriched_frame_hashes.keys()) & orphan_nids)

--- a/tests/test_tombstone_protocol.py
+++ b/tests/test_tombstone_protocol.py
@@ -1,0 +1,442 @@
+"""Tests for the unresolvable-frame tombstone protocol (figmaclaw#121).
+
+Protocol: when the same-run NO-PROGRESS guard fires, the dispatcher
+records the current manifest frame_hash into
+``frontmatter.unresolvable_frames[node_id]``. On the next run:
+
+- ``pending_frame_node_ids`` / ``pending_sections`` exclude the
+  tombstoned frame (terminal state honored) while the manifest hash
+  still matches.
+- ``enrichment_info`` no longer reports the file as needing enrichment
+  solely because of the tombstoned row.
+- When Figma content changes and the manifest hash diverges from the
+  recorded tombstone, the tombstone auto-invalidates — the frame is
+  pending again (one retry per content change).
+
+Cross-cuts:
+- The frame-keyed key-set invariant (figmaclaw#121, chokepoint prune)
+  applies equally to ``unresolvable_frames``: orphan tombstones (keys
+  not in ``frames``) are dropped on write.
+- Tombstones are preserved across pulls by ``update_page_frontmatter``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from figmaclaw.commands.claude_run import (
+    _record_tombstones,
+    enrichment_info,
+    pending_frame_node_ids,
+    pending_sections,
+)
+from figmaclaw.figma_frontmatter import FigmaPageFrontmatter, FrameComposition
+from figmaclaw.figma_parse import parse_frontmatter
+from figmaclaw.figma_render import build_page_frontmatter
+from figmaclaw.figma_sync_state import FigmaSyncState
+from figmaclaw.figma_models import FigmaFrame, FigmaPage, FigmaSection
+from figmaclaw.staleness import active_tombstoned_node_ids
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _write_manifest(repo_dir: Path, *, frame_hashes: dict[str, str]) -> None:
+    """Write a minimal manifest so active_tombstoned_node_ids can read it."""
+    state = FigmaSyncState(repo_dir)
+    state.load()
+    # Build manifest entries programmatically via the pydantic models.
+    from figmaclaw.figma_sync_state import FileEntry, PageEntry
+
+    page_entry = PageEntry(
+        page_name="Page",
+        page_slug="page",
+        md_path="figma/fk/pages/page.md",
+        page_hash="page-hash",
+        frame_hashes=frame_hashes,
+        last_refreshed_at="2026-04-18T00:00:00Z",
+    )
+    file_entry = FileEntry(
+        file_name="Test",
+        version="v1",
+        last_modified="2026-04-18T00:00:00Z",
+        last_refreshed_at="2026-04-18T00:00:00Z",
+        pages={"1:1": page_entry},
+    )
+    state.manifest.files["fk"] = file_entry
+    state.save()
+
+
+def _write_page(
+    md_path: Path,
+    *,
+    frames: list[str],
+    unresolvable_frames: dict[str, str] | None = None,
+    body_unresolved_frames: list[str] | None = None,
+) -> None:
+    """Write a minimal figmaclaw page .md with given frontmatter + body."""
+    lines = [
+        "---",
+        "file_key: fk",
+        "page_node_id: '1:1'",
+        f"frames: {frames!r}",
+        "enriched_schema_version: 1",
+    ]
+    if unresolvable_frames:
+        lines.append(f"unresolvable_frames: {unresolvable_frames!r}")
+    lines.append("---")
+    lines.append("")
+    lines.append("# Page")
+    lines.append("")
+    lines.append("## Section (`10:1`)")
+    lines.append("")
+    lines.append("| Screen | Node ID | Description |")
+    lines.append("|--------|---------|-------------|")
+    for nid in frames:
+        if body_unresolved_frames and nid in body_unresolved_frames:
+            lines.append(f"| Row | `{nid}` | (no screenshot available) |")
+        else:
+            lines.append(f"| Row | `{nid}` | A real description. |")
+    md_path.write_text("\n".join(lines) + "\n")
+
+
+# ---------------------------------------------------------------------------
+# active_tombstoned_node_ids — hash-matching semantics
+# ---------------------------------------------------------------------------
+
+
+class TestActiveTombstonedNodeIds:
+    def test_returns_empty_when_no_tombstones(self, tmp_path: Path) -> None:
+        fm = FigmaPageFrontmatter(
+            file_key="fk",
+            page_node_id="1:1",
+            frames=["11:1"],
+        )
+        assert active_tombstoned_node_ids(fm, tmp_path) == set()
+
+    def test_returns_empty_when_repo_dir_is_none(self) -> None:
+        fm = FigmaPageFrontmatter(
+            file_key="fk",
+            page_node_id="1:1",
+            frames=["11:1"],
+            unresolvable_frames={"11:1": "h1"},
+        )
+        assert active_tombstoned_node_ids(fm, None) == set()
+
+    def test_tombstone_active_when_hash_matches_manifest(self, tmp_path: Path) -> None:
+        _write_manifest(tmp_path, frame_hashes={"11:1": "h1", "11:2": "h2"})
+        fm = FigmaPageFrontmatter(
+            file_key="fk",
+            page_node_id="1:1",
+            frames=["11:1", "11:2"],
+            unresolvable_frames={"11:1": "h1"},
+        )
+        assert active_tombstoned_node_ids(fm, tmp_path) == {"11:1"}
+
+    def test_tombstone_invalid_when_hash_drifts(self, tmp_path: Path) -> None:
+        """Simulate Figma content change: manifest now carries a different
+        hash than the recorded tombstone. Tombstone is no longer active —
+        the frame becomes pending again for one retry.
+        """
+        _write_manifest(tmp_path, frame_hashes={"11:1": "h1-NEW"})
+        fm = FigmaPageFrontmatter(
+            file_key="fk",
+            page_node_id="1:1",
+            frames=["11:1"],
+            unresolvable_frames={"11:1": "h1-OLD"},
+        )
+        assert active_tombstoned_node_ids(fm, tmp_path) == set()
+
+    def test_missing_manifest_entry_returns_empty(self, tmp_path: Path) -> None:
+        """When the manifest has no entry for the file (never pulled), no
+        tombstone is active — safe default is "retry" rather than "skip"."""
+        _write_manifest(tmp_path, frame_hashes={})  # empty manifest pages
+        fm = FigmaPageFrontmatter(
+            file_key="other-key",  # not in manifest
+            page_node_id="1:1",
+            frames=["11:1"],
+            unresolvable_frames={"11:1": "h1"},
+        )
+        assert active_tombstoned_node_ids(fm, tmp_path) == set()
+
+
+# ---------------------------------------------------------------------------
+# pending_frame_node_ids / pending_sections — tombstone filtering
+# ---------------------------------------------------------------------------
+
+
+class TestPendingFiltersTombstones:
+    def test_tombstoned_frame_is_not_pending_when_hash_matches(self, tmp_path: Path) -> None:
+        _write_manifest(tmp_path, frame_hashes={"11:1": "h1", "11:2": "h2"})
+        md = tmp_path / "page.md"
+        _write_page(
+            md,
+            frames=["11:1", "11:2"],
+            unresolvable_frames={"11:1": "h1"},
+            body_unresolved_frames=["11:1", "11:2"],
+        )
+
+        pending = pending_frame_node_ids(md, repo_dir=tmp_path)
+        assert pending == {"11:2"}  # 11:1 filtered out by active tombstone
+
+    def test_tombstoned_frame_is_pending_when_hash_drifted(self, tmp_path: Path) -> None:
+        """Content changed after tombstone → tombstone no longer active →
+        frame pending again. This is the retry-on-change contract.
+        """
+        _write_manifest(tmp_path, frame_hashes={"11:1": "h1-NEW"})
+        md = tmp_path / "page.md"
+        _write_page(
+            md,
+            frames=["11:1"],
+            unresolvable_frames={"11:1": "h1-OLD"},
+            body_unresolved_frames=["11:1"],
+        )
+
+        pending = pending_frame_node_ids(md, repo_dir=tmp_path)
+        assert pending == {"11:1"}
+
+    def test_pending_frame_node_ids_without_repo_dir_is_unchanged(
+        self, tmp_path: Path
+    ) -> None:
+        """Legacy callers without repo_dir see the pre-tombstone behavior.
+
+        Important for callers that don't have manifest access — they get
+        the raw unresolved set, same as before figmaclaw#121.
+        """
+        md = tmp_path / "page.md"
+        _write_page(
+            md,
+            frames=["11:1"],
+            unresolvable_frames={"11:1": "h1"},
+            body_unresolved_frames=["11:1"],
+        )
+
+        pending = pending_frame_node_ids(md)
+        assert pending == {"11:1"}  # no filtering without repo_dir
+
+    def test_pending_sections_drops_fully_tombstoned_sections(
+        self, tmp_path: Path
+    ) -> None:
+        """When every pending frame in a section is tombstoned+matching,
+        the section is fully "done" and drops out of pending_sections.
+        """
+        _write_manifest(tmp_path, frame_hashes={"11:1": "h1", "11:2": "h2"})
+        md = tmp_path / "page.md"
+        _write_page(
+            md,
+            frames=["11:1", "11:2"],
+            unresolvable_frames={"11:1": "h1", "11:2": "h2"},
+            body_unresolved_frames=["11:1", "11:2"],
+        )
+
+        sections = pending_sections(md, repo_dir=tmp_path)
+        assert sections == []
+
+
+# ---------------------------------------------------------------------------
+# enrichment_info — selector honors tombstones
+# ---------------------------------------------------------------------------
+
+
+class TestEnrichmentInfoHonorsTombstones:
+    def test_all_tombstoned_file_is_not_enrichment_candidate(
+        self, tmp_path: Path
+    ) -> None:
+        """The critical cross-run loop guard: after tombstones land for every
+        unresolved row, the selector stops picking the file. This is what
+        stops the hourly RED loop in figmaclaw#121.
+        """
+        _write_manifest(tmp_path, frame_hashes={"11:1": "h1"})
+        md = tmp_path / "page.md"
+        _write_page(
+            md,
+            frames=["11:1"],
+            unresolvable_frames={"11:1": "h1"},
+            body_unresolved_frames=["11:1"],
+        )
+        # Anchor the schema to the current version so the "must update"
+        # branch doesn't spuriously requeue the file.
+        text = md.read_text()
+        text = text.replace(
+            "enriched_schema_version: 1",
+            "enriched_schema_version: 1\nenriched_hash: anything",
+        )
+        md.write_text(text)
+
+        needs_it, _ = enrichment_info(md, repo_dir=tmp_path)
+        assert needs_it is False
+
+    def test_hash_drift_makes_file_enrichable_again(self, tmp_path: Path) -> None:
+        _write_manifest(tmp_path, frame_hashes={"11:1": "h1-NEW"})
+        md = tmp_path / "page.md"
+        _write_page(
+            md,
+            frames=["11:1"],
+            unresolvable_frames={"11:1": "h1-OLD"},
+            body_unresolved_frames=["11:1"],
+        )
+
+        needs_it, _ = enrichment_info(md, repo_dir=tmp_path)
+        assert needs_it is True
+
+
+# ---------------------------------------------------------------------------
+# _record_tombstones — write-path behavior
+# ---------------------------------------------------------------------------
+
+
+class TestRecordTombstones:
+    def test_writes_tombstones_with_current_manifest_hashes(
+        self, tmp_path: Path
+    ) -> None:
+        _write_manifest(tmp_path, frame_hashes={"11:1": "h1", "11:2": "h2"})
+        md = tmp_path / "page.md"
+        _write_page(
+            md,
+            frames=["11:1", "11:2"],
+            body_unresolved_frames=["11:1", "11:2"],
+        )
+
+        added = _record_tombstones(md, tmp_path, {"11:1", "11:2"})
+        assert added == 2
+
+        fm = parse_frontmatter(md.read_text())
+        assert fm is not None
+        assert fm.unresolvable_frames == {"11:1": "h1", "11:2": "h2"}
+
+    def test_skips_node_ids_missing_from_manifest(self, tmp_path: Path) -> None:
+        _write_manifest(tmp_path, frame_hashes={"11:1": "h1"})  # no "11:2"
+        md = tmp_path / "page.md"
+        _write_page(
+            md,
+            frames=["11:1", "11:2"],
+            body_unresolved_frames=["11:1", "11:2"],
+        )
+
+        added = _record_tombstones(md, tmp_path, {"11:1", "11:2"})
+        assert added == 1
+        fm = parse_frontmatter(md.read_text())
+        assert fm.unresolvable_frames == {"11:1": "h1"}
+
+    def test_does_not_duplicate_existing_tombstones(self, tmp_path: Path) -> None:
+        _write_manifest(tmp_path, frame_hashes={"11:1": "h1"})
+        md = tmp_path / "page.md"
+        _write_page(
+            md,
+            frames=["11:1"],
+            unresolvable_frames={"11:1": "h1"},
+            body_unresolved_frames=["11:1"],
+        )
+
+        added = _record_tombstones(md, tmp_path, {"11:1"})
+        assert added == 0
+
+    def test_preserves_body_verbatim(self, tmp_path: Path) -> None:
+        _write_manifest(tmp_path, frame_hashes={"11:1": "h1"})
+        md = tmp_path / "page.md"
+        _write_page(
+            md,
+            frames=["11:1"],
+            body_unresolved_frames=["11:1"],
+        )
+        body_before = md.read_text().split("---\n", 2)[2]
+
+        _record_tombstones(md, tmp_path, {"11:1"})
+
+        body_after = md.read_text().split("---\n", 2)[2]
+        assert body_after == body_before
+
+
+# ---------------------------------------------------------------------------
+# Cross-cutting: key-set invariant applies to unresolvable_frames
+# ---------------------------------------------------------------------------
+
+
+class TestKeySetInvariantAppliesToTombstones:
+    def test_orphan_tombstones_pruned_on_write(self) -> None:
+        """A tombstone for a node_id no longer in frames gets dropped by
+        the frontmatter-write chokepoint. Same invariant as every other
+        frame-keyed dict.
+        """
+        page = FigmaPage(
+            file_key="fk",
+            file_name="F",
+            page_node_id="1:1",
+            page_name="Page",
+            page_slug="page",
+            figma_url="https://figma.com/design/fk?node-id=1-1",
+            sections=[
+                FigmaSection(
+                    node_id="10:10",
+                    name="Section",
+                    frames=[FigmaFrame(node_id="11:1", name="F1")],
+                )
+            ],
+            flows=[],
+            version="v",
+            last_modified="2026-04-18T00:00:00Z",
+        )
+        fm_text = build_page_frontmatter(
+            page,
+            unresolvable_frames={"11:1": "h1", "DEAD:1": "h-dead"},
+        )
+
+        parsed = parse_frontmatter(f"{fm_text}\n\n# body\n")
+        assert parsed is not None
+        assert parsed.unresolvable_frames == {"11:1": "h1"}
+        assert "DEAD:1" not in parsed.unresolvable_frames
+
+
+# ---------------------------------------------------------------------------
+# Cross-run: run N writes tombstone, run N+1 skips the file
+# ---------------------------------------------------------------------------
+
+
+class TestCrossRunIdempotency:
+    def test_second_run_does_not_reselect_fully_tombstoned_file(
+        self, tmp_path: Path
+    ) -> None:
+        """End-to-end cross-run shape (figmaclaw#121):
+
+            state_0: file has an unresolved body row with no screenshot
+            run 1:   NO-PROGRESS fires → _record_tombstones writes
+                     unresolvable_frames[node_id] = manifest_hash
+            state_1: file has both the body row AND the tombstone
+            run 2:   enrichment_info returns needs_it=False, because the
+                     tombstone matches the current manifest hash.
+
+        This is the only bug shape row 9 YELLOW + tombstones together
+        are meant to close. Without tombstones, run 2 would keep
+        selecting the file forever.
+        """
+        _write_manifest(tmp_path, frame_hashes={"11:1": "h1"})
+        md = tmp_path / "page.md"
+        _write_page(
+            md,
+            frames=["11:1"],
+            body_unresolved_frames=["11:1"],
+        )
+        # Anchor schema so "must update" doesn't override
+        text = md.read_text()
+        text = text.replace(
+            "enriched_schema_version: 1",
+            "enriched_schema_version: 1\nenriched_hash: anything",
+        )
+        md.write_text(text)
+
+        # Run 1: selector says yes (body has unresolved row, no tombstone yet)
+        needs_run1, _ = enrichment_info(md, repo_dir=tmp_path)
+        assert needs_run1 is True
+
+        # Simulate NO-PROGRESS: LLM wrote "(no screenshot available)" and
+        # dispatcher recorded tombstones
+        added = _record_tombstones(md, tmp_path, {"11:1"})
+        assert added == 1
+
+        # Run 2: selector now says no — tombstone matches manifest hash
+        needs_run2, _ = enrichment_info(md, repo_dir=tmp_path)
+        assert needs_run2 is False

--- a/tests/test_tombstone_protocol.py
+++ b/tests/test_tombstone_protocol.py
@@ -24,21 +24,18 @@ from __future__ import annotations
 
 from pathlib import Path
 
-import pytest
-
 from figmaclaw.commands.claude_run import (
     _record_tombstones,
     enrichment_info,
     pending_frame_node_ids,
     pending_sections,
 )
-from figmaclaw.figma_frontmatter import FigmaPageFrontmatter, FrameComposition
+from figmaclaw.figma_frontmatter import FigmaPageFrontmatter
+from figmaclaw.figma_models import FigmaFrame, FigmaPage, FigmaSection
 from figmaclaw.figma_parse import parse_frontmatter
 from figmaclaw.figma_render import build_page_frontmatter
 from figmaclaw.figma_sync_state import FigmaSyncState
-from figmaclaw.figma_models import FigmaFrame, FigmaPage, FigmaSection
 from figmaclaw.staleness import active_tombstoned_node_ids
-
 
 # ---------------------------------------------------------------------------
 # Fixtures
@@ -64,7 +61,7 @@ def _write_manifest(repo_dir: Path, *, frame_hashes: dict[str, str]) -> None:
         file_name="Test",
         version="v1",
         last_modified="2026-04-18T00:00:00Z",
-        last_refreshed_at="2026-04-18T00:00:00Z",
+        last_checked_at="2026-04-18T00:00:00Z",
         pages={"1:1": page_entry},
     )
     state.manifest.files["fk"] = file_entry
@@ -199,9 +196,7 @@ class TestPendingFiltersTombstones:
         pending = pending_frame_node_ids(md, repo_dir=tmp_path)
         assert pending == {"11:1"}
 
-    def test_pending_frame_node_ids_without_repo_dir_is_unchanged(
-        self, tmp_path: Path
-    ) -> None:
+    def test_pending_frame_node_ids_without_repo_dir_is_unchanged(self, tmp_path: Path) -> None:
         """Legacy callers without repo_dir see the pre-tombstone behavior.
 
         Important for callers that don't have manifest access — they get
@@ -218,9 +213,7 @@ class TestPendingFiltersTombstones:
         pending = pending_frame_node_ids(md)
         assert pending == {"11:1"}  # no filtering without repo_dir
 
-    def test_pending_sections_drops_fully_tombstoned_sections(
-        self, tmp_path: Path
-    ) -> None:
+    def test_pending_sections_drops_fully_tombstoned_sections(self, tmp_path: Path) -> None:
         """When every pending frame in a section is tombstoned+matching,
         the section is fully "done" and drops out of pending_sections.
         """
@@ -243,9 +236,7 @@ class TestPendingFiltersTombstones:
 
 
 class TestEnrichmentInfoHonorsTombstones:
-    def test_all_tombstoned_file_is_not_enrichment_candidate(
-        self, tmp_path: Path
-    ) -> None:
+    def test_all_tombstoned_file_is_not_enrichment_candidate(self, tmp_path: Path) -> None:
         """The critical cross-run loop guard: after tombstones land for every
         unresolved row, the selector stops picking the file. This is what
         stops the hourly RED loop in figmaclaw#121.
@@ -290,9 +281,7 @@ class TestEnrichmentInfoHonorsTombstones:
 
 
 class TestRecordTombstones:
-    def test_writes_tombstones_with_current_manifest_hashes(
-        self, tmp_path: Path
-    ) -> None:
+    def test_writes_tombstones_with_current_manifest_hashes(self, tmp_path: Path) -> None:
         _write_manifest(tmp_path, frame_hashes={"11:1": "h1", "11:2": "h2"})
         md = tmp_path / "page.md"
         _write_page(
@@ -320,6 +309,7 @@ class TestRecordTombstones:
         added = _record_tombstones(md, tmp_path, {"11:1", "11:2"})
         assert added == 1
         fm = parse_frontmatter(md.read_text())
+        assert fm is not None
         assert fm.unresolvable_frames == {"11:1": "h1"}
 
     def test_does_not_duplicate_existing_tombstones(self, tmp_path: Path) -> None:
@@ -397,9 +387,7 @@ class TestKeySetInvariantAppliesToTombstones:
 
 
 class TestCrossRunIdempotency:
-    def test_second_run_does_not_reselect_fully_tombstoned_file(
-        self, tmp_path: Path
-    ) -> None:
+    def test_second_run_does_not_reselect_fully_tombstoned_file(self, tmp_path: Path) -> None:
         """End-to-end cross-run shape (figmaclaw#121):
 
             state_0: file has an unresolved body row with no screenshot

--- a/tests/test_tombstone_protocol.py
+++ b/tests/test_tombstone_protocol.py
@@ -120,17 +120,17 @@ class TestActiveTombstonedNodeIds:
             file_key="fk",
             page_node_id="1:1",
             frames=["11:1"],
-            unresolvable_frames={"11:1": "h1"},
+            unresolvable_frames={"11:1": "a1a1a1a1"},
         )
         assert active_tombstoned_node_ids(fm, None) == set()
 
     def test_tombstone_active_when_hash_matches_manifest(self, tmp_path: Path) -> None:
-        _write_manifest(tmp_path, frame_hashes={"11:1": "h1", "11:2": "h2"})
+        _write_manifest(tmp_path, frame_hashes={"11:1": "a1a1a1a1", "11:2": "b2b2b2b2"})
         fm = FigmaPageFrontmatter(
             file_key="fk",
             page_node_id="1:1",
             frames=["11:1", "11:2"],
-            unresolvable_frames={"11:1": "h1"},
+            unresolvable_frames={"11:1": "a1a1a1a1"},
         )
         assert active_tombstoned_node_ids(fm, tmp_path) == {"11:1"}
 
@@ -139,12 +139,12 @@ class TestActiveTombstonedNodeIds:
         hash than the recorded tombstone. Tombstone is no longer active —
         the frame becomes pending again for one retry.
         """
-        _write_manifest(tmp_path, frame_hashes={"11:1": "h1-NEW"})
+        _write_manifest(tmp_path, frame_hashes={"11:1": "a1a1a1a1feedface"})
         fm = FigmaPageFrontmatter(
             file_key="fk",
             page_node_id="1:1",
             frames=["11:1"],
-            unresolvable_frames={"11:1": "h1-OLD"},
+            unresolvable_frames={"11:1": "a1a1a1a1deadbeef"},
         )
         assert active_tombstoned_node_ids(fm, tmp_path) == set()
 
@@ -156,7 +156,7 @@ class TestActiveTombstonedNodeIds:
             file_key="other-key",  # not in manifest
             page_node_id="1:1",
             frames=["11:1"],
-            unresolvable_frames={"11:1": "h1"},
+            unresolvable_frames={"11:1": "a1a1a1a1"},
         )
         assert active_tombstoned_node_ids(fm, tmp_path) == set()
 
@@ -168,12 +168,12 @@ class TestActiveTombstonedNodeIds:
 
 class TestPendingFiltersTombstones:
     def test_tombstoned_frame_is_not_pending_when_hash_matches(self, tmp_path: Path) -> None:
-        _write_manifest(tmp_path, frame_hashes={"11:1": "h1", "11:2": "h2"})
+        _write_manifest(tmp_path, frame_hashes={"11:1": "a1a1a1a1", "11:2": "b2b2b2b2"})
         md = tmp_path / "page.md"
         _write_page(
             md,
             frames=["11:1", "11:2"],
-            unresolvable_frames={"11:1": "h1"},
+            unresolvable_frames={"11:1": "a1a1a1a1"},
             body_unresolved_frames=["11:1", "11:2"],
         )
 
@@ -184,12 +184,12 @@ class TestPendingFiltersTombstones:
         """Content changed after tombstone → tombstone no longer active →
         frame pending again. This is the retry-on-change contract.
         """
-        _write_manifest(tmp_path, frame_hashes={"11:1": "h1-NEW"})
+        _write_manifest(tmp_path, frame_hashes={"11:1": "a1a1a1a1feedface"})
         md = tmp_path / "page.md"
         _write_page(
             md,
             frames=["11:1"],
-            unresolvable_frames={"11:1": "h1-OLD"},
+            unresolvable_frames={"11:1": "a1a1a1a1deadbeef"},
             body_unresolved_frames=["11:1"],
         )
 
@@ -206,7 +206,7 @@ class TestPendingFiltersTombstones:
         _write_page(
             md,
             frames=["11:1"],
-            unresolvable_frames={"11:1": "h1"},
+            unresolvable_frames={"11:1": "a1a1a1a1"},
             body_unresolved_frames=["11:1"],
         )
 
@@ -217,12 +217,12 @@ class TestPendingFiltersTombstones:
         """When every pending frame in a section is tombstoned+matching,
         the section is fully "done" and drops out of pending_sections.
         """
-        _write_manifest(tmp_path, frame_hashes={"11:1": "h1", "11:2": "h2"})
+        _write_manifest(tmp_path, frame_hashes={"11:1": "a1a1a1a1", "11:2": "b2b2b2b2"})
         md = tmp_path / "page.md"
         _write_page(
             md,
             frames=["11:1", "11:2"],
-            unresolvable_frames={"11:1": "h1", "11:2": "h2"},
+            unresolvable_frames={"11:1": "a1a1a1a1", "11:2": "b2b2b2b2"},
             body_unresolved_frames=["11:1", "11:2"],
         )
 
@@ -241,12 +241,12 @@ class TestEnrichmentInfoHonorsTombstones:
         unresolved row, the selector stops picking the file. This is what
         stops the hourly RED loop in figmaclaw#121.
         """
-        _write_manifest(tmp_path, frame_hashes={"11:1": "h1"})
+        _write_manifest(tmp_path, frame_hashes={"11:1": "a1a1a1a1"})
         md = tmp_path / "page.md"
         _write_page(
             md,
             frames=["11:1"],
-            unresolvable_frames={"11:1": "h1"},
+            unresolvable_frames={"11:1": "a1a1a1a1"},
             body_unresolved_frames=["11:1"],
         )
         # Anchor the schema to the current version so the "must update"
@@ -262,12 +262,12 @@ class TestEnrichmentInfoHonorsTombstones:
         assert needs_it is False
 
     def test_hash_drift_makes_file_enrichable_again(self, tmp_path: Path) -> None:
-        _write_manifest(tmp_path, frame_hashes={"11:1": "h1-NEW"})
+        _write_manifest(tmp_path, frame_hashes={"11:1": "a1a1a1a1feedface"})
         md = tmp_path / "page.md"
         _write_page(
             md,
             frames=["11:1"],
-            unresolvable_frames={"11:1": "h1-OLD"},
+            unresolvable_frames={"11:1": "a1a1a1a1deadbeef"},
             body_unresolved_frames=["11:1"],
         )
 
@@ -282,7 +282,7 @@ class TestEnrichmentInfoHonorsTombstones:
 
 class TestRecordTombstones:
     def test_writes_tombstones_with_current_manifest_hashes(self, tmp_path: Path) -> None:
-        _write_manifest(tmp_path, frame_hashes={"11:1": "h1", "11:2": "h2"})
+        _write_manifest(tmp_path, frame_hashes={"11:1": "a1a1a1a1", "11:2": "b2b2b2b2"})
         md = tmp_path / "page.md"
         _write_page(
             md,
@@ -295,10 +295,10 @@ class TestRecordTombstones:
 
         fm = parse_frontmatter(md.read_text())
         assert fm is not None
-        assert fm.unresolvable_frames == {"11:1": "h1", "11:2": "h2"}
+        assert fm.unresolvable_frames == {"11:1": "a1a1a1a1", "11:2": "b2b2b2b2"}
 
     def test_skips_node_ids_missing_from_manifest(self, tmp_path: Path) -> None:
-        _write_manifest(tmp_path, frame_hashes={"11:1": "h1"})  # no "11:2"
+        _write_manifest(tmp_path, frame_hashes={"11:1": "a1a1a1a1"})  # no "11:2"
         md = tmp_path / "page.md"
         _write_page(
             md,
@@ -310,15 +310,15 @@ class TestRecordTombstones:
         assert added == 1
         fm = parse_frontmatter(md.read_text())
         assert fm is not None
-        assert fm.unresolvable_frames == {"11:1": "h1"}
+        assert fm.unresolvable_frames == {"11:1": "a1a1a1a1"}
 
     def test_does_not_duplicate_existing_tombstones(self, tmp_path: Path) -> None:
-        _write_manifest(tmp_path, frame_hashes={"11:1": "h1"})
+        _write_manifest(tmp_path, frame_hashes={"11:1": "a1a1a1a1"})
         md = tmp_path / "page.md"
         _write_page(
             md,
             frames=["11:1"],
-            unresolvable_frames={"11:1": "h1"},
+            unresolvable_frames={"11:1": "a1a1a1a1"},
             body_unresolved_frames=["11:1"],
         )
 
@@ -326,7 +326,7 @@ class TestRecordTombstones:
         assert added == 0
 
     def test_preserves_body_verbatim(self, tmp_path: Path) -> None:
-        _write_manifest(tmp_path, frame_hashes={"11:1": "h1"})
+        _write_manifest(tmp_path, frame_hashes={"11:1": "a1a1a1a1"})
         md = tmp_path / "page.md"
         _write_page(
             md,
@@ -372,12 +372,12 @@ class TestKeySetInvariantAppliesToTombstones:
         )
         fm_text = build_page_frontmatter(
             page,
-            unresolvable_frames={"11:1": "h1", "DEAD:1": "h-dead"},
+            unresolvable_frames={"11:1": "a1a1a1a1", "DEAD:1": "deaddead"},
         )
 
         parsed = parse_frontmatter(f"{fm_text}\n\n# body\n")
         assert parsed is not None
-        assert parsed.unresolvable_frames == {"11:1": "h1"}
+        assert parsed.unresolvable_frames == {"11:1": "a1a1a1a1"}
         assert "DEAD:1" not in parsed.unresolvable_frames
 
 
@@ -401,7 +401,7 @@ class TestCrossRunIdempotency:
         are meant to close. Without tombstones, run 2 would keep
         selecting the file forever.
         """
-        _write_manifest(tmp_path, frame_hashes={"11:1": "h1"})
+        _write_manifest(tmp_path, frame_hashes={"11:1": "a1a1a1a1"})
         md = tmp_path / "page.md"
         _write_page(
             md,

--- a/tests/test_tombstone_validation.py
+++ b/tests/test_tombstone_validation.py
@@ -1,0 +1,123 @@
+"""Validation tests for unresolvable_frames (security review of figmaclaw#121).
+
+The pydantic model rejects tombstones whose shape could indicate
+corruption, hand-edit mistakes, or malicious injection:
+
+- keys must match Figma node_id format (``<number>:<number>``)
+- values must be short lowercase hex (content hash shape)
+- tombstones for node_ids not in ``frames`` are pruned on parse
+
+Strict parse-time validation is the belt-and-braces pair to the
+chokepoint prune in ``_build_frontmatter`` — no orphan or malformed
+tombstone can surface to downstream code, regardless of how the bad
+value got onto disk (hand edit, bad merge, tampering).
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from figmaclaw.figma_frontmatter import FigmaPageFrontmatter
+
+
+def _base_kwargs(**overrides):
+    return {
+        "file_key": "fk",
+        "page_node_id": "1:1",
+        "frames": ["11:1", "11:2"],
+        **overrides,
+    }
+
+
+class TestNodeIdShape:
+    def test_rejects_non_numeric_node_id(self) -> None:
+        with pytest.raises(ValidationError, match="not a valid Figma"):
+            FigmaPageFrontmatter(**_base_kwargs(unresolvable_frames={"evil-key": "abc123"}))
+
+    def test_rejects_node_id_missing_colon(self) -> None:
+        with pytest.raises(ValidationError, match="not a valid Figma"):
+            FigmaPageFrontmatter(**_base_kwargs(unresolvable_frames={"1234": "abc123"}))
+
+    def test_accepts_valid_figma_node_id(self) -> None:
+        fm = FigmaPageFrontmatter(**_base_kwargs(unresolvable_frames={"11:1": "abc123"}))
+        assert fm.unresolvable_frames == {"11:1": "abc123"}
+
+
+class TestHashShape:
+    def test_rejects_non_hex_hash(self) -> None:
+        with pytest.raises(ValidationError, match="not lowercase hex"):
+            FigmaPageFrontmatter(**_base_kwargs(unresolvable_frames={"11:1": "NOT-A-HASH"}))
+
+    def test_rejects_uppercase_hex(self) -> None:
+        """Standardize on lowercase hex — matches how frame_hash is written."""
+        with pytest.raises(ValidationError, match="not lowercase hex"):
+            FigmaPageFrontmatter(**_base_kwargs(unresolvable_frames={"11:1": "ABCDEF"}))
+
+    def test_rejects_empty_hash(self) -> None:
+        with pytest.raises(ValidationError, match="length 0"):
+            FigmaPageFrontmatter(**_base_kwargs(unresolvable_frames={"11:1": ""}))
+
+    def test_rejects_oversized_hash(self) -> None:
+        """Cap prevents frontmatter bloat from malicious/corrupt input."""
+        with pytest.raises(ValidationError, match="out of range"):
+            FigmaPageFrontmatter(**_base_kwargs(unresolvable_frames={"11:1": "a" * 100}))
+
+
+class TestOrphanPruneOnParse:
+    def test_orphan_tombstones_are_pruned_on_parse(self) -> None:
+        """A tombstone for a node_id not in `frames` is dropped on parse.
+
+        Defense-in-depth for the `_build_frontmatter` chokepoint: even
+        if a bad commit lands, downstream code never sees the orphan.
+        """
+        fm = FigmaPageFrontmatter(
+            **_base_kwargs(
+                # DEAD:1 fails the node_id shape AND is not in frames — the
+                # shape validator would reject it first. Use a key that
+                # passes shape but isn't in frames so we exercise the
+                # ⊆-frames prune specifically.
+                unresolvable_frames={"11:1": "abc123", "99:99": "def456"},
+            )
+        )
+        assert fm.unresolvable_frames == {"11:1": "abc123"}
+        assert "99:99" not in fm.unresolvable_frames
+
+    def test_empty_tombstones_with_non_empty_frames_is_fine(self) -> None:
+        fm = FigmaPageFrontmatter(**_base_kwargs(unresolvable_frames={}))
+        assert fm.unresolvable_frames == {}
+
+
+class TestFenceAwareWalker:
+    """Pins the fence-awareness of figma_md_parse's canonical walker.
+
+    Design review of figmaclaw#121: the CLAUDE.md policy claims a single
+    canonical body walker, but figma_md_parse._collect_frames_in_range
+    previously did not track fences. A fenced code block containing a
+    frame-row-shaped line would be walked as if real. Now both walkers
+    (this one and body_validation.iter_body_frame_rows) agree.
+    """
+
+    def test_collect_frames_skips_rows_inside_fence(self) -> None:
+        from figmaclaw.figma_md_parse import section_line_ranges
+
+        md = """## Section (`10:1`)
+
+| Screen | Node ID | Description |
+|--------|---------|-------------|
+| Real | `11:1` | desc |
+
+```
+| Fake | `DEAD:1` | in a fence |
+```
+
+| Screen | Node ID | Description |
+|--------|---------|-------------|
+| Real | `11:2` | desc |
+"""
+        ranges = section_line_ranges(md)
+        assert len(ranges) == 1
+        section, _, _ = ranges[0]
+        node_ids = {f.node_id for f in section.frames}
+        assert node_ids == {"11:1", "11:2"}
+        assert "DEAD:1" not in node_ids

--- a/tests/test_verdict.py
+++ b/tests/test_verdict.py
@@ -295,31 +295,141 @@ class TestRow7ClassicFailure:
         assert v.row == "row 7"
 
 
+class TestRow9AllStuckYellow:
+    """Row 9: every attempted file hit NO-PROGRESS → YELLOW (exit 0).
+
+    Incident context: in figmaclaw#121, the linear-git nightly sync ran
+    hourly for 24+ hours with the same 6 files stuck in NO-PROGRESS. The
+    old verdict mapped this to row 6 "silent dispatch failure" (RED), so
+    CI was RED every hour and real regressions would have been hidden.
+    Row 9 recognizes it as a known steady state instead.
+    """
+
+    def test_all_attempted_stuck_is_yellow_exit_zero(self) -> None:
+        v = compute_verdict(
+            files_selected=68,
+            work_attempted=6,
+            commits_made=0,
+            errors=0,
+            budget_exhausted=False,
+            skipped_no_work=0,
+            stuck=6,
+        )
+        assert v.exit_code == EXIT_GREEN  # YELLOW shares GREEN's exit code
+        assert v.row == "row 9"
+        assert "yellow" in v.label.lower()
+        assert "stuck" in v.label.lower()
+
+    def test_mixed_stuck_and_unstuck_no_commits_stays_row_6(self) -> None:
+        """If even one attempted file was not stuck (and no commits landed),
+        the run is still a silent dispatch failure, not all-stuck.
+
+        Pins the precise row 9 condition: ``stuck == work_attempted``, not
+        ``stuck > 0``. This prevents row 9 from swallowing real regressions
+        in runs where most files stalled for a legitimate bug.
+        """
+        v = compute_verdict(
+            files_selected=10,
+            work_attempted=5,
+            commits_made=0,
+            errors=0,
+            budget_exhausted=False,
+            skipped_no_work=0,
+            stuck=4,  # 4 of 5 stuck — not ALL
+        )
+        assert v.exit_code == EXIT_RED
+        assert v.row == "row 6"
+
+    def test_stuck_with_commits_is_not_row_9(self) -> None:
+        """Row 9 requires zero commits. If any commit landed, that file is
+        not stuck for the purposes of the verdict — fall through to rows
+        2/3/4a/4b as usual.
+        """
+        v = compute_verdict(
+            files_selected=6,
+            work_attempted=6,
+            commits_made=2,
+            errors=0,
+            budget_exhausted=False,
+            skipped_no_work=0,
+            stuck=4,
+        )
+        # commits made + no errors → row 2 (clean completion)
+        assert v.exit_code == EXIT_GREEN
+        assert v.row == "row 2"
+
+    def test_phantom_selection_beats_all_stuck(self) -> None:
+        """Row 5 (phantom selection) outranks row 9, always.
+
+        A phantom-selected file is a selector/dispatcher bug that must
+        never be hidden — even behind an otherwise-steady all-stuck run.
+        """
+        v = compute_verdict(
+            files_selected=10,
+            work_attempted=5,
+            commits_made=0,
+            errors=0,
+            budget_exhausted=False,
+            skipped_no_work=1,
+            stuck=5,
+        )
+        assert v.exit_code == EXIT_RED
+        assert v.row == "row 5"
+
+    def test_default_stuck_is_zero_preserving_existing_rows(self) -> None:
+        """Callers that have not yet been updated to pass `stuck` must see
+        the exact same verdict they got before row 9 was introduced.
+
+        This is a backward-compat pin — if a future edit accidentally
+        changes the default, pre-row-9 counter tuples would shift verdicts.
+        """
+        v_without = compute_verdict(
+            files_selected=3,
+            work_attempted=3,
+            commits_made=0,
+            errors=0,
+            budget_exhausted=False,
+            skipped_no_work=0,
+        )
+        v_with_zero = compute_verdict(
+            files_selected=3,
+            work_attempted=3,
+            commits_made=0,
+            errors=0,
+            budget_exhausted=False,
+            skipped_no_work=0,
+            stuck=0,
+        )
+        assert v_without == v_with_zero
+        assert v_without.row == "row 6"  # silent dispatch, as before
+
+
 # ---------------------------------------------------------------------------
-# Exit code contract — every RED must map to exit 2, every GREEN to 0.
+# Exit code contract — every RED must map to exit 2, every GREEN/YELLOW to 0.
 # ---------------------------------------------------------------------------
 
 
 class TestExitCodeContract:
-    """No 'soft red' — every RED label pairs with EXIT_RED, every GREEN with EXIT_GREEN."""
+    """Every RED label pairs with EXIT_RED; every GREEN/YELLOW with EXIT_GREEN."""
 
-    # (files_selected, work_attempted, commits_made, errors, budget_exhausted, skipped_no_work)
-    SCENARIOS: list[tuple[int, int, int, int, bool, int]] = [
-        (0, 0, 0, 0, False, 0),  # row 1
-        (5, 5, 5, 0, False, 0),  # row 2
-        (5, 3, 3, 0, True, 0),  # row 3
-        (10, 10, 9, 1, False, 0),  # row 4a
-        (10, 10, 3, 7, False, 0),  # row 4b
-        (5, 4, 4, 0, False, 1),  # row 5
-        (3, 3, 0, 0, False, 0),  # row 6
-        (3, 3, 0, 3, False, 0),  # row 7
+    # (files_selected, work_attempted, commits_made, errors, budget_exhausted, skipped_no_work, stuck)
+    SCENARIOS: list[tuple[int, int, int, int, bool, int, int]] = [
+        (0, 0, 0, 0, False, 0, 0),  # row 1
+        (5, 5, 5, 0, False, 0, 0),  # row 2
+        (5, 3, 3, 0, True, 0, 0),  # row 3
+        (10, 10, 9, 1, False, 0, 0),  # row 4a
+        (10, 10, 3, 7, False, 0, 0),  # row 4b
+        (5, 4, 4, 0, False, 1, 0),  # row 5
+        (3, 3, 0, 0, False, 0, 0),  # row 6
+        (3, 3, 0, 3, False, 0, 0),  # row 7
+        (6, 6, 0, 0, False, 0, 6),  # row 9
     ]
 
     def _verdict(
         self,
-        scenario: tuple[int, int, int, int, bool, int],
+        scenario: tuple[int, int, int, int, bool, int, int],
     ) -> RunVerdict:
-        fs, wa, cm, er, be, sn = scenario
+        fs, wa, cm, er, be, sn, st = scenario
         return compute_verdict(
             files_selected=fs,
             work_attempted=wa,
@@ -327,18 +437,19 @@ class TestExitCodeContract:
             errors=er,
             budget_exhausted=be,
             skipped_no_work=sn,
+            stuck=st,
         )
 
     def test_label_color_matches_exit_code(self) -> None:
         for s in self.SCENARIOS:
             v = self._verdict(s)
-            if v.label.startswith("GREEN"):
+            if v.label.startswith(("GREEN", "YELLOW")):
                 assert v.exit_code == EXIT_GREEN, f"{s} -> {v}"
             elif v.label.startswith("RED"):
                 assert v.exit_code == EXIT_RED, f"{s} -> {v}"
             else:
                 raise AssertionError(
-                    f"verdict label must start with GREEN or RED: {v.label}",
+                    f"verdict label must start with GREEN/YELLOW/RED: {v.label}",
                 )
 
 


### PR DESCRIPTION
Closes #121.

## Summary

Fixes the cross-run enrichment loop that burned ~5 min of CI hourly for 24+ hours in gigaverse-app/linear-git on the same 6 files, and adds the preventative invariants + tests + review policy to stop the same category of bugs from recurring via a different field, marker, walker, or log writer.

All six items from issue #121 ship in this PR plus CLAUDE.md policy and a bonus date-sensitive test fix.

## Commits

1. **Frame-keyed key-set invariant at `_build_frontmatter` chokepoint** — `keys(enriched_frame_hashes | raw_frames | raw_tokens | frame_sections) ⊆ frames`. Directly fixes the showcase-v2 orphan graveyard.
2. **Body orphan row prune at pull time** — structural row removal via the canonical `body_validation.iter_body_frame_rows` walker (pydantic `BodyFrameRow`). `body_frame_node_ids` is a one-line projection — single source of truth, no re-walking.
3. **Verdict row 9 YELLOW when all attempted files hit NO-PROGRESS** — `stuck` counter threaded through dispatcher. All-stuck runs exit 0 instead of RED row 6.
4. **Anti-loop engineering policy in CLAUDE.md** — documents the five missing dimensions (cross-run invariants, cross-field key-set, terminal states, canonical walker reuse, log writer self-healing) + review checklist.
5. **Fix pre-existing date-sensitive `test_diff` failure** — test was mixing pinned `_PINNED_NOW` with wall-clock `datetime.now()`.
6. **DRY: hoist frame-id extraction, thread `allowed_frame_ids` through pull** — new `page_frame_ids` / `section_frame_ids` helpers in `figma_render`; removes the re-parse hack in `_rewrite_frontmatter_preserving_body`.
7. **Unresolvable-frame tombstones** — proper terminal state for NO-PROGRESS frames. New `unresolvable_frames` frontmatter field. `pending_*` / `enrichment_info` filter tombstones whose hash matches the manifest. Auto-invalidates on content change (one retry per change). Selector/dispatcher parity maintained by threading `repo_dir` through both.
8. **Self-healing enrichment-log writer** — unrecognized schemas auto-archive (`<log>.bak.<UTC-timestamp><ext>`) and reset to schema-v1. The WARN-and-drop terminal state that lost the entire linear-git incident's log history is gone. Run 1 heals, run 2 appends normally — pinned by a cross-run test.
9. **Cross-run idempotency tests** — `tests/test_cross_run_idempotency.py` — the test shape the suite was missing. Replays the incident shape; asserts run 2 is a no-op after run 1's tombstones; retry-on-content-change; partial-progress still works; legacy callers without `repo_dir` unchanged.
10. **Refine CLAUDE.md log-writer policy** — policy #5 now promotes the middle-ground auto-archive option (implemented in commit 8) between "migrate" and "hard-fail".

## Why all six fit in one PR

The deferrals I initially proposed were weak on review:
- The design for each was already in issue #121 — not unknown work.
- Policy #3 in the CLAUDE.md section I just wrote explicitly says "retryable marker and tombstone must ship in the same PR". Deferring tombstones would contradict the policy.
- Smaller PRs don't actually de-risk: if tombstones had a bug, the fix would land in a follow-up anyway. Meanwhile every hour without them, linear-git's 6 stuck files drift further.

## Missing dimensions the existing suite wasn't exercising — now covered

| dimension | test file | pinned shape |
|---|---|---|
| Cross-run state invariants | `test_cross_run_idempotency.py` | state_0 → run → state_1 → run → state_2 relationships |
| Cross-field frontmatter key-set invariants | `test_frontmatter_key_set_invariant.py` | `keys(d) ⊆ frames` for every frame-keyed dict |
| Terminal-state completeness | `test_tombstone_protocol.py` | tombstones active↔inactive on hash, selector/dispatcher parity |
| Canonical walker reuse | `test_body_validation.py` (DRY contract) | `body_frame_node_ids` == projection over iterator |
| Log-writer self-healing | `test_claude_run.py` (new self-heal tests) | run 1 heals, run 2 no re-warn |

## Canonical walker consolidation

Body frame-row iteration now has exactly one canonical implementation: `body_validation.iter_body_frame_rows`. Fence-aware, exact rendered header matching, yields `BodyFrameRow` pydantic models with `line_index` and `node_id`. `body_frame_node_ids` is a thin projection. `pull_logic._prune_orphan_frame_rows` consumes the same iterator. No re-walking, no duplicated section/row/fence logic, no `re` imports anywhere outside `figma_schema`.

## Tests

```
uv run pytest
```

**924 passed, 2 errors** — the 2 errors are the MCP smoke tests that require `FIGMA_MCP_TOKEN` (separate credential not in the linear-git `.env`). No regressions. All prior-PR surface-area tests (#88, #92, #103, #112, #117) still pass — verified by running the exact test files that pinned each of those PRs' invariants.

## Immediate effect on linear-git

Once released and picked up by the next nightly sync:

- **showcase-v2-11550-42383.md** — next pull prunes ~100 orphan `enriched_frame_hashes` + ~60 orphan body rows; file becomes enrichable.
- **Other 5 stuck files** — first run writes tombstones, subsequent runs skip the files until Figma content changes.
- **Verdict** — row 9 YELLOW (exit 0) on runs where all attempted files are stuck; row 2 GREEN on normal runs; row 6 RED remains for actual silent dispatch failures.
- **Enrichment log** — the broken header drifting since 2026-04-16 gets auto-archived on the next run; fresh log takes over; no more hourly WARN.

## Test plan
- [ ] CI green on this branch
- [ ] Manually replay a stuck fixture through `claude-run` — should log `stuck=N` and verdict `YELLOW (row 9)`
- [ ] Run `figmaclaw pull` against showcase-v2 stuck fixture — confirm orphan keys + body rows + stale schema_version are all cleaned

🤖 Generated with [Claude Code](https://claude.com/claude-code)
