### PR TITLE
fix(sync): stop losing mid-batch progress; drain backlog at ~20 pages/run

### DIFF
--- a/figmaclaw/commands/pull.py
+++ b/figmaclaw/commands/pull.py
@@ -18,7 +18,7 @@ from figmaclaw.figma_sync_state import FigmaSyncState
 from figmaclaw.figma_utils import parse_since
 from figmaclaw.git_utils import git_commit, git_push
 from figmaclaw.prune_utils import prune_file_artifacts_from_manifest
-from figmaclaw.pull_logic import PullResult, pull_file
+from figmaclaw.pull_logic import DEFAULT_PER_PAGE_TIMEOUT_S, PullResult, pull_file
 from figmaclaw.schema_status import is_pull_schema_stale
 from figmaclaw.status_markers import COMMIT_MSG_PREFIX, HAS_MORE_TRUE
 
@@ -68,6 +68,17 @@ from figmaclaw.status_markers import COMMIT_MSG_PREFIX, HAS_MORE_TRUE
     show_default=True,
     help="Prune stale generated figma artifacts (orphans, old rename paths, removed pages).",
 )
+@click.option(
+    "--per-page-timeout-s",
+    "per_page_timeout_s",
+    default=DEFAULT_PER_PAGE_TIMEOUT_S,
+    type=float,
+    show_default=True,
+    help=(
+        "Abort get_page/get_nodes for a single page after this many seconds and "
+        "mark it errored so the loop can continue. Pass 0 to disable."
+    ),
+)
 @click.pass_context
 def pull_cmd(
     ctx: click.Context,
@@ -79,10 +90,15 @@ def pull_cmd(
     team_id: str | None,
     since: str,
     prune: bool,
+    per_page_timeout_s: float,
 ) -> None:
     """Pull all tracked Figma files and write changed pages to disk."""
     repo_dir = Path(ctx.obj["repo_dir"])
     api_key = require_figma_api_key()
+
+    # 0 = caller opts out of per-page timeouts. Map to None to keep the signature
+    # explicit in pull_logic.pull_file (None => no asyncio.wait_for wrapping).
+    resolved_timeout: float | None = per_page_timeout_s if per_page_timeout_s > 0 else None
 
     asyncio.run(
         _run(
@@ -96,6 +112,7 @@ def pull_cmd(
             team_id,
             since,
             prune=prune,
+            per_page_timeout_s=resolved_timeout,
         )
     )
 
@@ -287,6 +304,7 @@ async def _run(
     team_id: str | None,
     since: str,
     prune: bool = True,
+    per_page_timeout_s: float | None = None,
 ) -> None:
     state = load_state(repo_dir)
 
@@ -411,6 +429,7 @@ async def _run(
                         max_pages=pages_budget,
                         prune=prune,
                         on_page_written=on_page_written,
+                        per_page_timeout_s=per_page_timeout_s,
                     )
                 finally:
                     stop_heartbeat.set()

--- a/figmaclaw/pull_logic.py
+++ b/figmaclaw/pull_logic.py
@@ -86,10 +86,19 @@ from figmaclaw.token_scan import PageTokenScan, scan_page
 log = logging.getLogger(__name__)
 TOKEN_SIDECAR_SCHEMA_VERSION = 2
 
-# Per-page API-call timeout. Applied around get_page and the sequential-mode
-# get_nodes call to prevent one stuck page from hanging an entire batch.
+# Per-page API-call timeout. Applied around each concurrent get_page and the
+# sequential-mode get_nodes call so one stuck page can't hang an entire batch.
 # None disables per-page timeouts (falls back to the caller's wall-clock limit).
 DEFAULT_PER_PAGE_TIMEOUT_S: float = 240.0
+
+# Concurrent page-node fetches per chunk. Sized to get most of the parallel-speedup
+# (a 30-page file completes in ~3 chunks, ~3× timeout_s wall-clock max) without
+# unbounded concurrency: 100 simultaneous Figma HTTP requests works fine against
+# connection pooling but spikes memory and plays poorly with provider throttling.
+# 10 has been stable in production sync runs. Not currently exposed on the CLI —
+# bump if you observe chunks dominating batch time (i.e. throughput is CPU, not
+# API-bound).
+PAGE_FETCH_CHUNK: int = 10
 
 
 def _all_manifest_generated_paths(state: FigmaSyncState) -> set[str]:
@@ -808,25 +817,61 @@ async def pull_file(
     total_pages = len(page_stubs)
     pages_written_this_call = 0
 
-    # Fetch all page nodes concurrently when there is no page limit (fastest path).
-    # With a page limit, fetch sequentially to avoid wasting API calls on pages we
-    # will never process in this batch.
-    # skip_pages stubs are excluded from the parallel fetch to avoid wasted API calls.
+    # Fetch page nodes concurrently in bounded chunks.
+    #
+    # Why not serial (prior behaviour in max_pages mode): the only case where
+    # fetching one page at a time saved API calls was first-sync of a file with
+    # many pages. For the common case (resync of an already-synced file where
+    # most pages are content_unchanged), every page still has to be fetched to
+    # compute its hash — serial fetching just serialises N round-trips. Observed
+    # against a 34-page file on 2026-04-21: 274s serial vs ~32s chunked.
+    #
+    # Why not full parallel (all pages at once): first-sync of a huge file would
+    # fetch all N pages per batch even though only max_pages get written. Chunks
+    # give us a stopping point: if the write budget is hit mid-way through a
+    # file, we can skip fetching the remaining chunks and let a later batch pick
+    # them up. Same asymptotic API cost as the old serial path, far better wall
+    # clock.
+    #
+    # Exceptions from any one page_id's fetch (including per-page timeouts) are
+    # stored in the map and surface as pages_errored in the processing loop —
+    # one bad page does not poison the chunk.
+    fetch_stubs = [s for s in page_stubs if not state.should_skip_page(s.name)]
+
+    async def _fetch_page(node_id: str) -> dict | Exception:
+        try:
+            if per_page_timeout_s is not None:
+                return await asyncio.wait_for(
+                    client.get_page(file_key, node_id),
+                    timeout=per_page_timeout_s,
+                )
+            return await client.get_page(file_key, node_id)
+        except Exception as exc:
+            return exc
+
+    page_nodes_map: dict[str, dict | Exception] = {}
+
+    async def _fetch_chunk(start: int) -> None:
+        end = min(start + PAGE_FETCH_CHUNK, len(fetch_stubs))
+        chunk = fetch_stubs[start:end]
+        if not chunk:
+            return
+        fetched = await asyncio.gather(*[_fetch_page(s.id) for s in chunk])
+        for stub, result in zip(chunk, fetched, strict=False):
+            page_nodes_map[stub.id] = result
+
     if max_pages is None:
-        fetch_stubs = [s for s in page_stubs if not state.should_skip_page(s.name)]
-
-        async def _fetch(node_id: str) -> dict | Exception:
-            try:
-                return await client.get_page(file_key, node_id)
-            except Exception as exc:
-                return exc
-
-        fetched = await asyncio.gather(*[_fetch(s.id) for s in fetch_stubs])
-        page_nodes_map: dict[str, dict | Exception] = {
-            stub.id: result for stub, result in zip(fetch_stubs, fetched, strict=False)
-        }
+        # No write budget to guard — pre-fetch every page in chunks. Still chunked
+        # (not one giant gather) so very large files don't burst hundreds of
+        # concurrent HTTPs at Figma.
+        for chunk_start in range(0, len(fetch_stubs), PAGE_FETCH_CHUNK):
+            await _fetch_chunk(chunk_start)
     else:
-        page_nodes_map = {}  # populated lazily below
+        # First chunk only. Subsequent chunks are fetched lazily inside the
+        # processing loop when it reaches an unfetched page — that way, once
+        # pages_written_this_call hits max_pages and we break out of the loop,
+        # we also stop fetching further chunks.
+        await _fetch_chunk(0)
 
     # Batch-fetch direct children of ALL screen frames across ALL pages in one get_nodes call.
     # This is O(1) per file instead of O(pages), which makes schema-stale backfills fast.
@@ -884,58 +929,60 @@ async def pull_file(
             result.pages_skipped += 1
             continue
 
-        # Level 2: structural hash check
-        if max_pages is None:
-            # Already fetched above
-            page_node_or_exc = page_nodes_map[page_node_id]
-            if isinstance(page_node_or_exc, Exception):
-                log.error(
-                    "Failed to fetch page %r (%s): %s — skipping",
-                    page_name,
-                    page_node_id,
-                    page_node_or_exc,
-                )
-                result.pages_errored += 1
-                continue
-            page_node: dict = page_node_or_exc
-        else:
-            # Sequential fetch.
-            # When schema is current: stop before fetching if content-change budget is hit.
-            # When schema is stale: always fetch so we can upgrade frontmatter format.
-            # Schema-only upgrades (hash unchanged) don't consume the budget, so they
-            # can't cause has_more=True and won't block pull_schema_version from updating.
+        # Level 2: structural hash check. Page nodes come from the chunk-fetched
+        # page_nodes_map. In max_pages mode we may need to fetch the next chunk
+        # lazily here so we don't prefetch work we won't use once budget is hit.
+        if max_pages is not None and page_node_id not in page_nodes_map:
+            # Check write budget before fetching the next chunk: if we've already
+            # written max_pages content-changed pages, stop fetching. Schema-stale
+            # pages still need to be processed (they don't consume the budget) so
+            # keep fetching in that case.
             if not schema_stale and pages_written_this_call >= max_pages:
                 result.has_more = True
                 _progress(
                     f"  [{page_idx}/{total_pages}] {page_name} — reached max_pages={max_pages}, stopping"
                 )
                 break
-            try:
-                if per_page_timeout_s is not None:
-                    page_node = await asyncio.wait_for(
-                        client.get_page(file_key, page_node_id),
-                        timeout=per_page_timeout_s,
-                    )
-                else:
-                    page_node = await client.get_page(file_key, page_node_id)
-            except TimeoutError:
-                log.error(
-                    "get_page timed out after %ss for page %r (%s) — skipping",
-                    per_page_timeout_s,
-                    page_name,
-                    page_node_id,
+            # Fetch the chunk that contains this stub. We know fetch_stubs order
+            # matches page_stubs order for non-skip_pages entries.
+            chunk_start = (
+                next(
+                    (i for i, s in enumerate(fetch_stubs) if s.id == page_node_id),
+                    -1,
                 )
-                _progress(
-                    f"  [{page_idx}/{total_pages}] {page_name} — timed out after {per_page_timeout_s}s, skipping"
-                )
-                result.pages_errored += 1
-                continue
-            except Exception as exc:
-                log.error(
-                    "Failed to fetch page %r (%s): %s — skipping", page_name, page_node_id, exc
-                )
-                result.pages_errored += 1
-                continue
+                // PAGE_FETCH_CHUNK
+            ) * PAGE_FETCH_CHUNK
+            await _fetch_chunk(chunk_start)
+
+        page_node_or_exc = page_nodes_map.get(page_node_id)
+        if isinstance(page_node_or_exc, asyncio.TimeoutError):
+            log.error(
+                "get_page timed out after %ss for page %r (%s) — skipping",
+                per_page_timeout_s,
+                page_name,
+                page_node_id,
+            )
+            _progress(
+                f"  [{page_idx}/{total_pages}] {page_name} — timed out after {per_page_timeout_s}s, skipping"
+            )
+            result.pages_errored += 1
+            continue
+        if isinstance(page_node_or_exc, Exception):
+            log.error(
+                "Failed to fetch page %r (%s): %s — skipping",
+                page_name,
+                page_node_id,
+                page_node_or_exc,
+            )
+            result.pages_errored += 1
+            continue
+        if page_node_or_exc is None:
+            # Shouldn't happen — fetch_stubs excludes skip_pages and we fetched
+            # the containing chunk above. Treat as an error to be safe.
+            log.error("Page %r (%s) missing from fetch map — skipping", page_name, page_node_id)
+            result.pages_errored += 1
+            continue
+        page_node: dict = page_node_or_exc
 
         new_hash = compute_page_hash(page_node)
         stored_hash = state.get_page_hash(file_key, page_node_id)

--- a/figmaclaw/pull_logic.py
+++ b/figmaclaw/pull_logic.py
@@ -86,6 +86,11 @@ from figmaclaw.token_scan import PageTokenScan, scan_page
 log = logging.getLogger(__name__)
 TOKEN_SIDECAR_SCHEMA_VERSION = 2
 
+# Per-page API-call timeout. Applied around get_page and the sequential-mode
+# get_nodes call to prevent one stuck page from hanging an entire batch.
+# None disables per-page timeouts (falls back to the caller's wall-clock limit).
+DEFAULT_PER_PAGE_TIMEOUT_S: float = 240.0
+
 
 def _all_manifest_generated_paths(state: FigmaSyncState) -> set[str]:
     """Return all generated paths currently referenced by the manifest."""
@@ -667,6 +672,7 @@ async def pull_file(
     prune: bool = True,
     progress: Callable[[str], None] | None = None,
     on_page_written: Callable[[str, list[str]], None] | None = None,
+    per_page_timeout_s: float | None = DEFAULT_PER_PAGE_TIMEOUT_S,
 ) -> PullResult:
     """Pull all (or up to max_pages) changed pages for a tracked Figma file.
 
@@ -905,7 +911,25 @@ async def pull_file(
                 )
                 break
             try:
-                page_node = await client.get_page(file_key, page_node_id)
+                if per_page_timeout_s is not None:
+                    page_node = await asyncio.wait_for(
+                        client.get_page(file_key, page_node_id),
+                        timeout=per_page_timeout_s,
+                    )
+                else:
+                    page_node = await client.get_page(file_key, page_node_id)
+            except TimeoutError:
+                log.error(
+                    "get_page timed out after %ss for page %r (%s) — skipping",
+                    per_page_timeout_s,
+                    page_name,
+                    page_node_id,
+                )
+                _progress(
+                    f"  [{page_idx}/{total_pages}] {page_name} — timed out after {per_page_timeout_s}s, skipping"
+                )
+                result.pages_errored += 1
+                continue
             except Exception as exc:
                 log.error(
                     "Failed to fetch page %r (%s): %s — skipping", page_name, page_node_id, exc
@@ -1027,8 +1051,21 @@ async def pull_file(
                 else:
                     # Sequential mode: must fetch per-page (we don't have all page nodes upfront).
                     try:
-                        frame_docs = await client.get_nodes(file_key, screen_frame_ids, depth=2)
+                        if per_page_timeout_s is not None:
+                            frame_docs = await asyncio.wait_for(
+                                client.get_nodes(file_key, screen_frame_ids, depth=2),
+                                timeout=per_page_timeout_s,
+                            )
+                        else:
+                            frame_docs = await client.get_nodes(file_key, screen_frame_ids, depth=2)
                         raw_frames, frame_sections = _compute_raw_frames(frame_docs)
+                    except TimeoutError:
+                        log.warning(
+                            "get_nodes timed out after %ss for page %r (%s) — raw_frames will be omitted",
+                            per_page_timeout_s,
+                            page_name,
+                            page_node_id,
+                        )
                     except Exception as exc:
                         log.warning(
                             "Failed to fetch frame children for page %r (%s): %s — raw_frames will be omitted",

--- a/scripts/checkpoint_pull_loop.sh
+++ b/scripts/checkpoint_pull_loop.sh
@@ -92,6 +92,7 @@ run_pull_batch() {
 }
 
 commit_if_changed() {
+  local msg_override="${1:-}"
   local t0 t1
   GIT_PULL_S=0
   GIT_ADD_S=0
@@ -119,8 +120,12 @@ commit_if_changed() {
   t1="$(date +%s)"
   GIT_DIFF_S="$((t1 - t0))"
 
-  COMMIT_MSG="$(grep '^COMMIT_MSG:' "$FIGMACLAW_OUT_PATH" | head -1 | sed 's/^COMMIT_MSG://' | tr -d '\n\r')"
-  COMMIT_MSG="${COMMIT_MSG:-sync: figmaclaw — checkpoint batch $BATCH}"
+  if [ -n "$msg_override" ]; then
+    COMMIT_MSG="$msg_override"
+  else
+    COMMIT_MSG="$(grep '^COMMIT_MSG:' "$FIGMACLAW_OUT_PATH" | head -1 | sed 's/^COMMIT_MSG://' | tr -d '\n\r')"
+    COMMIT_MSG="${COMMIT_MSG:-sync: figmaclaw — checkpoint batch $BATCH}"
+  fi
 
   t0="$(date +%s)"
   git commit -m "${COMMIT_MSG}" >&2
@@ -161,6 +166,15 @@ while true; do
 
   if [ "$pull_status" -eq 124 ]; then
     TOTAL_TIMEOUTS=$((TOTAL_TIMEOUTS + 1))
+    # Persist partial progress before retrying/stopping. Python saves manifest + .md
+    # files per-page, so mid-batch timeouts still leave valid, committable progress
+    # in the working tree. Without this commit, the next CI run does a fresh checkout
+    # and throws all that work away — causing the loop to re-do the same schema
+    # upgrades indefinitely without ever landing a commit.
+    committed="$(commit_if_changed "sync: figmaclaw — partial progress (batch $BATCH timeout)")"
+    if [ "$committed" = "true" ]; then
+      TOTAL_COMMITS=$((TOTAL_COMMITS + 1))
+    fi
     if [ "$INPUT_FORCE" != "true" ] && [ "$CURRENT_MAX_PAGES_PER_BATCH" -gt 1 ]; then
       CURRENT_MAX_PAGES_PER_BATCH=$((CURRENT_MAX_PAGES_PER_BATCH / 2))
       if [ "$CURRENT_MAX_PAGES_PER_BATCH" -lt 1 ]; then

--- a/scripts/checkpoint_pull_loop.sh
+++ b/scripts/checkpoint_pull_loop.sh
@@ -13,6 +13,12 @@ FIGMACLAW_OUT_PATH="${FIGMACLAW_OUT_PATH:-/tmp/figmaclaw-out.txt}"
 FIGMA_TEAM_ID="${FIGMA_TEAM_ID:-}"
 SINCE="${SINCE:-3m}"
 FIGMACLAW_SYNC_OBS_DIR="${FIGMACLAW_SYNC_OBS_DIR:-}"
+# Delegate commit/push to figmaclaw itself at page granularity. Makes individual
+# pages durable in origin as soon as they're written, so a batch-level SIGKILL
+# no longer discards up-to-N-pages of work. The shell's commit_if_changed still
+# runs afterward as a safety net for manifest tail updates.
+AUTO_COMMIT_ENABLED="${AUTO_COMMIT_ENABLED:-true}"
+PUSH_EVERY="${PUSH_EVERY:-1}"
 
 declare -a PULL_ARGS
 CURRENT_MAX_PAGES_PER_BATCH="$MAX_PAGES_PER_BATCH"
@@ -77,6 +83,11 @@ set_pull_args() {
   fi
   if [ -n "$FIGMA_TEAM_ID" ]; then
     PULL_ARGS+=(--team-id "$FIGMA_TEAM_ID" --since "$SINCE")
+  fi
+  # Page-level commit+push keeps partial progress in origin even if the Python
+  # process is SIGKILL'd mid-batch — the next CI run's fresh checkout picks it up.
+  if [ "$AUTO_COMMIT_ENABLED" = "true" ]; then
+    PULL_ARGS+=(--auto-commit --push-every "$PUSH_EVERY")
   fi
 }
 
@@ -166,14 +177,23 @@ while true; do
 
   if [ "$pull_status" -eq 124 ]; then
     TOTAL_TIMEOUTS=$((TOTAL_TIMEOUTS + 1))
-    # Persist partial progress before retrying/stopping. Python saves manifest + .md
-    # files per-page, so mid-batch timeouts still leave valid, committable progress
-    # in the working tree. Without this commit, the next CI run does a fresh checkout
-    # and throws all that work away — causing the loop to re-do the same schema
-    # upgrades indefinitely without ever landing a commit.
+    # Persist partial progress before retrying/stopping. Two sources of work to save:
+    #   1. Local page commits from --auto-commit that weren't pushed yet (possible
+    #      when PUSH_EVERY > 1). Push them explicitly; best-effort, so failures
+    #      don't break the loop.
+    #   2. Any remaining dirty working-tree state (manifest tail updates, component
+    #      writes not attached to a page commit). commit_if_changed handles this.
+    # Without these, the next CI run's fresh `actions/checkout@v6` throws all
+    # mid-batch work away — causing the loop to re-do the same schema upgrades
+    # forever without ever landing a commit upstream.
+    git push >&2 || true
     committed="$(commit_if_changed "sync: figmaclaw — partial progress (batch $BATCH timeout)")"
     if [ "$committed" = "true" ]; then
       TOTAL_COMMITS=$((TOTAL_COMMITS + 1))
+      # Distinct event + log line so operators can tell at a glance whether a
+      # timed-out batch made forward progress or was completely wasted.
+      echo "figmaclaw pull timed out but partial progress committed (batch $BATCH)."
+      emit_obs "partial_commit_on_timeout" "timeout commit saved work"
     fi
     if [ "$INPUT_FORCE" != "true" ] && [ "$CURRENT_MAX_PAGES_PER_BATCH" -gt 1 ]; then
       CURRENT_MAX_PAGES_PER_BATCH=$((CURRENT_MAX_PAGES_PER_BATCH / 2))

--- a/scripts/checkpoint_pull_loop.sh
+++ b/scripts/checkpoint_pull_loop.sh
@@ -151,6 +151,18 @@ commit_if_changed() {
 }
 
 init_observability
+
+# Final-push safety net. With --auto-commit and any PUSH_EVERY value, a SIGKILL
+# between figmaclaw's `git commit` and `git push` can leave local commits that
+# never made it to origin. The next CI run does `actions/checkout@v6` (fresh
+# tree) and throws those commits away, which is exactly the data-loss shape
+# this whole PR exists to fix. The trap fires on normal exit, error exit, and
+# signals — `git push` with nothing to push is a no-op, so it's always safe.
+final_push_flush() {
+  git push >&2 || true
+}
+trap final_push_flush EXIT
+
 emit_obs "loop_start" "checkpoint loop started"
 
 idle_has_more=0

--- a/tests/test_checkpoint_pull_loop.py
+++ b/tests/test_checkpoint_pull_loop.py
@@ -116,6 +116,11 @@ def _run_loop(
             "BATCH_TIMEOUT_SECONDS": "1",
             "MAX_PAGES_PER_BATCH": "5",
             "INPUT_FORCE": "false",
+            # Default off in the test harness so existing expected-args assertions
+            # (e.g. "pull --max-pages 7") stay stable; individual tests flip this
+            # on when they want to exercise the auto-commit wiring.
+            "AUTO_COMMIT_ENABLED": "false",
+            "PUSH_EVERY": "1",
         }
     )
     env.update(extra_env)
@@ -313,6 +318,87 @@ def test_timeout_backoff_commits_partial_progress_and_retries(tmp_path: Path) ->
     assert "partial progress" in trace
     # Retry happened at halved batch size.
     assert "retrying with --max-pages 4" in out
+
+
+def test_auto_commit_appends_flags_to_pull_args(tmp_path: Path) -> None:
+    """With AUTO_COMMIT_ENABLED=true, the loop must pass --auto-commit and
+    --push-every to figmaclaw so individual pages become durable in origin as
+    they're written — making the batch-level timeout no longer a data-loss risk
+    for already-processed pages."""
+    _run_loop(
+        tmp_path,
+        scenario="single_done",
+        git_dirty="1",
+        timeout_mode="pass",
+        AUTO_COMMIT_ENABLED="true",
+        PUSH_EVERY="1",
+    )
+    args = (tmp_path / "pull-args.txt").read_text().strip()
+    assert "--auto-commit" in args
+    assert "--push-every 1" in args
+
+
+def test_auto_commit_respects_custom_push_every(tmp_path: Path) -> None:
+    _run_loop(
+        tmp_path,
+        scenario="single_done",
+        git_dirty="1",
+        timeout_mode="pass",
+        AUTO_COMMIT_ENABLED="true",
+        PUSH_EVERY="5",
+    )
+    args = (tmp_path / "pull-args.txt").read_text().strip()
+    assert "--push-every 5" in args
+
+
+def test_auto_commit_also_flushes_unpushed_commits_on_timeout(tmp_path: Path) -> None:
+    """With --push-every > 1, a SIGKILL can leave local page commits unpushed.
+    On timeout the loop must explicitly git push before any safety-net commit
+    so those page commits reach origin before the job ends."""
+    _run_loop(
+        tmp_path,
+        scenario="has_more_forever",
+        git_dirty="1",
+        timeout_mode="always",
+        AUTO_COMMIT_ENABLED="true",
+        PUSH_EVERY="5",
+    )
+    trace = (tmp_path / "git-trace.txt").read_text()
+    # Push must run independently of commit_if_changed's trailing push —
+    # even a no-op local tree shouldn't suppress it, since --auto-commit
+    # may have committed pages that aren't pushed yet.
+    assert "git push" in trace
+
+
+def test_partial_commit_on_timeout_emits_distinct_observability_event(tmp_path: Path) -> None:
+    """Operators need to tell apart 'timeout produced work' vs 'timeout wasted
+    a run' at a glance. The partial_commit_on_timeout event surfaces the former."""
+    obs_dir = tmp_path / "obs"
+    out = _run_loop(
+        tmp_path,
+        scenario="has_more_forever",
+        git_dirty="1",
+        timeout_mode="always",
+        FIGMACLAW_SYNC_OBS_DIR=str(obs_dir),
+    )
+    events_text = (obs_dir / "checkpoint_events.csv").read_text()
+    assert "partial_commit_on_timeout" in events_text
+    assert "partial progress committed" in out
+
+
+def test_clean_tree_timeout_does_not_emit_partial_commit_event(tmp_path: Path) -> None:
+    """If there was nothing to commit on timeout, don't spam the partial-commit
+    event — it's meant to signal forward progress, not just that a timeout fired."""
+    obs_dir = tmp_path / "obs"
+    _run_loop(
+        tmp_path,
+        scenario="has_more_forever",
+        git_dirty="0",
+        timeout_mode="always",
+        FIGMACLAW_SYNC_OBS_DIR=str(obs_dir),
+    )
+    events_text = (obs_dir / "checkpoint_events.csv").read_text()
+    assert "partial_commit_on_timeout" not in events_text
 
 
 def test_timeout_stop_emits_batch_end_event(tmp_path: Path) -> None:

--- a/tests/test_checkpoint_pull_loop.py
+++ b/tests/test_checkpoint_pull_loop.py
@@ -147,7 +147,7 @@ def test_stops_immediately_on_pull_timeout(tmp_path: Path) -> None:
     out = _run_loop(
         tmp_path,
         scenario="has_more_forever",
-        git_dirty="1",
+        git_dirty="0",  # nothing to commit on timeout → no git pull either
         timeout_mode="always",  # timeout returns 124 before figmaclaw runs
     )
     assert (tmp_path / "count.txt").exists() is False
@@ -155,7 +155,9 @@ def test_stops_immediately_on_pull_timeout(tmp_path: Path) -> None:
     trace = (
         (tmp_path / "git-trace.txt").read_text() if (tmp_path / "git-trace.txt").exists() else ""
     )
-    assert "git pull" not in trace
+    # With no dirty state, the timeout path must not attempt to commit, so no
+    # `git pull` / `git add` / `git commit` should be traced.
+    assert "git commit" not in trace
 
 
 def test_force_mode_runs_single_batch_even_when_has_more(tmp_path: Path) -> None:
@@ -271,6 +273,46 @@ def test_emits_sync_observability_logs_and_files(tmp_path: Path) -> None:
 
     assert "SYNC_OBS event=batch_start" in out
     assert "SYNC_OBS summary_file=" in out
+
+
+def test_timeout_commits_partial_progress_when_tree_dirty(tmp_path: Path) -> None:
+    """On timeout with a dirty tree, the loop must commit partial progress before
+    retrying or stopping. Without this, the next CI run does a fresh checkout and
+    all work done before SIGKILL is discarded."""
+    out = _run_loop(
+        tmp_path,
+        scenario="has_more_forever",
+        git_dirty="1",
+        timeout_mode="always",
+    )
+    trace = (tmp_path / "git-trace.txt").read_text()
+    # Must commit partial progress before giving up.
+    assert "git commit" in trace
+    # Message tag makes the commit recognizable in git log and distinct from
+    # normal `checkpoint batch` commits.
+    assert "partial progress" in trace
+    # And still produces the timeout-stop observability event.
+    assert "timed out" in out
+    assert "stopping checkpoint loop early" in out
+
+
+def test_timeout_backoff_commits_partial_progress_and_retries(tmp_path: Path) -> None:
+    """On timeout with dirty tree AND backoff eligibility, the loop must commit
+    before retrying with a smaller batch size."""
+    out = _run_loop(
+        tmp_path,
+        scenario="single_done",
+        git_dirty="1",
+        timeout_mode="first_only",
+        MAX_PAGES_PER_BATCH="8",
+    )
+    trace = (tmp_path / "git-trace.txt").read_text()
+    # Two commits expected: one partial-progress after the timed-out batch 1,
+    # one normal after the successful batch 2.
+    assert trace.count("git commit") == 2
+    assert "partial progress" in trace
+    # Retry happened at halved batch size.
+    assert "retrying with --max-pages 4" in out
 
 
 def test_timeout_stop_emits_batch_end_event(tmp_path: Path) -> None:

--- a/tests/test_checkpoint_pull_loop.py
+++ b/tests/test_checkpoint_pull_loop.py
@@ -370,6 +370,69 @@ def test_auto_commit_also_flushes_unpushed_commits_on_timeout(tmp_path: Path) ->
     assert "git push" in trace
 
 
+def test_exit_trap_flushes_any_unpushed_commits_on_normal_exit(tmp_path: Path) -> None:
+    """Normal-exit path must still `git push` once via the EXIT trap. With
+    --auto-commit this drains any per-page commits that weren't pushed (e.g.
+    PUSH_EVERY > 1 leaving a tail of unpushed commits, or a SIGKILL between
+    Python's `git commit` and `git push`). Without this, the next CI run's
+    fresh checkout discards those local commits."""
+    _run_loop(
+        tmp_path,
+        scenario="single_done",
+        git_dirty="0",
+        timeout_mode="pass",
+        AUTO_COMMIT_ENABLED="true",
+        PUSH_EVERY="5",
+    )
+    trace = (tmp_path / "git-trace.txt").read_text()
+    assert "git push" in trace, (
+        "EXIT trap must issue at least one `git push` even when commit_if_changed "
+        "returned false, to flush unpushed --auto-commit page commits."
+    )
+
+
+def test_exit_trap_does_not_fail_script_when_push_fails(tmp_path: Path) -> None:
+    """A transient `git push` failure during the trap must not crash the script
+    and mask the real exit status / observability output."""
+    bin_dir = _setup_fake_bin(tmp_path, scenario="single_done", git_dirty="0", timeout_mode="pass")
+    # Overwrite the helper's git stub with one that fails on `push` — simulates
+    # network hiccup / auth token expired / remote conflict during the trap.
+    (bin_dir / "git").write_text(
+        "#!/usr/bin/env bash\n"
+        'if [ "${1:-}" = "push" ]; then exit 1; fi\n'
+        'if [ "${1:-}" = "diff" ] && [ "${GIT_DIRTY:-0}" = "1" ]; then exit 1; fi\n'
+        "exit 0\n"
+    )
+    (bin_dir / "git").chmod(0o755)
+
+    repo = Path(__file__).resolve().parents[1]
+    script = repo / "scripts" / "checkpoint_pull_loop.sh"
+    env = os.environ.copy()
+    env.update(
+        {
+            "PATH": f"{bin_dir}:{env['PATH']}",
+            "COUNT_FILE": str(tmp_path / "count.txt"),
+            "TRACE_FILE": str(tmp_path / "git-trace.txt"),
+            "FIGMACLAW_OUT_PATH": str(tmp_path / "figmaclaw-out.txt"),
+            "ARGS_FILE": str(tmp_path / "pull-args.txt"),
+            "TIMEOUT_COUNT_FILE": str(tmp_path / "timeout-count.txt"),
+            "SCENARIO": "single_done",
+            "GIT_DIRTY": "0",
+            "TIMEOUT_MODE": "pass",
+            "MAX_BATCHES": "10",
+            "MAX_IDLE_HAS_MORE_BATCHES": "3",
+            "BATCH_TIMEOUT_SECONDS": "1",
+            "MAX_PAGES_PER_BATCH": "5",
+            "INPUT_FORCE": "false",
+            "AUTO_COMMIT_ENABLED": "true",
+            "PUSH_EVERY": "1",
+        }
+    )
+    # check=True catches nonzero exit — we expect exit 0 even with the failing
+    # trap push.
+    subprocess.run([str(script)], cwd=tmp_path, text=True, capture_output=True, env=env, check=True)
+
+
 def test_partial_commit_on_timeout_emits_distinct_observability_event(tmp_path: Path) -> None:
     """Operators need to tell apart 'timeout produced work' vs 'timeout wasted
     a run' at a glance. The partial_commit_on_timeout event surfaces the former."""

--- a/tests/test_pull_logic.py
+++ b/tests/test_pull_logic.py
@@ -568,6 +568,107 @@ async def test_pull_file_has_more_false_when_all_pages_written(tmp_path: Path):
 
 
 @pytest.mark.asyncio
+async def test_pull_file_fetches_pages_concurrently_in_sequential_mode(tmp_path: Path):
+    """INVARIANT: max_pages mode must fetch page nodes concurrently within each
+    chunk, not one at a time. Before this fix, a resynced file with N unchanged
+    pages cost N × per-call latency serialised (observed: 34 pages × ~8s = 274s).
+    Concurrent chunked fetch collapses that to ~chunk_latency × ceil(N/chunk) —
+    for a 10-page chunk, roughly the slowest single call in the chunk.
+
+    We verify concurrency by timing N slow mock fetches: if serial, total time
+    would be N * sleep_s; if concurrent, total ≈ sleep_s regardless of N."""
+    import time
+
+    state = FigmaSyncState(tmp_path)
+    state.load()
+    state.add_tracked_file("abc123", "Web App")
+    state.manifest.files["abc123"].version = "v1"
+
+    n_pages = 8
+    per_call_sleep_s = 0.3  # each mock get_page takes 0.3s
+
+    async def slow_get_page(_fk: str, pid: str):
+        await asyncio.sleep(per_call_sleep_s)
+        return fake_page_node_for_id(pid, f"Page {pid}")
+
+    mock_client = MagicMock(spec=FigmaClient)
+    mock_client.get_file_meta = AsyncMock(return_value=fake_file_meta_multi(n_pages))
+    mock_client.get_page = AsyncMock(side_effect=slow_get_page)
+    mock_client.get_nodes = AsyncMock(return_value={})
+    mock_client.get_component_sets = AsyncMock(return_value=[])
+
+    t0 = time.monotonic()
+    result = await pull_file(
+        mock_client,
+        "abc123",
+        state,
+        tmp_path,
+        force=False,
+        max_pages=n_pages,  # no write budget headroom — fetch+process all
+    )
+    elapsed = time.monotonic() - t0
+
+    # All pages should be written.
+    assert result.pages_written == n_pages
+
+    # Serial would be n_pages * per_call_sleep_s = 2.4s. Concurrent (one chunk)
+    # should complete in ~per_call_sleep_s plus overhead. Pick a threshold
+    # comfortably between the two: n*sleep - sleep*2 so even a very loaded CI
+    # machine shouldn't trip it without the fix genuinely being broken.
+    serial_floor_s = (n_pages - 2) * per_call_sleep_s
+    assert elapsed < serial_floor_s, (
+        f"pull_file fetched pages serially in {elapsed:.2f}s "
+        f"(serial floor would be {serial_floor_s:.2f}s for {n_pages} pages × "
+        f"{per_call_sleep_s}s). Chunk-parallel fetch is not wired up."
+    )
+
+
+@pytest.mark.asyncio
+async def test_pull_file_chunk_fetch_stops_when_budget_hit(tmp_path: Path):
+    """INVARIANT: when the write budget is hit inside a chunk, subsequent chunks
+    must NOT be fetched. Otherwise first-sync of a huge file would redo N ×
+    full-parallel-fetch work on every batch — same bad O(N²) pattern as before,
+    just with concurrency. Chunked early-stop preserves the sequential-mode API
+    budget while keeping parallel speedups within each chunk.
+
+    We verify by counting get_page calls: with chunk=10, max_pages=3,
+    n_pages=30, we should see exactly one chunk of fetches (10), not 30."""
+    from figmaclaw.pull_logic import PAGE_FETCH_CHUNK
+
+    state = FigmaSyncState(tmp_path)
+    state.load()
+    state.add_tracked_file("abc123", "Web App")
+    state.manifest.files["abc123"].version = "v1"
+
+    n_pages = 3 * PAGE_FETCH_CHUNK  # ensures at least 3 chunks exist
+    mock_client = MagicMock(spec=FigmaClient)
+    mock_client.get_file_meta = AsyncMock(return_value=fake_file_meta_multi(n_pages))
+    mock_client.get_page = AsyncMock(
+        side_effect=lambda fk, pid: fake_page_node_for_id(pid, f"Page {pid}")
+    )
+    mock_client.get_nodes = AsyncMock(return_value={})
+    mock_client.get_component_sets = AsyncMock(return_value=[])
+
+    result = await pull_file(
+        mock_client,
+        "abc123",
+        state,
+        tmp_path,
+        force=False,
+        max_pages=3,  # hit budget within the first chunk
+    )
+
+    assert result.pages_written == 3
+    assert result.has_more is True
+    # With first-chunk prefetch + mid-chunk budget hit, only the first chunk
+    # (PAGE_FETCH_CHUNK pages) should have been fetched — not all n_pages.
+    assert mock_client.get_page.await_count == PAGE_FETCH_CHUNK, (
+        f"expected {PAGE_FETCH_CHUNK} get_page calls (one chunk), got "
+        f"{mock_client.get_page.await_count}. Chunk-early-stop broken."
+    )
+
+
+@pytest.mark.asyncio
 async def test_pull_file_per_page_timeout_marks_stuck_page_errored_and_continues(
     tmp_path: Path,
 ):

--- a/tests/test_pull_logic.py
+++ b/tests/test_pull_logic.py
@@ -568,6 +568,82 @@ async def test_pull_file_has_more_false_when_all_pages_written(tmp_path: Path):
 
 
 @pytest.mark.asyncio
+async def test_pull_file_per_page_timeout_marks_stuck_page_errored_and_continues(
+    tmp_path: Path,
+):
+    """INVARIANT: one page whose get_page exceeds per_page_timeout_s must not
+    hang the whole file — it should be marked errored so subsequent pages still
+    get processed. This is the per-page analog of the shell-level batch timeout:
+    without it, a single slow page blocks all progress on the file forever."""
+
+    state = FigmaSyncState(tmp_path)
+    state.load()
+    state.add_tracked_file("abc123", "Web App")
+    state.manifest.files["abc123"].version = "v1"
+
+    n_pages = 3
+    # fake_file_meta_multi emits page ids "100:1" … "100:N". Hang the first.
+    stuck_pid = "100:1"
+
+    async def maybe_hang(_fk: str, pid: str):
+        if pid == stuck_pid:
+            # Longer than the test's per-page timeout — wait_for must cancel us.
+            await asyncio.sleep(10.0)
+        return fake_page_node_for_id(pid, f"Page {pid}")
+
+    mock_client = MagicMock(spec=FigmaClient)
+    mock_client.get_file_meta = AsyncMock(return_value=fake_file_meta_multi(n_pages))
+    mock_client.get_page = AsyncMock(side_effect=maybe_hang)
+    mock_client.get_nodes = AsyncMock(return_value={})
+    mock_client.get_component_sets = AsyncMock(return_value=[])
+
+    result = await pull_file(
+        mock_client,
+        "abc123",
+        state,
+        tmp_path,
+        force=False,
+        max_pages=5,  # sequential mode — uses the per-page get_page path we wrapped
+        per_page_timeout_s=0.1,
+    )
+
+    # The hung page is errored; the remaining two complete normally.
+    assert result.pages_errored == 1
+    assert result.pages_written == n_pages - 1
+    assert result.has_more is False
+
+
+@pytest.mark.asyncio
+async def test_pull_file_per_page_timeout_none_disables_wrapping(tmp_path: Path):
+    """INVARIANT: per_page_timeout_s=None preserves original behavior (no
+    asyncio.wait_for wrapping) — needed so callers that want to rely solely on
+    a higher-level timeout can opt out."""
+
+    state = FigmaSyncState(tmp_path)
+    state.load()
+    state.add_tracked_file("abc123", "Web App")
+    state.manifest.files["abc123"].version = "v1"
+
+    mock_client = MagicMock(spec=FigmaClient)
+    mock_client.get_file_meta = AsyncMock(return_value=fake_file_meta_multi(2))
+    mock_client.get_page = AsyncMock(
+        side_effect=lambda fk, pid: fake_page_node_for_id(pid, f"Page {pid}")
+    )
+
+    result = await pull_file(
+        mock_client,
+        "abc123",
+        state,
+        tmp_path,
+        force=False,
+        max_pages=5,
+        per_page_timeout_s=None,
+    )
+    assert result.pages_errored == 0
+    assert result.pages_written == 2
+
+
+@pytest.mark.asyncio
 async def test_pull_file_has_more_false_when_no_limit(tmp_path: Path):
     """INVARIANT: has_more is False when max_pages is not set."""
 


### PR DESCRIPTION
Closes #126.

## Why

Scheduled sync runs on `linear-git` had produced zero commits since **2026-04-17**. Every hourly run burned ~45–50 min of CI time and silently discarded all mid-batch work on timeout. Full root cause write-up (logs, run IDs, observability events) in #126.

## What's in this PR

Four commits, each fixing a distinct invariant gap that compounds into the observed stall:

| # | Commit | What it does |
|---|---|---|
| 1 | `fix(sync): commit partial progress when pull batch times out` | Calls `commit_if_changed "…partial progress…"` in the timeout branch. Mid-batch manifest + page writes now survive SIGKILL instead of being thrown away on the next `actions/checkout@v6`. |
| 2 | `feat(sync): per-page timeout, per-page commits, and partial-commit obs event` | (a) `--per-page-timeout-s` on `figmaclaw pull` wraps `get_page` / `get_nodes` in `asyncio.wait_for` — one stuck page can't block its batch. (b) Shell now passes `--auto-commit --push-every 1` by default — every page is durable in origin the instant it's written. (c) New `partial_commit_on_timeout` event distinguishes "timeout saved work" from "timeout was wasted" in the CSV / logs. |
| 3 | `fix(sync): EXIT-trap git push flushes unpushed commits on any exit path` | Safety net for the combo of `--auto-commit` with any `PUSH_EVERY` and/or a SIGKILL between Python's `git commit` and `git push`. Idempotent, lenient (swallows transient push failures). |
| 4 | `perf(pull): chunked-parallel page fetch in max_pages mode` | `pull_logic.py` sequential mode now fetches pages in concurrent chunks of 10 via `asyncio.gather`, with between-chunk early-stop preserving the `max_pages` write budget for first-sync. Serial per-page fetching was 1 round-trip per page even for content-unchanged pages; chunked-parallel collapses that. |

## Proof against the real problem

Two reality-check runs against `gigaverse-app/linear-git` (MAX_BATCHES=2, BATCH_TIMEOUT_SECONDS=300, default max_pages=5, default push_every=1):

**Round 1** — fix only, no perf commit:
- 7 commits landed on `origin/main` in ~10 min.
- Batch 1 SIGKILL at 308s → `partial_commit_on_timeout` fired, safety net committed 1 page + manifest tail.
- Batch 2 produced 6 per-page auto-commits before its own SIGKILL.

**Round 2** — fix + perf commit:
- **21 commits landed on `origin/main` in ~10 min** — 3× more throughput from the same CI budget.
- Per-file duration regressions closed substantially:

| File | Pages | Serial (before) | Chunked-parallel (after) | Speedup |
|---|---|---|---|---|
| `hOV4QMBnDIG5s5OYkSrX9E` (Web App) | 34 | 274s | 154s | 1.8× |
| `7az6PPiHUQumhxtV935xuD` (Mobile App) | 21 | 249s | 125s | 2.0× |

Speedup is below the theoretical 10× of a chunk-of-10 fetch — likely bounded by httpx's default connection pool and/or Figma's server-side concurrency throttle. Still meaningfully lifts real throughput; worth a follow-up investigation if further perf is needed, not a blocker here.

## Invariants validated in reality

- **Next-batch skips** — in round 2's batch 2, every file processed in batch 1 returns `outcome=listing_prefilter_skip duration_s=0.0`. The manifest updates from partial-progress commits correctly short-circuit the next run.
- **Idempotency of the safety net** — both batches in round 2 timed out with `committed=false` on the safety-net commit. All pages were already durable via `--auto-commit`; no duplicate commits.
- **Merge-on-push-conflict** — round 2 produced a `cc7b47b64 Merge branch 'main' …` merge commit when a concurrent webhook push raced with an auto-commit push. `git_utils.git_push`'s pull+retry handled it correctly (creates a merge; does not rebase).
- **EXIT trap fires cleanly on both success and failure paths** — 20 shell tests and 948 Python tests cover the combinations.

## Cadence note (asked during review)

The hourly cron was never the wrong frequency — runs were just doing nothing productive. With this PR a healthy steady-state run is ~5s (listing prefilter + no-op). Backlog-present runs drain ~20 pages in ~10 min. Hourly is fine; dropping to 6-hourly would only degrade the webhook-miss backstop latency. No cadence change needed.

## Test plan

- [x] `uv run pytest tests/test_checkpoint_pull_loop.py` — 20 passed (10 original + 1 tightened + 9 new)
- [x] `uv run pytest tests/test_pull_logic.py -k "per_page_timeout or fetches_pages_concurrently or chunk_fetch_stops"` — 4 passed
- [x] `uv run pytest` (full, minus `tests/smoke`) — 948 passed
- [x] Reality-check round 1 against `linear-git`: 7 commits, both timeout paths fired correctly
- [x] Reality-check round 2 against `linear-git`: 21 commits, perf fix visible in per-file durations, listing_prefilter skip confirmed
- [ ] First in-CI scheduled run post-merge lands at least one page commit

## Known follow-ups (NOT in this PR)

1. **Concurrency ceiling** — observed 1.8× speedup from chunked-parallel, not the theoretical 10×. Likely httpx default max_connections or Figma rate-limiting. Worth profiling if further throughput needed.
2. **Discovery vs pull decoupling** — `figmaclaw list --since 3m` runs every pull and scans the team project. Could be decoupled to daily. Marginal savings unless rate-limited.

🤖 Generated with [Claude Code](https://claude.com/claude-code)