### PR TITLE
fix(#133): suggest-tokens writes to separate file + --library filter

### DIFF
--- a/figmaclaw/commands/suggest_tokens.py
+++ b/figmaclaw/commands/suggest_tokens.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import sys
 from collections import Counter
 from pathlib import Path
 
@@ -12,13 +13,40 @@ from figmaclaw.commands._shared import load_state
 from figmaclaw.token_catalog import catalog_staleness_errors, load_catalog, suggest_for_sidecar
 
 
+def _default_output_path(sidecar_file: Path) -> Path:
+    """Sibling output path: ``foo.tokens.json`` → ``foo.suggestions.json``.
+
+    For sidecars that don't follow the ``.tokens.json`` convention,
+    fall back to replacing the final ``.json`` with ``.suggestions.json``.
+    """
+    name = sidecar_file.name
+    if name.endswith(".tokens.json"):
+        base = name[: -len(".tokens.json")]
+        return sidecar_file.parent / f"{base}.suggestions.json"
+    if name.endswith(".json"):
+        base = name[: -len(".json")]
+        return sidecar_file.parent / f"{base}.suggestions.json"
+    return sidecar_file.parent / f"{name}.suggestions.json"
+
+
 @click.command("suggest-tokens")
 @click.option(
     "--sidecar",
     "sidecar_path",
     required=True,
     type=click.Path(exists=True),
-    help="Path to the .tokens.json sidecar file.",
+    help="Path to the .tokens.json sidecar file (read-only — never mutated).",
+)
+@click.option(
+    "--output",
+    "-o",
+    "output_path_arg",
+    default=None,
+    help=(
+        "Where to write the suggestions JSON. "
+        "Default: sibling of the sidecar with .suggestions.json suffix. "
+        "Use '-' for stdout."
+    ),
 )
 @click.option(
     "--frame",
@@ -27,21 +55,49 @@ from figmaclaw.token_catalog import catalog_staleness_errors, load_catalog, sugg
     help="Only process frames matching this name substring (case-insensitive). "
     "May be specified multiple times.",
 )
-@click.option("--dry-run", is_flag=True, help="Print summary but don't write changes.")
+@click.option(
+    "--library",
+    "libraries",
+    multiple=True,
+    help=(
+        "Only suggest tokens from libraries whose name OR library_hash contains "
+        "this substring (case-insensitive). May be specified multiple times. "
+        "Essential for migration audits — without it, suggestions can point at "
+        "the OLD design system instead of the migration target. "
+        "Example: --library tap --library lsn"
+    ),
+)
+@click.option(
+    "--dry-run",
+    is_flag=True,
+    help="Print summary but write nothing (sidecar, output file, or stdout).",
+)
 @click.pass_context
 def suggest_tokens_cmd(
     ctx: click.Context,
     sidecar_path: str,
+    output_path_arg: str | None,
     frames: tuple[str, ...],
+    libraries: tuple[str, ...],
     dry_run: bool,
 ) -> None:
     """Match raw token values to DS variable candidates.
 
-    Loads the DS variable catalog built during pull and annotates each issue in
-    the sidecar with suggest_status and fix_variable_id (when unambiguous).
+    Loads the DS variable catalog built during pull and produces a
+    suggestions JSON annotating each issue with ``suggest_status`` and
+    candidate variable IDs. The input sidecar is never mutated; output
+    goes to a separate file (default sibling) so CI re-pulls and webhook
+    refreshes don't silently revert audit annotations.
     """
     repo_dir = Path(ctx.obj["repo_dir"])
     catalog = load_catalog(repo_dir)
+
+    # When the JSON output is going to stdout, redirect informational
+    # messages to stderr so consumers can pipe to `jq` / similar.
+    info_to_stderr = output_path_arg == "-"
+
+    def info(msg: str = "") -> None:
+        click.echo(msg, err=info_to_stderr)
 
     sidecar_file = Path(sidecar_path)
     sidecar = json.loads(sidecar_file.read_text(encoding="utf-8"))
@@ -51,7 +107,8 @@ def suggest_tokens_cmd(
         if errors:
             raise click.ClickException(errors[0])
 
-    # Apply frame filter if requested
+    # Apply frame filter if requested. The output reflects exactly what
+    # was processed — filtered runs produce filtered output files.
     if frames:
         filtered_frames = {
             fid: fdata
@@ -86,10 +143,37 @@ def suggest_tokens_cmd(
     numeric_vars = sum(1 for v in catalog.variables.values() if _has_numeric(v))
     total_vars = len(catalog.variables)
 
-    click.echo(f"Catalog: {total_vars} variables ({color_vars} color, {numeric_vars} numeric)")
-    click.echo(f"Frames processed: {frames_processed} / {total_frames}")
+    info(f"Catalog: {total_vars} variables ({color_vars} color, {numeric_vars} numeric)")
+    info(f"Frames processed: {frames_processed} / {total_frames}")
 
-    suggest_for_sidecar(work_sidecar, catalog)
+    library_hash_filter: set[str] | None = None
+    if libraries:
+        # Resolve each substring against library NAME or library_hash KEY.
+        matched: dict[str, str] = {}  # hash -> name (for display)
+        for needle in libraries:
+            n = needle.lower()
+            for lib_hash, lib in catalog.libraries.items():
+                if n in lib_hash.lower() or n in (lib.name or "").lower():
+                    matched[lib_hash] = lib.name or lib_hash
+        if not matched:
+            raise click.ClickException(
+                f"--library filter matched no libraries in the catalog. "
+                f"Searched for: {', '.join(libraries)!r}. "
+                f"Run `figmaclaw doctor` or inspect .figma-sync/ds_catalog.json "
+                f"to see available libraries."
+            )
+        library_hash_filter = set(matched.keys())
+        # Count how many variables that filter selects, so the user can
+        # spot a near-miss substring that picked the wrong library.
+        kept_vars = sum(
+            1 for v in catalog.variables.values() if v.library_hash in library_hash_filter
+        )
+        info(f"Library filter: {len(matched)} libraries, {kept_vars} candidate variables")
+        for lib_hash, name in sorted(matched.items(), key=lambda x: x[1].lower()):
+            n_vars = sum(1 for v in catalog.variables.values() if v.library_hash == lib_hash)
+            info(f"  ✓ {name}  ({lib_hash}, {n_vars} vars)")
+
+    suggest_for_sidecar(work_sidecar, catalog, library_hashes=library_hash_filter)
 
     # Collect results stats — use count field (schema v2) or default to 1 (v1)
     auto = ambiguous = no_match = 0
@@ -117,28 +201,31 @@ def suggest_tokens_cmd(
                     val_str = str(val)
                 prop_value_no_match[(prop, val_str)] += count
 
-    click.echo("")
-    click.echo("Results:")
-    click.echo(f"  auto:      {auto:>5}  (will be set automatically)")
-    click.echo(f"  ambiguous: {ambiguous:>5}  (need manual review — multiple token candidates)")
-    click.echo(f"  no_match:  {no_match:>5}  (no DS variable found for this value)")
+    info("")
+    info("Results:")
+    info(f"  auto:      {auto:>5}  (will be set automatically)")
+    info(f"  ambiguous: {ambiguous:>5}  (need manual review — multiple token candidates)")
+    info(f"  no_match:  {no_match:>5}  (no DS variable found for this value)")
 
     if prop_value_no_match:
-        click.echo("")
-        click.echo("Top no_match values:")
+        info("")
+        info("Top no_match values:")
         for (prop, val_str), count in prop_value_no_match.most_common(10):
-            click.echo(f"  {prop} {val_str}: {count} occurrences")
+            info(f"  {prop} {val_str}: {count} occurrences")
 
-    if not dry_run:
-        # If we only processed a subset of frames, merge back into original sidecar
-        if frames:
-            for fid, fdata in filtered_frames.items():
-                sidecar["frames"][fid] = fdata
-            sidecar["suggested_at"] = work_sidecar.get("suggested_at", "")
-        else:
-            sidecar = work_sidecar
-        sidecar_file.write_text(
-            json.dumps(sidecar, indent=2, ensure_ascii=False),
-            encoding="utf-8",
-        )
-        click.echo(f"\nWrote updated sidecar → {sidecar_path}")
+    if dry_run:
+        return
+
+    output_json = json.dumps(work_sidecar, indent=2, ensure_ascii=False)
+
+    if output_path_arg == "-":
+        sys.stdout.write(output_json)
+        if not output_json.endswith("\n"):
+            sys.stdout.write("\n")
+        sys.stdout.flush()
+        return
+
+    output_file = Path(output_path_arg) if output_path_arg else _default_output_path(sidecar_file)
+    output_file.parent.mkdir(parents=True, exist_ok=True)
+    output_file.write_text(output_json + "\n", encoding="utf-8")
+    info(f"\nWrote suggestions → {output_file}")

--- a/figmaclaw/token_catalog.py
+++ b/figmaclaw/token_catalog.py
@@ -598,7 +598,11 @@ def _extract_library_hash(vid: str) -> str | None:
 # ---------------------------------------------------------------------------
 
 
-def suggest_for_sidecar(sidecar: dict, catalog: TokenCatalog) -> dict:
+def suggest_for_sidecar(
+    sidecar: dict,
+    catalog: TokenCatalog,
+    library_hashes: set[str] | None = None,
+) -> dict:
     """Enrich a sidecar dict in-place with token suggestions from the catalog.
 
     Sets ``suggest_status`` ("auto"|"ambiguous"|"no_match") and
@@ -612,12 +616,20 @@ def suggest_for_sidecar(sidecar: dict, catalog: TokenCatalog) -> dict:
       * Numeric properties — match by ``round(value, 4)`` within the
         same property bucket.
 
+    If ``library_hashes`` is provided, only variables whose
+    ``library_hash`` is in that set are considered as candidates. This is
+    how ``suggest-tokens --library`` limits matches to the migration
+    target DS (e.g. Tap-In / LSN) instead of all libraries in the
+    catalog. ``None`` (the default) considers all variables.
+
     Returns the modified sidecar dict.
     """
     hex_to_vids: dict[str, list[str]] = {}
     numeric_to_vids: dict[tuple[str, str], list[str]] = {}
 
     for vid, entry in catalog.variables.items():
+        if library_hashes is not None and entry.library_hash not in library_hashes:
+            continue
         # Pick the default-mode value for indexing; fall back to the first
         # mode value if no default is recorded.
         value = _pick_default_value(entry, catalog)

--- a/skills/figmaclaw-cli/SKILL.md
+++ b/skills/figmaclaw-cli/SKILL.md
@@ -70,10 +70,15 @@ For per-section enrichment on giant pages (>80 frames), use `--section <node_id>
 
 | Command | What it does | Writes |
 |---|---|---|
-| `figmaclaw suggest-tokens --sidecar <path>` | Annotate raw/stale token issues in a sidecar with DS-variable candidates. | The sidecar (adds `suggest_status`, `candidates`, `fix_variable_id`). |
-| `figmaclaw suggest-tokens --sidecar <path> --dry-run` | Print stats without writing. | nothing. |
+| `figmaclaw suggest-tokens --sidecar <path>` | Annotate raw/stale token issues with DS-variable candidates. | A sibling `<base>.suggestions.json` next to the sidecar (sidecar itself is read-only — never mutated). |
+| `figmaclaw suggest-tokens --sidecar <path> --library tap --library lsn` | Limit candidates to specific DS libraries (substring match on library name OR `library_hash`). | Same sibling file. **Use this for migration audits** — without `--library`, suggestions can point at the OLD design system instead of the migration target. |
+| `figmaclaw suggest-tokens --sidecar <path> --output <path>` | Write to a custom path. | `<path>`. |
+| `figmaclaw suggest-tokens --sidecar <path> --output -` | Write JSON to stdout (informational messages go to stderr — pipeable to `jq` etc). | stdout. |
+| `figmaclaw suggest-tokens --sidecar <path> --dry-run` | Print stats without writing anywhere. | nothing. |
 
 `suggest-tokens` reads `.figma-sync/ds_catalog.json`. If the catalog is stale, run `figmaclaw variables` first; per canon CR-2 the consumer should refuse to produce results from a stale catalog.
+
+The output file (`*.suggestions.json`) is regeneratable and should be added to `.gitignore` — it's recomputed from the sidecar + catalog on every run, so checking it in causes merge conflicts and quietly stale data.
 
 ### Webhooks (server side)
 

--- a/tests/test_low_coverage_commands.py
+++ b/tests/test_low_coverage_commands.py
@@ -77,11 +77,193 @@ Body\n""",
     assert "no figmaclaw frontmatter" in res2.output
 
 
-def test_suggest_tokens_dry_run_and_frame_filtered_write(tmp_path: Path) -> None:
+def _suggest_fixture_with_libraries(
+    tmp_path: Path,
+) -> tuple[Path, SimpleNamespace, object]:
+    """Variant of the suggest fixture with multi-library catalog stub —
+    used to exercise --library filtering behavior (#133)."""
     sidecar = tmp_path / "page.tokens.json"
     sidecar.write_text(
         json.dumps(
             {
+                "file_key": "abc123",
+                "frames": {
+                    "11:1": {
+                        "name": "Login Screen",
+                        "issues": [
+                            {
+                                "property": "fill",
+                                "current_value": {"r": 1},
+                                "hex": "#FFFFFF",
+                                "count": 1,
+                            },
+                        ],
+                    }
+                },
+            },
+            ensure_ascii=False,
+        ),
+        encoding="utf-8",
+    )
+
+    # Two libraries: TAP IN (target) and OLD DS (should be filterable away).
+    # Each has one variable with the same hex, to prove the filter
+    # actually narrows candidates.
+    catalog = SimpleNamespace(
+        libraries={
+            "local:tap-in-hash": SimpleNamespace(name="TAP IN DESIGN SYSTEM"),
+            "local:old-ds-hash": SimpleNamespace(name="OLD_Gigaverse Design System"),
+        },
+        variables={
+            "vid_tap_white": SimpleNamespace(
+                values_by_mode={"_default": SimpleNamespace(hex="#FFFFFF", numeric_value=None)},
+                library_hash="local:tap-in-hash",
+            ),
+            "vid_old_white": SimpleNamespace(
+                values_by_mode={"_default": SimpleNamespace(hex="#FFFFFF", numeric_value=None)},
+                library_hash="local:old-ds-hash",
+            ),
+        },
+    )
+
+    # Fake suggester that records which library_hashes it received.
+    received: dict[str, set[str] | None] = {"library_hashes": None}
+
+    def fake_suggest(work_sidecar: dict, _catalog: SimpleNamespace, library_hashes=None) -> None:
+        received["library_hashes"] = library_hashes
+        # Mimic real matcher: filter candidates by the allowlist if one was given.
+        for frame in work_sidecar.get("frames", {}).values():
+            for issue in frame.get("issues", []):
+                hex_ = issue.get("hex")
+                cands = []
+                if hex_ == "#FFFFFF":
+                    for vid, entry in _catalog.variables.items():
+                        if library_hashes is None or entry.library_hash in library_hashes:
+                            cands.append(vid)
+                if len(cands) == 1:
+                    issue["suggest_status"] = "auto"
+                    issue["candidates"] = cands
+                    issue["fix_variable_id"] = cands[0]
+                elif len(cands) > 1:
+                    issue["suggest_status"] = "ambiguous"
+                    issue["candidates"] = cands
+                else:
+                    issue["suggest_status"] = "no_match"
+                    issue["candidates"] = []
+
+    # Attach the recorder onto the callable so tests can inspect it.
+    fake_suggest.received = received  # type: ignore[attr-defined]
+    return sidecar, catalog, fake_suggest
+
+
+def test_suggest_tokens_library_filter_narrows_candidates(tmp_path: Path) -> None:
+    """INVARIANT (#133, audit-log F1): --library limits matches to listed
+    libraries, so migration audits don't get OLD-DS suggestions."""
+    sidecar, catalog, fake_suggest = _suggest_fixture_with_libraries(tmp_path)
+
+    runner = CliRunner()
+    p1, p2, p3, p4 = _patch_catalog_loaders(catalog, fake_suggest)
+    with p1, p2, p3, p4:
+        # Without --library: both white-variants match → ambiguous.
+        unfiltered = runner.invoke(
+            cli,
+            ["--repo-dir", str(tmp_path), "suggest-tokens", "--sidecar", str(sidecar)],
+            catch_exceptions=False,
+        )
+        assert unfiltered.exit_code == 0
+        out = sidecar.parent / "page.suggestions.json"
+        data = json.loads(out.read_text(encoding="utf-8"))
+        assert data["frames"]["11:1"]["issues"][0]["suggest_status"] == "ambiguous"
+        assert set(data["frames"]["11:1"]["issues"][0]["candidates"]) == {
+            "vid_tap_white",
+            "vid_old_white",
+        }
+        out.unlink()  # reset for the next invocation
+
+    with p1, p2, p3, p4:
+        # With --library tap: only TAP IN variant matches → auto.
+        filtered = runner.invoke(
+            cli,
+            [
+                "--repo-dir",
+                str(tmp_path),
+                "suggest-tokens",
+                "--sidecar",
+                str(sidecar),
+                "--library",
+                "tap",
+            ],
+            catch_exceptions=False,
+        )
+    assert filtered.exit_code == 0
+    assert "Library filter: 1 libraries" in filtered.output
+    assert "TAP IN DESIGN SYSTEM" in filtered.output
+    assert "OLD_Gigaverse" not in filtered.output
+
+    data = json.loads((sidecar.parent / "page.suggestions.json").read_text(encoding="utf-8"))
+    issue = data["frames"]["11:1"]["issues"][0]
+    assert issue["suggest_status"] == "auto"
+    assert issue["candidates"] == ["vid_tap_white"]
+    assert issue["fix_variable_id"] == "vid_tap_white"
+
+
+def test_suggest_tokens_library_filter_no_match_errors(tmp_path: Path) -> None:
+    """If --library matches no library, fail loudly rather than silently
+    proceed with an empty filter (which would mark every issue no_match)."""
+    sidecar, catalog, fake_suggest = _suggest_fixture_with_libraries(tmp_path)
+
+    runner = CliRunner()
+    p1, p2, p3, p4 = _patch_catalog_loaders(catalog, fake_suggest)
+    with p1, p2, p3, p4:
+        result = runner.invoke(
+            cli,
+            [
+                "--repo-dir",
+                str(tmp_path),
+                "suggest-tokens",
+                "--sidecar",
+                str(sidecar),
+                "--library",
+                "nonexistent-library-name",
+            ],
+            catch_exceptions=False,
+        )
+    assert result.exit_code != 0
+    assert "matched no libraries" in result.output
+
+
+def test_suggest_tokens_library_filter_matches_by_hash(tmp_path: Path) -> None:
+    """--library can match either by name OR by library_hash key."""
+    sidecar, catalog, fake_suggest = _suggest_fixture_with_libraries(tmp_path)
+
+    runner = CliRunner()
+    p1, p2, p3, p4 = _patch_catalog_loaders(catalog, fake_suggest)
+    with p1, p2, p3, p4:
+        result = runner.invoke(
+            cli,
+            [
+                "--repo-dir",
+                str(tmp_path),
+                "suggest-tokens",
+                "--sidecar",
+                str(sidecar),
+                "--library",
+                "tap-in-hash",  # substring of the library_hash key, not the name
+            ],
+            catch_exceptions=False,
+        )
+    assert result.exit_code == 0
+    assert "TAP IN DESIGN SYSTEM" in result.output
+
+
+def _suggest_fixture(tmp_path: Path) -> tuple[Path, SimpleNamespace, object]:
+    """Common fixture for suggest-tokens tests: writes a sidecar, returns
+    (sidecar_path, catalog_stub, fake_suggest_callable)."""
+    sidecar = tmp_path / "page.tokens.json"
+    sidecar.write_text(
+        json.dumps(
+            {
+                "file_key": "abc123",
                 "frames": {
                     "11:1": {
                         "name": "Login Screen",
@@ -101,7 +283,7 @@ def test_suggest_tokens_dry_run_and_frame_filtered_write(tmp_path: Path) -> None
                             {"property": "radius", "current_value": 12, "count": 1},
                         ],
                     },
-                }
+                },
             },
             ensure_ascii=False,
         ),
@@ -120,7 +302,8 @@ def test_suggest_tokens_dry_run_and_frame_filtered_write(tmp_path: Path) -> None
         }
     )
 
-    def fake_suggest(work_sidecar: dict, _catalog: object) -> None:
+    def fake_suggest(work_sidecar: dict, _catalog: SimpleNamespace, library_hashes=None) -> None:
+        del library_hashes  # not used by this fixture
         for frame in work_sidecar.get("frames", {}).values():
             for issue in frame.get("issues", []):
                 prop = issue.get("property")
@@ -132,25 +315,168 @@ def test_suggest_tokens_dry_run_and_frame_filtered_write(tmp_path: Path) -> None
                     issue["suggest_status"] = "no_match"
         work_sidecar["suggested_at"] = "2026-04-15T12:00:00Z"
 
-    runner = CliRunner()
-    with (
+    return sidecar, catalog, fake_suggest
+
+
+def _patch_catalog_loaders(catalog: object, fake_suggest: object):
+    """Helper: patch out catalog load + suggest computation + staleness check."""
+    return (
         patch("figmaclaw.commands.suggest_tokens.load_catalog", return_value=catalog),
         patch("figmaclaw.commands.suggest_tokens.suggest_for_sidecar", side_effect=fake_suggest),
-    ):
-        dry = runner.invoke(
+        patch("figmaclaw.commands.suggest_tokens.catalog_staleness_errors", return_value=[]),
+        patch("figmaclaw.commands.suggest_tokens.load_state", return_value=MagicMock()),
+    )
+
+
+def test_suggest_tokens_does_not_mutate_sidecar(tmp_path: Path) -> None:
+    """INVARIANT (#133): suggest-tokens must never modify the input sidecar.
+
+    The sidecar is a CI-managed artifact regenerated by `pull`; mutations get
+    silently reverted by the next CI run. Suggestions belong in a sibling file.
+    """
+    sidecar, catalog, fake_suggest = _suggest_fixture(tmp_path)
+    sidecar_bytes_before = sidecar.read_bytes()
+
+    runner = CliRunner()
+    p1, p2, p3, p4 = _patch_catalog_loaders(catalog, fake_suggest)
+    with p1, p2, p3, p4:
+        result = runner.invoke(
             cli,
-            ["--repo-dir", str(tmp_path), "suggest-tokens", "--sidecar", str(sidecar), "--dry-run"],
+            ["--repo-dir", str(tmp_path), "suggest-tokens", "--sidecar", str(sidecar)],
             catch_exceptions=False,
         )
-        assert dry.exit_code == 0
-        assert "Catalog: 2 variables (1 color, 1 numeric)" in dry.output
-        assert "auto:" in dry.output and "2" in dry.output
-        assert "ambiguous:" in dry.output and "3" in dry.output
-        assert "no_match:" in dry.output and "1" in dry.output
-        after_dry = json.loads(sidecar.read_text(encoding="utf-8"))
-        assert "suggest_status" not in json.dumps(after_dry)
 
-        write = runner.invoke(
+    assert result.exit_code == 0
+    assert sidecar.read_bytes() == sidecar_bytes_before, (
+        "suggest-tokens mutated the sidecar — see #133"
+    )
+
+
+def test_suggest_tokens_default_output_is_sibling_suggestions_json(tmp_path: Path) -> None:
+    """Default output: ``foo.tokens.json`` → sibling ``foo.suggestions.json``."""
+    sidecar, catalog, fake_suggest = _suggest_fixture(tmp_path)
+
+    runner = CliRunner()
+    p1, p2, p3, p4 = _patch_catalog_loaders(catalog, fake_suggest)
+    with p1, p2, p3, p4:
+        result = runner.invoke(
+            cli,
+            ["--repo-dir", str(tmp_path), "suggest-tokens", "--sidecar", str(sidecar)],
+            catch_exceptions=False,
+        )
+
+    assert result.exit_code == 0
+    expected = sidecar.parent / "page.suggestions.json"
+    assert expected.exists(), f"expected {expected} to exist; output:\n{result.output}"
+    assert "Wrote suggestions" in result.output and "page.suggestions.json" in result.output
+
+    written = json.loads(expected.read_text(encoding="utf-8"))
+    login_issues = written["frames"]["11:1"]["issues"]
+    assert login_issues[0]["suggest_status"] == "auto"
+    assert login_issues[1]["suggest_status"] == "ambiguous"
+    assert written["frames"]["11:2"]["issues"][0]["suggest_status"] == "no_match"
+    assert written["suggested_at"] == "2026-04-15T12:00:00Z"
+
+
+def test_suggest_tokens_custom_output_path(tmp_path: Path) -> None:
+    sidecar, catalog, fake_suggest = _suggest_fixture(tmp_path)
+    custom = tmp_path / "out" / "elsewhere.json"
+
+    runner = CliRunner()
+    p1, p2, p3, p4 = _patch_catalog_loaders(catalog, fake_suggest)
+    with p1, p2, p3, p4:
+        result = runner.invoke(
+            cli,
+            [
+                "--repo-dir",
+                str(tmp_path),
+                "suggest-tokens",
+                "--sidecar",
+                str(sidecar),
+                "--output",
+                str(custom),
+            ],
+            catch_exceptions=False,
+        )
+
+    assert result.exit_code == 0
+    assert custom.exists()
+    # Sibling default path must NOT exist when --output overrides it.
+    assert not (sidecar.parent / "page.suggestions.json").exists()
+    written = json.loads(custom.read_text(encoding="utf-8"))
+    assert written["frames"]["11:1"]["issues"][0]["suggest_status"] == "auto"
+
+
+def test_suggest_tokens_output_dash_writes_stdout(tmp_path: Path) -> None:
+    sidecar, catalog, fake_suggest = _suggest_fixture(tmp_path)
+
+    runner = CliRunner()
+    p1, p2, p3, p4 = _patch_catalog_loaders(catalog, fake_suggest)
+    with p1, p2, p3, p4:
+        result = runner.invoke(
+            cli,
+            [
+                "--repo-dir",
+                str(tmp_path),
+                "suggest-tokens",
+                "--sidecar",
+                str(sidecar),
+                "--output",
+                "-",
+            ],
+            catch_exceptions=False,
+        )
+
+    assert result.exit_code == 0
+    # No file written.
+    assert not (sidecar.parent / "page.suggestions.json").exists()
+    # Stdout must contain a parseable JSON document with the suggestions.
+    # Click captures stdout; the printed table comes first, then the JSON.
+    out = result.output
+    json_start = out.index("{\n")
+    parsed = json.loads(out[json_start:])
+    assert parsed["frames"]["11:1"]["issues"][0]["suggest_status"] == "auto"
+
+
+def test_suggest_tokens_dry_run_writes_nothing(tmp_path: Path) -> None:
+    sidecar, catalog, fake_suggest = _suggest_fixture(tmp_path)
+    sidecar_bytes_before = sidecar.read_bytes()
+
+    runner = CliRunner()
+    p1, p2, p3, p4 = _patch_catalog_loaders(catalog, fake_suggest)
+    with p1, p2, p3, p4:
+        result = runner.invoke(
+            cli,
+            [
+                "--repo-dir",
+                str(tmp_path),
+                "suggest-tokens",
+                "--sidecar",
+                str(sidecar),
+                "--dry-run",
+            ],
+            catch_exceptions=False,
+        )
+
+    assert result.exit_code == 0
+    assert sidecar.read_bytes() == sidecar_bytes_before
+    assert not (sidecar.parent / "page.suggestions.json").exists()
+    # Summary table still printed.
+    assert "Catalog: 2 variables" in result.output
+    assert "auto:" in result.output
+    # No "Wrote" message.
+    assert "Wrote suggestions" not in result.output
+
+
+def test_suggest_tokens_frame_filter_outputs_only_processed_frames(tmp_path: Path) -> None:
+    """Frame-filtered runs produce filtered output — they don't merge back into
+    a hidden full sidecar (which the original mutating implementation did)."""
+    sidecar, catalog, fake_suggest = _suggest_fixture(tmp_path)
+
+    runner = CliRunner()
+    p1, p2, p3, p4 = _patch_catalog_loaders(catalog, fake_suggest)
+    with p1, p2, p3, p4:
+        result = runner.invoke(
             cli,
             [
                 "--repo-dir",
@@ -163,16 +489,12 @@ def test_suggest_tokens_dry_run_and_frame_filtered_write(tmp_path: Path) -> None
             ],
             catch_exceptions=False,
         )
-        assert write.exit_code == 0
-        assert "Wrote updated sidecar" in write.output
 
-    written = json.loads(sidecar.read_text(encoding="utf-8"))
-    login_issues = written["frames"]["11:1"]["issues"]
-    assert login_issues[0]["suggest_status"] == "auto"
-    assert login_issues[1]["suggest_status"] == "ambiguous"
-    # Filtered write should not alter non-matching frame
-    assert "suggest_status" not in written["frames"]["11:2"]["issues"][0]
-    assert written["suggested_at"] == "2026-04-15T12:00:00Z"
+    assert result.exit_code == 0
+    written = json.loads((sidecar.parent / "page.suggestions.json").read_text(encoding="utf-8"))
+    assert "11:1" in written["frames"]
+    assert "11:2" not in written["frames"]
+    assert written["frames"]["11:1"]["issues"][0]["suggest_status"] == "auto"
 
 
 def test_suggest_tokens_refuses_stale_catalog(tmp_path: Path) -> None:


### PR DESCRIPTION
Closes #133.

## Summary

- `suggest-tokens` no longer mutates the input sidecar. Output goes to a sibling `<base>.suggestions.json` by default, with `--output <path>` for a custom location and `--output -` for stdout (informational messages route to stderr in that mode so JSON is pipeable to `jq`).
- Adds `--library <substring>` (repeatable, matches name OR `library_hash` substring) to limit candidates to specific DS libraries — essential for migration audits.
- Adds `library_hashes: set[str] | None = None` parameter to `suggest_for_sidecar()`; default preserves prior behavior.

## Why both in one PR

The migration audit in linear-git (see [`figma/migrations/login-sign-up-onboarding-2026-04-29/audit-log.md`](https://github.com/gigaverse-app/linear-git/blob/main/figma/migrations/login-sign-up-onboarding-2026-04-29/audit-log.md)) surfaced the library-filtering gap as friction point F1 *during* the workaround for #133. Without `--library`, a migration audit's "ambiguous" list is dominated by candidates from the OLD design system the user is migrating *away from*. With `--library tap --library lsn` against the real `web-app-sprint-16-8064-3222.tokens.json` sidecar, candidate variables collapse from 1807 to 315, and audit results go from noise to actionable: 44 auto / 2 ambiguous / 37 no_match.

Library filtering also resolves audit-log F2 (SEEDED variables matching as `auto`) mechanically — SEEDED entries either have null `library_hash` or live in a library that isn't selected, so they drop out of the candidate pool.

## Behavior changes

- Sidecar bytes are guaranteed unchanged after a run (byte-equal test).
- Frame-filtered runs produce filtered output files — the previous merge-back-into-full-sidecar behavior is gone (it was part of the foot-gun this fixes).
- `--library` with no match exits non-zero with a list-of-libraries hint rather than silently filtering everything to no_match.

## Test plan

- [x] All 11 suggest-token tests pass (9 new + 2 carried over from the rewritten fixture).
- [x] Lint (`ruff check`), format (`ruff format --check`), and types (`basedpyright`) clean on changed files.
- [x] End-to-end against real linear-git sidecar: SHA256 of sidecar matches before/after; sibling `.suggestions.json` written; `--library tap --library lsn` narrows correctly; `--output -` produces parseable JSON on stdout with summary on stderr.
- [x] The error path: `--library nonsense` fails fast with a hint to inspect available libraries.
- [x] Pre-commit hooks pass (ruff, format, trailing whitespace, EOF, merge conflicts).

## Out of scope (follow-ups)

- `.gitignore` entry for `*.suggestions.json` — issue mentioned this could be added by `figmaclaw init` or workflow templates. Neither currently manages `.gitignore`, and adding that surface is a separate conversation. Documented in the updated `figmaclaw-cli` SKILL so consumers (e.g. linear-git) can add the entry themselves.
- Removing the vestigial `fix_variable_id` field from the in-sidecar schema — explicitly out of scope per the ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)