### PR TITLE
Normalize on encounter: heal stuck files from every entry point (#123)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -218,6 +218,31 @@ Never accept "warn and forget every run" as a terminal state. The test
 shape that pins this: run 1 with bad input triggers the heal, run 2
 with no new bad input does NOT re-emit the error.
 
+### 6. Invariants heal at every entry, not only at write
+
+A structural invariant that fires only when WE write a file leaves
+files written by older figmaclaw versions, hand-edited files, or
+merge-conflict resolutions in a violating state. Readers that only
+read (no write) will encounter these files and see inconsistent state.
+
+**Every selection/entry boundary must call `normalize_page_file`** (or
+go through something that does — e.g. `enrichment_info`) as its first
+step. The function is the one canonical "heal on encounter" entry
+point; it composes the same helpers the write paths use, so there's
+no second implementation to drift.
+
+Known entry points (keep the test in
+`tests/test_entry_point_heals.py` updated when adding a new one):
+- `claude_run.enrichment_info` — calls `normalize_page_file` at top
+- `pull.*` — goes through `_build_frontmatter` chokepoint on write
+- Direct `normalize_page_file` (CLI, scripted use)
+
+If you add a new code path that reads a page `.md`, register it in
+`_HEALING_ENTRY_POINTS` in the parametric test. Either it heals and
+the test passes, or you have to explain in comments why your path
+specifically doesn't need to heal. Silent exceptions to this rule
+reintroduce the figmaclaw#121 / #123 category.
+
 ### Review checklist for enrichment / pull / logging PRs
 
 - [ ] Does this PR add a loop-break? If yes, does it have a cross-run
@@ -231,3 +256,6 @@ with no new bad input does NOT re-emit the error.
       `iter_body_frame_rows` / `section_line_ranges` (dimension 4)?
 - [ ] Does this PR touch a log writer? If yes, does it auto-heal or
       hard-fail on schema drift (dimension 5)?
+- [ ] Does this PR add a new selection/entry boundary that reads a
+      page `.md`? If yes, is it registered in `_HEALING_ENTRY_POINTS`
+      and does it call `normalize_page_file` (dimension 6)?

--- a/figmaclaw/commands/claude_run.py
+++ b/figmaclaw/commands/claude_run.py
@@ -42,6 +42,7 @@ from figmaclaw.figma_parse import parse_frontmatter, split_frontmatter
 from figmaclaw.figma_render import rebuild_frontmatter_from_parsed
 from figmaclaw.figma_schema import unresolved_row_node_id
 from figmaclaw.figma_sync_state import FigmaSyncState
+from figmaclaw.normalize import normalize_page_file
 from figmaclaw.schema_status import enrichment_schema_status
 from figmaclaw.staleness import active_tombstoned_node_ids
 from figmaclaw.verdict import (
@@ -502,26 +503,13 @@ def _exclude_non_enrichable_markdown(files: list[Path]) -> tuple[list[Path], int
     return filtered, len(files) - len(filtered)
 
 
-def _migrate_missing_enrichment_schema_version(md_path: Path, text: str) -> str:
-    """Backfill explicit ``enriched_schema_version`` when missing.
-
-    Migration is body-preserving and idempotent. Missing version is written as ``0``
-    so selector/inspect parity treats legacy pages as ENRICH MUST.
-    """
-    parts = split_frontmatter(text)
-    if parts is None:
-        return text
-    fm_block, body = parts
-    if "enriched_schema_version:" in fm_block:
-        return text
-    if "file_key:" not in fm_block:
-        return text
-
-    new_fm_block = f"{fm_block.rstrip()}\nenriched_schema_version: 0"
-    migrated = f"---\n{new_fm_block}\n---\n{body}"
-    if migrated != text:
-        md_path.write_text(migrated)
-    return migrated
+# Note: the former ``_migrate_missing_enrichment_schema_version`` helper
+# was subsumed by :func:`figmaclaw.normalize.normalize_page_file`, which
+# applies the same schema-version backfill plus every other structural
+# invariant (frame-keyed dict key-set, body orphan row prune). See
+# figmaclaw#123. Callers that used to invoke the migration directly
+# should call ``normalize_page_file`` instead — it's the single canonical
+# "heal on encounter" entry point.
 
 
 def enrichment_info(md_path: Path, repo_dir: Path | None = None) -> tuple[bool, int]:
@@ -542,6 +530,12 @@ def enrichment_info(md_path: Path, repo_dir: Path | None = None) -> tuple[bool, 
     if _is_non_enrichable_markdown(md_path):
         return False, 0
 
+    # Heal on encounter (figmaclaw#123): canonical entry point applies
+    # every structural invariant — schema-version backfill, frame-keyed
+    # dict key-set, body orphan row prune — before any selector logic
+    # runs. Idempotent; a normalized file passes through unchanged.
+    normalize_page_file(md_path)
+
     try:
         text = md_path.read_text()
     except OSError:
@@ -550,8 +544,6 @@ def enrichment_info(md_path: Path, repo_dir: Path | None = None) -> tuple[bool, 
     # Must have figmaclaw-like frontmatter to be enrichable.
     if "file_key:" not in text:
         return False, 0
-
-    text = _migrate_missing_enrichment_schema_version(md_path, text)
 
     # Frame-size estimate from canonical body parser (frame sections only).
     frame_count = frame_row_count(text)

--- a/figmaclaw/commands/pull.py
+++ b/figmaclaw/commands/pull.py
@@ -19,6 +19,7 @@ from figmaclaw.figma_utils import parse_since
 from figmaclaw.git_utils import git_commit, git_push
 from figmaclaw.prune_utils import prune_file_artifacts_from_manifest
 from figmaclaw.pull_logic import PullResult, pull_file
+from figmaclaw.schema_status import is_pull_schema_stale
 from figmaclaw.status_markers import COMMIT_MSG_PREFIX, HAS_MORE_TRUE
 
 
@@ -369,11 +370,21 @@ async def _run(
             #     skip — if it's not reachable via the listing, it can't have changed
             #   - listing_lm == stored → last_modified unchanged; skip
             #   - listing_lm != stored → file changed; proceed to get_file_meta
+            #
+            # Exception (figmaclaw#123): a tracked file whose
+            # ``pull_schema_version`` is below CURRENT must be pulled even
+            # if Figma reports it unchanged — otherwise schema bumps never
+            # reach files that are idle on the Figma side. Before this
+            # escape hatch, the linear-git showcase-v2 stuck case sat in
+            # a listing-match skip forever and the v7 refresh never fired.
             if not force and listing_last_modified is not None:
                 listing_lm = listing_last_modified.get(key)
                 stored_entry = state.manifest.files.get(key)
                 stored_lm = stored_entry.last_modified if stored_entry else ""
-                if listing_lm is None or stored_lm == listing_lm:
+                stored_schema = stored_entry.pull_schema_version if stored_entry else 0
+                schema_needs_refresh = is_pull_schema_stale(stored_schema)
+                unchanged_on_figma = listing_lm is None or stored_lm == listing_lm
+                if unchanged_on_figma and not schema_needs_refresh:
                     obs.files_skipped_prefilter += 1
                     obs.file_end(key, "listing_prefilter_skip", file_start)
                     continue

--- a/figmaclaw/normalize.py
+++ b/figmaclaw/normalize.py
@@ -1,0 +1,220 @@
+"""In-place structural normalization for figmaclaw page files (figmaclaw#123).
+
+Every selection/entry boundary in figmaclaw that READS a page file must
+call :func:`normalize_page_file` as its first step. The function is
+idempotent — calling it twice makes zero changes on the second call —
+and narrowly structural: it never touches prose, section intros,
+Mermaid charts, or any body content other than canonical frame rows
+whose node_id is objectively invalid (not in ``frames``).
+
+Why this exists
+---------------
+figmaclaw invariants (see CLAUDE.md anti-loop policy) are enforced at
+WRITE time: the ``_build_frontmatter`` chokepoint prunes frame-keyed
+dicts, ``_rewrite_frontmatter_preserving_body`` drops orphan body rows.
+But write time is not the only time a file can enter a bad state:
+
+- A file written by an older figmaclaw version predates a newer invariant.
+- A merge conflict resolution can land inconsistent state on disk.
+- A hand edit can violate shape rules.
+- A pull pass that's filtered out by ``--since`` never touches a file,
+  so its write-time invariants never fire on that file.
+
+Meanwhile, multiple code paths READ these files without writing:
+``claude-run`` walks the filesystem and dispatches enrichment, ``inspect``
+renders a summary, etc. If only writers heal, readers encounter stuck
+state repeatedly.
+
+The fix is an explicit, shared healing entry point that every reader
+calls. This is that entry point.
+
+DRY by construction
+-------------------
+This module introduces NO new parsing, NO new invariant logic, NO new
+write path. It composes three existing canonical helpers:
+
+- :func:`figma_render.rebuild_frontmatter_from_parsed` — rebuilds the
+  YAML frontmatter through the ``_build_frontmatter`` chokepoint, which
+  already prunes frame-keyed dicts to ``⊆ frames`` and serializes
+  ``unresolvable_frames`` validated by the parse-time validator.
+- :func:`body_validation.iter_body_frame_rows` (via
+  ``pull_logic._prune_orphan_frame_rows``) — the canonical fence-aware
+  frame-row walker; orphan rows are dropped, prose untouched.
+- ``_backfill_schema_version`` (below) — moved here from
+  ``claude_run._migrate_missing_enrichment_schema_version``; it's the
+  same operation, just called from a single canonical location now.
+
+If you find yourself tempted to add a fourth helper, ask whether it
+belongs in one of the three places above instead — keep this module
+a composition, not a reimplementation.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pydantic
+
+from figmaclaw.figma_parse import parse_frontmatter, split_frontmatter
+
+
+class NormalizationResult(pydantic.BaseModel):
+    """Observable outcome of a :func:`normalize_page_file` call.
+
+    Frozen pydantic model (per CLAUDE.md conventions) so callers can
+    rely on it being hashable/comparable in tests and assertions.
+
+    ``changed`` is the primary bit: False means the file was already
+    in a normalized state (or couldn't be normalized — check ``reason``).
+    True means bytes on disk changed.
+
+    The per-invariant counters are for observability. They are exact,
+    not estimates: each one counts a specific structural operation that
+    was applied. Downstream summarization code should sum them for a
+    top-line "structural actions applied" metric rather than computing
+    the numbers by diffing text.
+    """
+
+    model_config = pydantic.ConfigDict(frozen=True)
+
+    changed: bool = False
+    reason: str = ""
+    schema_version_backfilled: bool = False
+    frame_keyed_dict_orphans_pruned: int = 0
+    body_orphan_rows_pruned: int = 0
+
+
+def _backfill_schema_version(text: str) -> tuple[str, bool]:
+    """Ensure ``enriched_schema_version`` field is present in frontmatter.
+
+    Migrated from :func:`claude_run._migrate_missing_enrichment_schema_version`;
+    behavior is byte-for-byte identical. Returns ``(possibly-migrated-text,
+    was_migrated)``.
+
+    Legacy figmaclaw pages lacked an explicit ``enriched_schema_version``.
+    The selector/inspect parity contract (figmaclaw#111) requires the field
+    to always be present; missing is treated as ``0`` (= ENRICH MUST).
+    """
+    parts = split_frontmatter(text)
+    if parts is None:
+        return text, False
+    fm_block, body = parts
+    if "enriched_schema_version:" in fm_block:
+        return text, False
+    if "file_key:" not in fm_block:
+        return text, False
+    new_fm_block = f"{fm_block.rstrip()}\nenriched_schema_version: 0"
+    return f"---\n{new_fm_block}\n---\n{body}", True
+
+
+def _count_frame_keyed_orphans(fm: object, allowed: set[str]) -> int:
+    """Count entries in frame-keyed dicts whose key is not in *allowed*.
+
+    Uses :attr:`figma_frontmatter.FigmaPageFrontmatter` attributes
+    directly rather than hard-coding the field names, so adding a new
+    frame-keyed dict in the model only requires registering it in
+    ``_FRAME_KEYED_DICT_FIELDS`` below. Kept in sync with the chokepoint
+    prune in :func:`figma_render._build_frontmatter`.
+    """
+    total = 0
+    for field_name in _FRAME_KEYED_DICT_FIELDS:
+        d = getattr(fm, field_name, None) or {}
+        total += sum(1 for k in d if k not in allowed)
+    return total
+
+
+# Single source of truth for which frontmatter fields are frame-keyed
+# dicts. Kept in lockstep with the prune call-list in
+# ``figma_render._build_frontmatter`` via a guardrail test
+# (``test_frame_keyed_dict_fields_match_chokepoint``).
+_FRAME_KEYED_DICT_FIELDS: tuple[str, ...] = (
+    "enriched_frame_hashes",
+    "raw_frames",
+    "raw_tokens",
+    "frame_sections",
+    "unresolvable_frames",
+)
+
+
+def normalize_page_file(md_path: Path) -> NormalizationResult:
+    """Apply every structural invariant to *md_path* in-place.
+
+    Invariants applied, in order:
+
+    1. ``enriched_schema_version`` field exists in frontmatter
+       (backfilled to 0 if missing) — selector/inspect parity.
+    2. Frame-keyed dict keys ⊆ ``frames`` — pruned through the
+       ``_build_frontmatter`` chokepoint (enriched_frame_hashes,
+       raw_frames, raw_tokens, frame_sections, unresolvable_frames).
+    3. Canonical body frame rows with node_id ∉ ``frames`` are dropped.
+    4. ``unresolvable_frames`` shape and size — already enforced by the
+       pydantic validator on parse, so simply parsing-then-rewriting
+       normalizes any legacy on-disk shape that passed the validator.
+
+    Idempotent: a normalized file passed through this function is
+    byte-for-byte unchanged and returns ``NormalizationResult(changed=False)``.
+
+    Body prose is preserved verbatim. This function is the one narrow
+    exception to "code never rewrites body," and only within the scope
+    the body-preservation invariants (BP-1 through BP-6) already permit:
+    structural removal of canonical rows that point to frames not in
+    the authoritative ``frames`` list.
+
+    Safe to call on non-figmaclaw files — returns ``changed=False,
+    reason='no frontmatter'`` when the file isn't a figmaclaw page.
+    """
+    from figmaclaw.figma_render import rebuild_frontmatter_from_parsed
+    from figmaclaw.pull_logic import _prune_orphan_frame_rows
+
+    try:
+        original = md_path.read_text()
+    except OSError as exc:
+        return NormalizationResult(reason=f"read failed: {exc}")
+
+    # Invariant 1: backfill schema_version before parsing so pydantic
+    # validators see a canonical frontmatter.
+    after_backfill, did_backfill = _backfill_schema_version(original)
+
+    # Parse. The pydantic model runs its validators here, which already
+    # enforce the ``unresolvable_frames`` shape + ⊆ frames invariants on
+    # the parsed model (see figmaclaw#121 security review).
+    try:
+        fm = parse_frontmatter(after_backfill)
+    except Exception as exc:
+        return NormalizationResult(reason=f"parse failed: {exc}")
+    if fm is None:
+        return NormalizationResult(reason="no frontmatter")
+
+    parts = split_frontmatter(after_backfill)
+    if parts is None:
+        return NormalizationResult(reason="split failed")
+    _, body = parts
+
+    allowed = set(fm.frames)
+
+    # Invariant 2: frame-keyed dict key-set. Re-rendering through the
+    # chokepoint applies the prune. Counting orphans BEFORE the rebuild
+    # (not via diff after) keeps the counter exact.
+    orphan_dict_count = _count_frame_keyed_orphans(fm, allowed)
+    new_fm = rebuild_frontmatter_from_parsed(fm)
+
+    # Invariant 3: body orphan frame rows. Use the canonical walker.
+    body_lines_before = body.count("\n")
+    new_body = _prune_orphan_frame_rows(body, allowed) if allowed else body
+    body_lines_after = new_body.count("\n")
+    orphan_rows_count = body_lines_before - body_lines_after
+
+    new_text = f"{new_fm}\n{new_body}"
+    if new_text == original:
+        return NormalizationResult(
+            changed=False,
+            schema_version_backfilled=did_backfill,
+        )
+
+    md_path.write_text(new_text)
+    return NormalizationResult(
+        changed=True,
+        schema_version_backfilled=did_backfill,
+        frame_keyed_dict_orphans_pruned=orphan_dict_count,
+        body_orphan_rows_pruned=orphan_rows_count,
+    )

--- a/tests/test_entry_point_heals.py
+++ b/tests/test_entry_point_heals.py
@@ -1,0 +1,157 @@
+"""Parametric invariant: every selection/entry boundary heals stuck files.
+
+Issue: figmaclaw#123 — structural invariants must heal on encounter.
+
+The bug shape this test pins: a file with known invariant violations
+(orphan enriched_frame_hashes, orphan body rows, missing
+enriched_schema_version) must be healed on the very next invocation of
+any entry point that reads it. Without this, a reader-only path
+(claude-run selection, inspect) can encounter stuck state hour after
+hour and never trigger the healing logic that lives in write paths.
+
+Adding a new selection/entry boundary later? Add it to
+``_HEALING_ENTRY_POINTS`` below and the test will automatically
+exercise it. If your new entry point doesn't call
+``normalize_page_file`` (or equivalent), this test fails and you're
+told to wire it.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from pathlib import Path
+
+import pytest
+
+from figmaclaw.commands.claude_run import enrichment_info
+from figmaclaw.figma_parse import parse_frontmatter
+from figmaclaw.normalize import normalize_page_file
+
+# A "stuck" fixture: exactly the shape of the linear-git incident files
+# — orphan enriched_frame_hashes entry, orphan body row, missing
+# schema_version.
+_STUCK_FIXTURE = """---
+file_key: fk
+page_node_id: '1:1'
+frames: ['11:1']
+enriched_frame_hashes: {'11:1': aaaaaaaa, 'DEAD:1': deadbeef}
+---
+
+# Page
+
+## Section (`10:1`)
+
+| Screen | Node ID | Description |
+|--------|---------|-------------|
+| Kept | `11:1` | Real description. |
+| Ghost | `DEAD:1` | (no screenshot available) |
+"""
+
+
+def _invoke_normalize(md: Path) -> None:
+    """Direct call — baseline for what "healing" means."""
+    normalize_page_file(md)
+
+
+def _invoke_enrichment_info(md: Path) -> None:
+    """claude-run selection path. Calls normalize_page_file internally."""
+    enrichment_info(md)
+
+
+# Single source of truth for entry points under test. When a new
+# selection/entry boundary is added to figmaclaw, list it here. The
+# registered callable must leave any invariant violations healed after
+# its first invocation — either by calling normalize_page_file
+# directly, or by being downstream of something that does.
+_HEALING_ENTRY_POINTS: list[tuple[str, Callable[[Path], None]]] = [
+    ("normalize_page_file", _invoke_normalize),
+    ("enrichment_info", _invoke_enrichment_info),
+    # Future entries go here. Examples:
+    # ("pull._pull_file_gate", _invoke_pull_gate),
+    # ("inspect_cmd", _invoke_inspect),
+]
+
+
+def _assert_healed(md: Path) -> None:
+    """Shared post-conditions: the stuck fixture is resolved."""
+    fm = parse_frontmatter(md.read_text())
+    assert fm is not None
+    # Invariant 1: schema_version present.
+    assert fm.enriched_schema_version is not None
+    # Invariant 2: frame-keyed dict orphan pruned.
+    assert "DEAD:1" not in fm.enriched_frame_hashes
+    assert set(fm.enriched_frame_hashes.keys()) <= set(fm.frames)
+    # Invariant 3: body orphan row dropped.
+    assert "`DEAD:1`" not in md.read_text()
+    # Valid content preserved.
+    assert "`11:1`" in md.read_text()
+    assert "Real description." in md.read_text()
+
+
+@pytest.mark.parametrize(
+    "entry_name,entry_call",
+    _HEALING_ENTRY_POINTS,
+    ids=[name for name, _ in _HEALING_ENTRY_POINTS],
+)
+def test_entry_point_heals_stuck_fixture_on_first_encounter(
+    tmp_path: Path,
+    entry_name: str,
+    entry_call: Callable[[Path], None],
+) -> None:
+    """Every registered entry point must leave a stuck file in a
+    healed state after one invocation.
+
+    This is the contract that closes figmaclaw#123's category. A future
+    PR that adds a new selection path must either register it here (and
+    prove it heals) or explicitly acknowledge that the path does NOT
+    heal — in which case we need a clear rationale and a stable "that's
+    OK for this path" comment.
+    """
+    md = tmp_path / "stuck.md"
+    md.write_text(_STUCK_FIXTURE)
+
+    entry_call(md)
+
+    _assert_healed(md)
+
+
+@pytest.mark.parametrize(
+    "entry_name,entry_call",
+    _HEALING_ENTRY_POINTS,
+    ids=[name for name, _ in _HEALING_ENTRY_POINTS],
+)
+def test_entry_point_is_idempotent_on_already_healed_file(
+    tmp_path: Path,
+    entry_name: str,
+    entry_call: Callable[[Path], None],
+) -> None:
+    """After the first healing call, subsequent calls must be byte-for-byte
+    no-ops. Guards against accidental re-serialization side effects
+    (e.g. YAML ordering drift) and preserves the "idempotency per
+    CLAUDE.md" rule for any entry-point wire.
+    """
+    md = tmp_path / "stuck.md"
+    md.write_text(_STUCK_FIXTURE)
+
+    # First call heals (or observes that the file is already clean).
+    entry_call(md)
+    canonical = md.read_text()
+    mtime_after_first = md.stat().st_mtime_ns
+
+    # Second call must leave the file byte-for-byte unchanged.
+    entry_call(md)
+
+    assert md.read_text() == canonical
+    assert md.stat().st_mtime_ns == mtime_after_first
+
+
+def test_registered_entry_point_list_is_non_empty() -> None:
+    """Loud failure if someone accidentally empties _HEALING_ENTRY_POINTS.
+
+    The list IS the category invariant — dropping entries without
+    replacement would silently remove the guarantee.
+    """
+    assert _HEALING_ENTRY_POINTS, (
+        "_HEALING_ENTRY_POINTS must register at least normalize_page_file + "
+        "every selection/entry boundary in figmaclaw that reads a page file."
+    )

--- a/tests/test_normalize.py
+++ b/tests/test_normalize.py
@@ -1,0 +1,276 @@
+"""Tests for figmaclaw.normalize (figmaclaw#123).
+
+``normalize_page_file`` is the canonical "heal on encounter" entry
+point. Every entry boundary (claude-run selector, pull discovery, CLI)
+must call it. These tests pin:
+
+- Idempotency: a clean file is byte-for-byte unchanged; two consecutive
+  calls make zero writes on the second.
+- DRY: the function composes existing helpers (chokepoint rebuild +
+  orphan-row prune + schema-version backfill). No logic lives here that
+  lives elsewhere.
+- Prose preservation: section intros, Mermaid, page summary untouched.
+- Observability: :class:`NormalizationResult` counters are exact.
+- Guardrail: ``_FRAME_KEYED_DICT_FIELDS`` stays in lockstep with the
+  chokepoint prune in ``_build_frontmatter``.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+from figmaclaw.normalize import (
+    _FRAME_KEYED_DICT_FIELDS,
+    NormalizationResult,
+    normalize_page_file,
+)
+
+_CLEAN_PAGE = """---
+file_key: fk
+page_node_id: '1:1'
+frames: ['11:1', '11:2']
+enriched_schema_version: 1
+---
+
+# Page
+
+Page summary paragraph.
+
+## Auth (`10:1`)
+
+Section intro.
+
+| Screen | Node ID | Description |
+|--------|---------|-------------|
+| Login | `11:1` | A real description. |
+| Signup | `11:2` | Another description. |
+"""
+
+
+_STUCK_PAGE = """---
+file_key: fk
+page_node_id: '1:1'
+frames: ['11:1']
+enriched_schema_version: 1
+enriched_frame_hashes: {'11:1': aaaaaaaa, 'DEAD:1': deadbeef}
+---
+
+# Page
+
+Page summary paragraph.
+
+## Auth (`10:1`)
+
+Section intro.
+
+| Screen | Node ID | Description |
+|--------|---------|-------------|
+| Login | `11:1` | A real description. |
+| Ghost | `DEAD:1` | (no screenshot available) |
+
+```mermaid
+flowchart LR
+  A --> B
+```
+"""
+
+
+class TestIdempotency:
+    def test_already_normalized_file_is_untouched(self, tmp_path: Path) -> None:
+        """After the FIRST normalize canonicalizes a file (field order etc),
+        subsequent normalize calls must be a pure no-op — no mtime bump,
+        no byte change. This is the idempotency contract from CLAUDE.md."""
+        md = tmp_path / "page.md"
+        md.write_text(_CLEAN_PAGE)
+
+        # First call may canonicalize field order — that's allowed.
+        normalize_page_file(md)
+        normalized_text = md.read_text()
+        mtime_after_first = md.stat().st_mtime_ns
+
+        # Second call must be a pure no-op.
+        result = normalize_page_file(md)
+
+        assert result.changed is False
+        assert md.read_text() == normalized_text
+        assert md.stat().st_mtime_ns == mtime_after_first
+
+    def test_second_call_is_noop_after_first_heals(self, tmp_path: Path) -> None:
+        md = tmp_path / "page.md"
+        md.write_text(_STUCK_PAGE)
+
+        first = normalize_page_file(md)
+        assert first.changed is True
+
+        mtime_after_first = md.stat().st_mtime_ns
+        second = normalize_page_file(md)
+
+        assert second.changed is False
+        assert md.stat().st_mtime_ns == mtime_after_first
+
+
+class TestHealing:
+    def test_heals_orphan_enriched_frame_hashes(self, tmp_path: Path) -> None:
+        md = tmp_path / "page.md"
+        md.write_text(_STUCK_PAGE)
+
+        result = normalize_page_file(md)
+
+        assert result.changed is True
+        assert result.frame_keyed_dict_orphans_pruned == 1  # DEAD:1
+        assert "DEAD:1" not in md.read_text()
+
+    def test_heals_orphan_body_rows(self, tmp_path: Path) -> None:
+        md = tmp_path / "page.md"
+        md.write_text(_STUCK_PAGE)
+
+        result = normalize_page_file(md)
+
+        assert result.body_orphan_rows_pruned == 1
+        assert "`DEAD:1`" not in md.read_text()
+
+    def test_heals_missing_schema_version(self, tmp_path: Path) -> None:
+        md = tmp_path / "page.md"
+        # Legacy page: no enriched_schema_version field.
+        md.write_text(_CLEAN_PAGE.replace("enriched_schema_version: 1\n", ""))
+
+        result = normalize_page_file(md)
+
+        assert result.schema_version_backfilled is True
+        assert result.changed is True
+        assert "enriched_schema_version: 0" in md.read_text()
+
+
+class TestPreservesProse:
+    def test_prose_and_mermaid_survive_heal(self, tmp_path: Path) -> None:
+        md = tmp_path / "page.md"
+        md.write_text(_STUCK_PAGE)
+
+        normalize_page_file(md)
+
+        after = md.read_text()
+        assert "Page summary paragraph." in after
+        assert "## Auth (`10:1`)" in after
+        assert "Section intro." in after
+        assert "```mermaid" in after
+        assert "flowchart LR" in after
+        assert "A --> B" in after
+
+    def test_valid_rows_preserved(self, tmp_path: Path) -> None:
+        md = tmp_path / "page.md"
+        md.write_text(_STUCK_PAGE)
+
+        normalize_page_file(md)
+
+        after = md.read_text()
+        assert "`11:1`" in after
+        assert "A real description." in after
+
+
+class TestEdgeCases:
+    def test_non_figmaclaw_file_is_ignored(self, tmp_path: Path) -> None:
+        md = tmp_path / "README.md"
+        md.write_text("# Project\n\nSome prose.\n")
+        before = md.read_text()
+
+        result = normalize_page_file(md)
+
+        assert result.changed is False
+        assert result.reason
+        assert md.read_text() == before
+
+    def test_missing_file_does_not_raise(self, tmp_path: Path) -> None:
+        result = normalize_page_file(tmp_path / "nonexistent.md")
+        assert result.changed is False
+        assert "read failed" in result.reason
+
+    def test_empty_frames_is_safe(self, tmp_path: Path) -> None:
+        """A page with empty frames list shouldn't have its body pruned
+        just because the allowed set is empty (fallback behavior from
+        figmaclaw#121: empty-allowed = no-op prune)."""
+        md = tmp_path / "page.md"
+        md.write_text(
+            "---\n"
+            "file_key: fk\n"
+            "page_node_id: '1:1'\n"
+            "frames: []\n"
+            "enriched_schema_version: 1\n"
+            "---\n\n"
+            "# Page\n\n"
+            "## Section (`10:1`)\n\n"
+            "| Screen | Node ID | Description |\n"
+            "|--------|---------|-------------|\n"
+            "| Row | `11:1` | desc |\n"
+        )
+
+        normalize_page_file(md)
+
+        # frames=[] means "nothing is allowed" — but the empty-allowed
+        # fallback short-circuits to no-op to avoid mutating legacy files.
+        # If the frontmatter genuinely should prune, the rebuild through
+        # the chokepoint will still clear frame-keyed dicts.
+        assert "`11:1`" in md.read_text()
+
+
+class TestDrynessGuardrail:
+    """The set of frame-keyed dict fields in normalize._FRAME_KEYED_DICT_FIELDS
+    must match the set pruned by the _build_frontmatter chokepoint.
+
+    If someone adds a new frame-keyed dict but forgets to update one
+    side, either pruning or counting drifts. This guardrail locks the
+    two lists to a single source of truth.
+    """
+
+    def test_frame_keyed_dict_fields_match_chokepoint(self) -> None:
+        source = Path("figmaclaw/figma_render.py").read_text()
+
+        # Extract every variable name passed to `_prune_to_allowed` inside
+        # `_build_frontmatter`. The chokepoint is the only caller.
+        tree = ast.parse(source)
+        pruned_names: set[str] = set()
+        for node in ast.walk(tree):
+            if (
+                isinstance(node, ast.Call)
+                and isinstance(node.func, ast.Name)
+                and node.func.id == "_prune_to_allowed"
+            ):
+                arg = node.args[0] if node.args else None
+                if isinstance(arg, ast.Name):
+                    pruned_names.add(arg.id)
+
+        assert pruned_names == set(_FRAME_KEYED_DICT_FIELDS), (
+            f"normalize._FRAME_KEYED_DICT_FIELDS={set(_FRAME_KEYED_DICT_FIELDS)} "
+            f"but _build_frontmatter prunes {pruned_names}. "
+            "Keep these in lockstep — every frame-keyed dict must be in both "
+            "(counted by normalize, pruned by the chokepoint)."
+        )
+
+
+class TestObservability:
+    def test_result_is_frozen(self) -> None:
+        """Frozen pydantic (per CLAUDE.md conventions) — callers can
+        rely on hashability / no mutation surprises."""
+        import contextlib
+
+        r = NormalizationResult(changed=True)
+        with contextlib.suppress(Exception):
+            r.changed = False  # pyright: ignore[reportAttributeAccessIssue]
+        assert r.changed is True
+
+    def test_counters_sum_to_change_signal(self, tmp_path: Path) -> None:
+        """If ``changed`` is True, at least one per-invariant counter
+        is non-zero. Guarantees the observability counters stay useful
+        for debugging / analytics — no silent "changed but no counter"."""
+        md = tmp_path / "page.md"
+        md.write_text(_STUCK_PAGE)
+
+        result = normalize_page_file(md)
+
+        assert result.changed is True
+        per_invariant_signal = (
+            result.schema_version_backfilled
+            or result.frame_keyed_dict_orphans_pruned > 0
+            or result.body_orphan_rows_pruned > 0
+        )
+        assert per_invariant_signal

--- a/tests/test_pull_logic.py
+++ b/tests/test_pull_logic.py
@@ -881,10 +881,18 @@ async def test_pull_file_parallel_fetch_handles_individual_page_errors(tmp_path:
 
 
 def _make_state_with_file(tmp_path: Path, file_key: str, last_modified: str) -> FigmaSyncState:
+    from figmaclaw.figma_frontmatter import CURRENT_PULL_SCHEMA_VERSION
+
     state = FigmaSyncState(tmp_path)
     state.load()
     state.add_tracked_file(file_key, "My File")
     state.manifest.files[file_key].last_modified = last_modified
+    # Default to CURRENT schema so "unchanged file is skipped" tests are
+    # meaningful — a file at an older schema is intentionally pulled
+    # regardless of Figma activity (figmaclaw#123). Tests that want to
+    # exercise the schema-stale escape must set this to an older value
+    # explicitly.
+    state.manifest.files[file_key].pull_schema_version = CURRENT_PULL_SCHEMA_VERSION
     return state
 
 
@@ -991,6 +999,53 @@ async def test_pull_cmd_skips_unchanged_files_via_listing(tmp_path: Path):
         await _run("key", tmp_path, None, False, None, False, 10, "team123", "all")
 
     mock_client.get_file_meta.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_pull_cmd_bypasses_listing_prefilter_for_schema_stale_file(
+    tmp_path: Path,
+) -> None:
+    """INVARIANT (figmaclaw#123): a tracked file whose stored pull_schema_version
+    is below CURRENT must be pulled even when Figma reports it as unchanged.
+
+    Without this escape hatch, a schema bump (e.g. v6→v7) only propagates
+    to files that happen to be modified in Figma. Idle files stay at the
+    old schema forever — which is what left the linear-git stuck files
+    unhealed after figmaclaw#122 merged.
+    """
+    from figmaclaw.commands.pull import _run
+    from figmaclaw.figma_frontmatter import CURRENT_PULL_SCHEMA_VERSION
+
+    state = _make_state_with_file(tmp_path, "fileA", "2026-03-01T00:00:00Z")
+    # Simulate stored schema below CURRENT.
+    state.manifest.files["fileA"].pull_schema_version = CURRENT_PULL_SCHEMA_VERSION - 1
+    state.save()
+
+    mock_client = MagicMock(spec=FigmaClient)
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+    mock_client.list_team_projects = AsyncMock(return_value=[ProjectSummary(id="p1", name="Web")])
+    mock_client.list_project_files = AsyncMock(
+        return_value=[
+            # listing reports the same last_modified as stored (unchanged on Figma).
+            FileSummary(key="fileA", name="App", last_modified="2026-03-01T00:00:00Z"),
+        ]
+    )
+    mock_client.get_file_meta = AsyncMock(
+        return_value={
+            "version": "v2",
+            "lastModified": "2026-03-01T00:00:00Z",
+            "name": "App",
+            "document": {"children": []},
+        }
+    )
+
+    with patch("figmaclaw.commands.pull.FigmaClient", return_value=mock_client):
+        await _run("key", tmp_path, None, False, None, False, 10, "team123", "all")
+
+    # The schema-stale escape must have bypassed the pre-filter skip;
+    # get_file_meta is called because pull_file proceeded.
+    mock_client.get_file_meta.assert_called_once_with("fileA")
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Closes #123.

## Summary

Actually heals the 5 linear-git stuck files that #122 left behind. Addresses the category root cause (invariants fire only on write; readers encounter stuck state without writing) rather than patching individual cases.

10 files changed, ~760 lines. Real-data dry-run confirms the 5 stuck files clean up correctly.

## What the PR does

1. **`figmaclaw/normalize.py` — `normalize_page_file(md_path)`**
   One canonical, idempotent, structural-only heal function. Applied invariants:
   - `enriched_schema_version` backfilled if missing.
   - Frame-keyed dict keys ⊆ `frames` (via the existing `_build_frontmatter` chokepoint).
   - Body canonical frame rows with node_id ∉ `frames` dropped (via the existing `iter_body_frame_rows` walker).
   - Body prose / Mermaid / section intros preserved byte-for-byte.

2. **Claude-run selection now heals every encounter.**
   `enrichment_info` calls `normalize_page_file` as its first step. Subsumes the former `_migrate_missing_enrichment_schema_version` helper (deleted — its work is now one of several invariants `normalize_page_file` applies).

3. **Pull's listing pre-filter bypasses skip for schema-stale files.**
   The `--since=3m` listing skip now checks `is_pull_schema_stale` before short-circuiting. Without this, schema bumps never reached files Figma reports as unchanged — which is exactly why the 5 stuck files didn't heal after #122 despite the v7 schema bump.

4. **CLAUDE.md policy — new dimension #6**.
   "Invariants heal at every entry, not only at write" plus the additional review-checklist item. Documents the test-shape contributors must meet when adding a new selection/entry boundary.

## DRY — what this PR does NOT introduce

- No new parsing logic. Reuses `parse_frontmatter`, `iter_body_frame_rows`, `split_frontmatter`.
- No new invariant logic. The key-set chokepoint in `_build_frontmatter` stays unchanged.
- No new body-write path. `_rewrite_frontmatter_preserving_body` unchanged.
- No duplication of the schema-version migration. The single `_backfill_schema_version` helper in `normalize.py` replaces the identical `_migrate_missing_enrichment_schema_version` in `claude_run.py`.

## Preventative test — the real deliverable

`tests/test_entry_point_heals.py` — parametric over `_HEALING_ENTRY_POINTS`. Every registered entry point must heal a stuck fixture on its first invocation AND be idempotent on subsequent calls. Adding a new selection path means either registering it (and passing) or explicitly opting out with a comment. **Silent drift back into the "reader doesn't heal" trap is structurally prevented.**

Plus `tests/test_normalize.py::TestDrynessGuardrail` — AST-based guardrail asserting `_FRAME_KEYED_DICT_FIELDS` stays in lockstep with the chokepoint prune in `_build_frontmatter`. Future contributor adds a new frame-keyed dict in one place but forgets the other → this test fails with a clear diagnostic.

## Real-data verification

Installed on the linear-git working copy. Ran `enrichment_info` on each of the 5 stuck files in a sandbox:

| file | before | after |
|---|---|---|
| showcase-v2-11550-42383.md | pending=60, efh=108 | pending=0, efh=4 |
| live-2307-251062.md | pending=3, efh=0 | pending=0, efh=0 |
| playground-mobile-1-8.md | pending=1, efh=222 | pending=0, efh=221 |
| community-page-ux-321-26772.md | pending=2, efh=221 | pending=0, efh=221 |
| playground-3-19.md | pending=2, efh=0 | pending=0, efh=0 |
| community-wireframes-7-15127.md | pending=1, efh=0 | pending=0, efh=0 |

All 5 heal on first encounter. Zero stuck rows remaining. Expected verdict on next nightly run: row 1 GREEN (no-op) instead of row 9 YELLOW.

## How the fix lands in production

Two independent paths both land the cleanup in the next nightly run:

1. **Pull** — with the new schema-stale escape hatch, pull now visits the 5 idle files, calls `update_page_frontmatter` → `_rewrite_frontmatter_preserving_body` → body orphan rows pruned, committed, pushed. Primary healing path.
2. **Claude-run** — normalize fires on every file encounter, heals in-place in the CI runner's working tree. Safety net if pull misses.

## Test run

```
uv run pytest
```

935 passed, 0 failures. Lint/format/typecheck clean.

## Test plan
- [ ] CI green on this branch
- [ ] Trigger figmaclaw nightly on linear-git; verify 5 stuck files appear in commit history with the cleanup applied
- [ ] Confirm subsequent run shows zero `stuck=N` — verdict row 1 GREEN

🤖 Generated with [Claude Code](https://claude.com/claude-code)
