### PR TITLE
fix: refresh target ref before enrichment

### DIFF
--- a/.github/workflows/claude-run.yml
+++ b/.github/workflows/claude-run.yml
@@ -55,6 +55,10 @@ on:
         required: false
         type: string
         default: main
+      target_ref:
+        required: false
+        type: string
+        default: main
     secrets:
       CLAUDE_CODE_OAUTH_TOKEN:
         required: true
@@ -92,6 +96,9 @@ jobs:
 
       - name: Install figmaclaw
         run: pip install uv && uv tool install "git+https://github.com/aviadr1/figmaclaw@${{ inputs.figmaclaw_ref }}"
+
+      - name: Pull latest changes
+        run: git pull --no-rebase --ff-only origin "${{ inputs.target_ref }}"
 
       - name: Configure git
         run: |

--- a/figmaclaw/workflows/figmaclaw-sync.yaml
+++ b/figmaclaw/workflows/figmaclaw-sync.yaml
@@ -97,6 +97,7 @@ jobs:
       max_frames: 80
       max_files: 0
       figmaclaw_ref: ${{ github.event.inputs.figmaclaw_ref || 'main' }}
+      target_ref: ${{ github.ref_name }}
     secrets:
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
       FIGMA_API_KEY: ${{ secrets.FIGMA_API_KEY }}
@@ -123,6 +124,7 @@ jobs:
       max_files: 0
       section_mode: true
       figmaclaw_ref: ${{ github.event.inputs.figmaclaw_ref || 'main' }}
+      target_ref: ${{ github.ref_name }}
     secrets:
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
       FIGMA_API_KEY: ${{ secrets.FIGMA_API_KEY }}

--- a/figmaclaw/workflows/figmaclaw-webhook.yaml
+++ b/figmaclaw/workflows/figmaclaw-webhook.yaml
@@ -22,6 +22,7 @@ jobs:
     with:
       # github.event is not available in the callee — pass payload as input
       webhook_payload: ${{ toJson(github.event.client_payload) }}
+      target_ref: ${{ github.ref_name }}
     secrets:
       FIGMA_API_KEY: ${{ secrets.FIGMA_API_KEY }}
       FIGMA_WEBHOOK_SECRET: ${{ secrets.FIGMA_WEBHOOK_SECRET }}
@@ -36,6 +37,7 @@ jobs:
       model: claude-sonnet-4-6
       max_turns: 80
       changed_only: true
+      target_ref: ${{ github.ref_name }}
     secrets:
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
       FIGMA_API_KEY: ${{ secrets.FIGMA_API_KEY }}

--- a/skills/figmaclaw-canon/SKILL.md
+++ b/skills/figmaclaw-canon/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: figmaclaw canon
-description: Use when working with figmaclaw-generated data (figma/*.md pages, _census.md, ds_catalog.json, token sidecars) or modifying figmaclaw itself. Covers the four-layer data contract (frontmatter / body / manifest / file-scope registries), invariant classes (BP/SC/FM/CL/W/CR/KS/TS/CW/LW/HE/TC/TS-S/REG/PP/NC/HSH/SI/MIG/AUTH/ERR/WF), design decisions D1-D15, refresh-trigger ladder, and the failure-mode catalog F1-F21. Authoritative for "is this change safe?" questions.
+description: Use when working with figmaclaw-generated data (figma/*.md pages, _census.md, ds_catalog.json, token sidecars) or modifying figmaclaw itself. Covers the four-layer data contract (frontmatter / body / manifest / file-scope registries), invariant classes (BP/SC/FM/CL/W/CR/KS/TS/CW/LW/HE/TC/TS-S/REG/PP/NC/HSH/SI/MIG/AUTH/ERR/WF), design decisions D1-D15, refresh-trigger ladder, and the failure-mode catalog F1-F22. Authoritative for "is this change safe?" questions.
 ---
 
 # figmaclaw canon — invariants and design decisions
@@ -386,6 +386,7 @@ Reusable workflows write generated cache artifacts in shared git branches. Their
 |---|---|---|---|---|
 | **WF-1** | Replay deterministic generated artifacts | When a workflow push is rejected for deterministic generated artifacts, recovery must recompute those artifacts from the latest remote source state instead of text-merging stale generated JSON/markdown. | Generated artifacts are cache snapshots. Text-merging two snapshots can create a state that was never generated from any Figma/Linear source. Reset-and-replay preserves determinism and avoids cache corruption. | Concurrent variables/census/enrichment pushes produced generated JSON conflicts. Evidence: [PR #129 replay note](https://github.com/aviadr1/figmaclaw/pull/129#issuecomment-4341938356), commit [`60bfbb4`](https://github.com/aviadr1/figmaclaw/commit/60bfbb4), commit [`f5bdc51`](https://github.com/aviadr1/figmaclaw/commit/f5bdc51), `tests/test_workflow_template_invariants.py`. |
 | **WF-2** | Prompts must not teach merge recovery | Agent prompts and skills that ask LLMs/humans to commit generated or enriched Figma data must not prescribe `git push || git pull && git push` or any equivalent merge-pull retry. If the work is deterministic generated cache, workflows reset and replay it under WF-1. If the work is LLM/human-authored body, the prompt stops on rejected push and lets a human or orchestrator choose the integration strategy. | Workflow fixes do not kill the category if bundled prompts keep teaching the same unsafe pattern. Body edits are not deterministic replayable; generated registries are. Keeping those recovery paths separate prevents agents from accidentally text-merging generated cache snapshots while trying to publish page prose. | `tests/test_prompt_git_add_rules.py`, `tests/test_workflow_template_invariants.py`. |
+| **WF-3** | Stateful jobs start from latest target ref | Any reusable workflow that selects, mutates, commits, or pushes repo state must fast-forward to the caller's target branch before doing that work. A scheduled or webhook-triggered run's checkout SHA is only the dispatch snapshot; it may already be stale by the time downstream jobs start. | Work selection from stale git state causes agents to process deleted/moved files, generators to backfill obsolete paths, or push recovery to reason from the wrong base. Refreshing the target ref before selection preserves the source-of-truth branch boundary without merging. | A scheduled `linear-git` enrichment job selected `figma/migrations/...` from a pre-merge checkout after the branch had moved migration receipts to `figma_migrations/`. `tests/test_workflow_template_invariants.py`. |
 
 ## 5. Design decisions
 
@@ -548,6 +549,7 @@ Each row records a failure mode that has actually occurred (or that we shipped a
 | **F19** | Transient failure poisoned later files. A per-file MCP export error was cached like missing credentials and suppressed authoritative fallback for unrelated later files. | PR #129 live `linear-git` run. | ERR-1 |
 | **F20** | Merged generated cache snapshot. Rejected workflow pushes attempted merge-pull recovery for generated JSON, allowing conflict states that were not the output of a deterministic generator over current source. | PR #129 variables workflow lane. | WF-1 |
 | **F21** | MCP read-only denial treated as transient. `use_figma` can run in contexts where Figma refuses file mutation, even if figmaclaw's JavaScript is intended to read variables. Retrying that error burns CI minutes and repeats the same unavailable marker. | `linear-git` PR #140 marination: FigJam files and an archived Figma file returned `Operation attempted to modify the file while in read-only mode`. | TC-11, ERR-1 |
+| **F22** | Stateful workflow selected work from a stale dispatch snapshot. Downstream enrichment checked out the scheduled run's old SHA and selected a file path that had already been moved on the branch. | `linear-git` scheduled run `25456720296`, after PR #23 moved migration receipts from `figma/migrations/` to `figma_migrations/`. | WF-3 |
 
 Each row was either repeated more than once or had a near-miss before being canonized. New rows are appended; nothing is renumbered.
 
@@ -596,6 +598,7 @@ Use this checklist when reviewing any PR that touches figmaclaw's data model, ca
 - [ ] Does this PR cache an API/MCP failure or suppress retries? If yes, is the cache scoped only to evidence that is persistent at that scope (ERR-1)?
 - [ ] Does this PR recover from rejected pushes of generated artifacts? If yes, does it reset/replay deterministic generation instead of text-merging generated cache snapshots (WF-1)?
 - [ ] Does this PR edit prompts or skills that tell agents to push commits? If yes, do they avoid merge-pull retry recipes and preserve the authored-vs-generated recovery split (WF-2)?
+- [ ] Does this PR add or edit a stateful reusable workflow? If yes, does it fast-forward to the caller's target branch before selecting or writing repo state (WF-3)?
 
 ### Token catalog and sidecar specifically
 

--- a/tests/test_workflow_template_invariants.py
+++ b/tests/test_workflow_template_invariants.py
@@ -56,10 +56,11 @@ def test_sync_template_threads_current_branch_to_stateful_jobs() -> None:
     """INVARIANT: workflow_dispatch on consumer PR branches must not pull main."""
     text = bundled_template_text("figmaclaw-sync.yaml")
 
-    assert text.count("target_ref: ${{ github.ref_name }}") == 3
+    assert text.count("target_ref: ${{ github.ref_name }}") == 5
     assert "uses: aviadr1/figmaclaw/.github/workflows/sync.yml@main" in text
     assert "uses: aviadr1/figmaclaw/.github/workflows/census.yml@main" in text
     assert "uses: aviadr1/figmaclaw/.github/workflows/variables.yml@main" in text
+    assert "uses: aviadr1/figmaclaw/.github/workflows/claude-run.yml@main" in text
 
 
 def test_variables_template_threads_current_branch_to_reusable_workflow() -> None:
@@ -67,6 +68,22 @@ def test_variables_template_threads_current_branch_to_reusable_workflow() -> Non
     text = bundled_template_text("figmaclaw-variables.yaml")
 
     assert "target_ref: ${{ github.ref_name }}" in text
+
+
+def test_webhook_template_threads_current_branch_to_stateful_jobs() -> None:
+    """INVARIANT WF-3: webhook apply/enrich jobs refresh the current target branch."""
+    text = bundled_template_text("figmaclaw-webhook.yaml")
+
+    assert text.count("target_ref: ${{ github.ref_name }}") == 2
+
+
+def test_claude_run_refreshes_target_ref_before_selecting_work() -> None:
+    """INVARIANT WF-3: enrichment must not select work from a stale dispatch snapshot."""
+    text = _reusable_workflow_text("claude-run.yml")
+
+    assert "target_ref:" in text
+    assert 'git pull --no-rebase --ff-only origin "${{ inputs.target_ref }}"' in text
+    assert text.index("name: Pull latest changes") < text.index("          figmaclaw claude-run \\")
 
 
 def test_manage_webhooks_template_is_installed() -> None:


### PR DESCRIPTION
## Summary
- Add `target_ref` to the reusable `claude-run.yml` workflow and fast-forward before enrichment selects work.
- Thread `target_ref` through nightly and webhook managed callers for enrichment jobs.
- Canonize WF-3 so stateful reusable workflows must start from the latest target branch before selecting or writing repo state.

## Why
The `linear-git` scheduled run 25456720296 started from a pre-merge checkout and enrichment selected `figma/migrations/...` after PR #23 had moved those receipts to `figma_migrations/`. WF-1/WF-2 covered push recovery, but not stale dispatch snapshots before selection.

## Validation
- `uv run pytest tests/test_workflow_template_invariants.py -q`
- `uv run pytest tests/test_workflow_template_invariants.py tests/test_prompt_git_add_rules.py -q`
- YAML parse for `.github/workflows/claude-run.yml`, `figmaclaw/workflows/figmaclaw-sync.yaml`, `figmaclaw/workflows/figmaclaw-webhook.yaml`
- pre-commit hooks
